### PR TITLE
Increase timeout for nightly windows build 

### DIFF
--- a/build/nightly-windows.yml
+++ b/build/nightly-windows.yml
@@ -11,7 +11,11 @@ resources:
   clean: true
   
 trigger: none # disable CI build
-  
+
+queue:
+  name: Hosted VS2017
+  timeoutInMinutes: 120
+
 steps:
 - task: Bash@3
   displayName: 'Updating assembly versions'


### PR DESCRIPTION
Debug configuration takes more than an hour which breaks build with default timeout. So timeout is set to 2hrs.