### PR TITLE
Pinned net core runtime version in netcoretest.sh.

### DIFF
--- a/test/netcoretest.sh
+++ b/test/netcoretest.sh
@@ -18,6 +18,9 @@ fi
 compath=/bin/${configuration}/netcoreapp2.1/
 dlls="Learners/LearnersTests${compath}Microsoft.ML.Probabilistic.Learners.Tests.dll Tests${compath}Microsoft.ML.Probabilistic.Tests.dll TestPublic${compath}TestPublic.dll"
 
+# dotnet command
+dotnet='dotnet --fx-version 2.1.5'
+
 # path to the xunit runner
 runner=~/.nuget/packages/xunit.runner.console/2.3.1/tools/netcoreapp2.0/xunit.console.dll
 
@@ -34,7 +37,7 @@ echo -e "\033[44;37m=====================PARALLEL TESTS RUNNING=================
 for assembly in $dlls
 do
     # Please note that due to xUnit issue we need to run tests for each assembly separately
-    dotnet "$runner" "$assembly" $parallel_filter -xml "netcoretest-result${index}.xml"
+    $dotnet "$runner" "$assembly" $parallel_filter -xml "netcoretest-result${index}.xml"
     if [ 0 -ne $? ]
     then
         echo -e "\033[5;41;1;37mParallel running failure!\033[0m"
@@ -46,7 +49,7 @@ do
 done
 
 echo -e "\033[44;37m=====================SEQUENTIAL TESTS RUNNING=========================\033[0m"
-dotnet "$runner" "Tests${compath}Microsoft.ML.Probabilistic.Tests.dll" $sequential_filter -parallel none -xml "netcoretest-result${index}.xml"
+$dotnet "$runner" "Tests${compath}Microsoft.ML.Probabilistic.Tests.dll" $sequential_filter -parallel none -xml "netcoretest-result${index}.xml"
 if [ 0 -ne $? ]
 then
     echo -e "\033[5;41;1;37mSequential running failure!\033[0m"


### PR DESCRIPTION
Otherwise problems arise when there're multiple runtimes istalled: system chooses one nearest to what xunit runner was compiled with, which may be to low for our test assemblies.