### PR TITLE
Update build definitions

### DIFF
--- a/build/nightly-netcore.yml
+++ b/build/nightly-netcore.yml
@@ -9,6 +9,9 @@ name: 0.3.$(Date:yyMM).$(Date:dd)$(Rev:rr)
 resources:
 - repo: self
   clean: true
+
+queue:
+  timeoutInMinutes: 120
   
 trigger: none # disable CI build
 

--- a/build/pr-msbuild.yml
+++ b/build/pr-msbuild.yml
@@ -29,3 +29,7 @@ steps:
 - template: vstest-fast.yml
   parameters:
     Platform: 'x64'
+
+- template: vstest-fast.yml
+  parameters:
+    Platform: 'x86'

--- a/build/pr-msbuild.yml
+++ b/build/pr-msbuild.yml
@@ -29,7 +29,3 @@ steps:
 - template: vstest-fast.yml
   parameters:
     Platform: 'x64'
-
-- template: vstest-fast.yml
-  parameters:
-    Platform: 'x86'


### PR DESCRIPTION
1) Increased nightly build timeout on Linux and macOS to 2 hours
2) Added x86 testing to Windows PR