### PR TITLE
Test fixing

### DIFF
--- a/test/Tests/CodeCompilerTests/AbstractCompilerTesters.cs
+++ b/test/Tests/CodeCompilerTests/AbstractCompilerTesters.cs
@@ -25,7 +25,11 @@ namespace Microsoft.ML.Probabilistic.Tests.CodeCompilerTests
 
         public AbstractCompilerTester()
         {
-            assemblies = AppDomain.CurrentDomain.GetAssemblies().GroupBy(x => x.FullName).Select(x => x.First()).ToList();
+            assemblies = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+                .GroupBy(x => x.FullName)
+                .Select(x => x.First())
+                .ToList();
             compiler = new CodeCompiler();
         }
 

--- a/test/netcoretest.sh
+++ b/test/netcoretest.sh
@@ -31,7 +31,7 @@ exitcode=0
 index=0
 
 echo -e "\033[44;37m=====================PARALLEL TESTS RUNNING============================\033[0m"
-for assembly in Learners/LearnersTests${compath}Microsoft.ML.Probabilistic.Learners.Tests.dll Tests${compath}Microsoft.ML.Probabilistic.Tests.dll TestPublic${compath}TestPublic.dll
+for assembly in $dlls
 do
     # Please note that due to xUnit issue we need to run tests for each assembly separately
     dotnet "$runner" "$assembly" $parallel_filter -xml "netcoretest-result${index}.xml"


### PR DESCRIPTION
1. Error with loading assemblies, which location is empty, is fixed.
2. Usage of `dlls` variable in _netcoretest.sh_ script is added.