### PR TITLE
Implement ISerializable for Automaton explicitely to avoid netstandard/netframework incompatibilities

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.State.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.State.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// Represents a state of an automaton.
         /// </summary>
         [Serializable]
-        [DataContract]
+        [DataContract(IsReference = true)]
         public class State
         {
             //// This class has been made inner so that the user doesn't have to deal with a lot of generic parameters on it.
@@ -87,7 +87,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// Gets the automaton which owns the state.
             /// </summary>
+            /// <remarks>
+            /// Owner is not serialized to avoid circular references. It has to be restored manually upon deserialization.
+            /// BinaryFormatter and Newtonsoft.Json handle circular references differently by default.
+            /// </remarks>
             [DataMember]
+            [NonSerializedProperty]
             public TThis Owner { get; internal set; }
 
             /// <summary>

--- a/src/Runtime/Distributions/Automata/Automaton.State.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.State.cs
@@ -90,6 +90,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <remarks>
             /// Owner is not serialized to avoid circular references. It has to be restored manually upon deserialization.
             /// BinaryFormatter and Newtonsoft.Json handle circular references differently by default.
+            /// At the same time [DataMember] does the right thing, because IsReference=true property on State DataContract
+            /// makes DataContractSerializer handle circular references just fine.
             /// </remarks>
             [DataMember]
             [NonSerializedProperty]

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -2927,8 +2927,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// Constructor used during deserialization by Newtonsoft.Json and BinaryFormatter .
         /// </summary>
         /// <remarks>
-        /// To be serializable classes inherited from Automaton to implement constructor with the same signature
-        /// and delegate to this one.
+        /// To be (de)serializable, classes inherited from Automaton must constructor with the same signature.
         /// </remarks>
         protected Automaton(SerializationInfo info, StreamingContext context)
         {

--- a/src/Runtime/Distributions/Automata/ListAutomaton.cs
+++ b/src/Runtime/Distributions/Automata/ListAutomaton.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
+using Microsoft.ML.Probabilistic.Collections;
+
 namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
     using System;
@@ -22,6 +25,17 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
         where TThis : ListAutomaton<TList, TElement, TElementDistribution, TThis>, new()
     {
+        protected ListAutomaton()
+        {
+        }
+
+        /// <summary>
+        /// Constructor used during deserialization by Newtonsoft.Json and BinaryFormatter .
+        /// </summary>
+        protected ListAutomaton(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
     }
 
     /// <summary>
@@ -35,6 +49,18 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         where TList : class, IList<TElement>, new()
         where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
     {
+        public ListAutomaton()
+        {
+        }
+
+        /// <summary>
+        /// Constructor used during deserialization by Newtonsoft.Json and BinaryFormatter .
+        /// </summary>
+        protected ListAutomaton(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
         /// <summary>
         /// Computes a set of outgoing transitions from a given state of the determinization result.
         /// </summary>
@@ -62,6 +88,18 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>,
         CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
     {
+        public ListAutomaton()
+        {
+        }
+
+        /// <summary>
+        /// Constructor used during deserialization by Newtonsoft.Json and BinaryFormatter .
+        /// </summary>
+        protected ListAutomaton(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
         /// <summary>
         /// Computes a set of outgoing transitions from a given state of the determinization result.
         /// </summary>

--- a/src/Runtime/Distributions/Automata/StringAutomaton.cs
+++ b/src/Runtime/Distributions/Automata/StringAutomaton.cs
@@ -259,33 +259,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <returns>True if equal, false otherwise.</returns>
             public override bool Equals(object obj)
             {
-                if (!(obj is TransitionCharSegmentBound))
-                {
-                    return false;
-                }
-
-                TransitionCharSegmentBound that = (TransitionCharSegmentBound)obj;
-                if (this.DestinationStateId != that.DestinationStateId)
-                {
-                    return false;
-                }
-                
-                if (this.Bound != that.Bound)
-                {
-                    return false;
-                }
-
-                if (this.IsStart != that.IsStart)
-                {
-                    return false;
-                }
-
-                if (this.Weight != that.Weight)
-                {
-                    return false;
-                }
-
-                return true;
+                return
+                    obj is TransitionCharSegmentBound that &&
+                    this.DestinationStateId == that.DestinationStateId &&
+                    this.Bound == that.Bound &&
+                    this.IsStart == that.IsStart &&
+                    this.Weight == that.Weight;
             }
 
             /// <summary>

--- a/src/Runtime/Distributions/Automata/StringAutomaton.cs
+++ b/src/Runtime/Distributions/Automata/StringAutomaton.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
+
 namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
     using System;
@@ -19,6 +21,18 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     [Serializable]
     public class StringAutomaton : Automaton<string, char, DiscreteChar, StringManipulator, StringAutomaton>
     {
+        public StringAutomaton()
+        {
+        }
+
+        /// <summary>
+        /// Constructor used during deserialization by Newtonsoft.Json and BinaryFormatter .
+        /// </summary>
+        protected StringAutomaton(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
         /// <summary>
         /// Computes a set of outgoing transitions from a given state of the determinization result.
         /// </summary>

--- a/src/Runtime/Distributions/Automata/Weight.cs
+++ b/src/Runtime/Distributions/Automata/Weight.cs
@@ -19,6 +19,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     /// <remarks>
     /// Weights are stored in log-domain so that weights of tiny magnitude can be handled without the loss of precision.
     /// </remarks>
+    [Serializable]
     [DataContract]
     public struct Weight
     {

--- a/src/Runtime/Distributions/DiscreteChar.cs
+++ b/src/Runtime/Distributions/DiscreteChar.cs
@@ -28,6 +28,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
     /// and assumes that the number of constant-probability character ranges is small (1-10).
     /// </remarks>
     [Quality(QualityBand.Experimental)]
+    [Serializable]
     [DataContract]
     public sealed class DiscreteChar
         : IDistribution<char>, SettableTo<DiscreteChar>, SettableToProduct<DiscreteChar>, SettableToRatio<DiscreteChar>, SettableToPower<DiscreteChar>,
@@ -1808,6 +1809,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <summary>
         /// Represents a range of characters, with an associated probability.
         /// </summary>
+        [Serializable]
         [DataContract]
         public struct CharRange
         {

--- a/test/Tests/Distributions/SerializableTest.cs
+++ b/test/Tests/Distributions/SerializableTest.cs
@@ -180,6 +180,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             [DataMember] private IDistribution<Vector[][]> vgaJ;
             [DataMember] private SparseGP sparseGp;
             [DataMember] private QuantileEstimator quantileEstimator;
+            [DataMember] private StringDistribution stringDistribution;
 
             public void Initialize()
             {
@@ -233,6 +234,8 @@ namespace Microsoft.ML.Probabilistic.Tests
 
                 this.quantileEstimator = new QuantileEstimator(0.01);
                 this.quantileEstimator.Add(5);
+
+                this.stringDistribution = StringDistribution.String("aa").Append(StringDistribution.OneOf("b", "ccc")).Append("dddd");
             }
 
             public void AssertEqualTo(MyClass that)
@@ -268,6 +271,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 Assert.Equal(0, vgaJ.MaxDiff(that.vgaJ));
                 Assert.Equal(0, this.sparseGp.MaxDiff(that.sparseGp));
                 Assert.True(this.quantileEstimator.ValueEquals(that.quantileEstimator));
+                Assert.Equal(0, this.stringDistribution.MaxDiff(that.stringDistribution));
             }
         }
 


### PR DESCRIPTION
Due to known bug in netframework, OnDeserializingAttribute can't be used in assemblies built against netstandard. Relevant discussion: https://github.com/dotnet/standard/issues/300

Automaton deserialization relied on OnDeserializingAttribute. To avoid it, ISerializable was implemented explicitly.

Changes:
1. SerializableTests now tests StringDistribution serialization. Which implicitly triggers Automaton serialization
2. Methods/Constructors needed by ISerializable were implemented Automaton and all classes inherited from it
3. [Serializable] attributes were added where neccessary
4. [DataContract] attribute was removed from Automaton class. DataContractAttribute and ISerializable can not be used in the same class. DataContractSerializer does the right thing even without this attribute
5. StringAutomaton.TransitionCharSegmentBound.Equals method was simplified (Completely unrelated to this PR, but couldn't resist when was reading code)