### PR TITLE
Small changes to automaton transition table layout to improve memory consumption

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.GroupExtractor.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.GroupExtractor.cs
@@ -21,19 +21,19 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     {
         private static class GroupExtractor
         {           
-            internal static Dictionary<byte, TThis> ExtractGroups(Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> automaton)
+            internal static Dictionary<int, TThis> ExtractGroups(Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> automaton)
             {
-                Dictionary<byte, HashSet<int>> subGraphs;
+                Dictionary<int, HashSet<int>> subGraphs;
                 var order = ComputeTopologicalOrderAndGroupSubgraphs(automaton, out subGraphs);
                 return BuildSubautomata(automaton.states, order, subGraphs);
             }
 
-            private static Dictionary<byte, TThis> BuildSubautomata(
+            private static Dictionary<int, TThis> BuildSubautomata(
                 List<State> states,
                 List<State> topologicalOrder,
-                Dictionary<byte, HashSet<int>> groupSubGraphs) => groupSubGraphs.ToDictionary(g => g.Key, g => BuildSubautomaton(states, topologicalOrder, g.Key, g.Value));
+                Dictionary<int, HashSet<int>> groupSubGraphs) => groupSubGraphs.ToDictionary(g => g.Key, g => BuildSubautomaton(states, topologicalOrder, g.Key, g.Value));
 
-            private static TThis BuildSubautomaton(List<State> states, List<State> topologicalOrder, byte group, HashSet<int> subgraph)
+            private static TThis BuildSubautomaton(List<State> states, List<State> topologicalOrder, int group, HashSet<int> subgraph)
             {
                 var weightsFromRoot = ComputeWeightsFromRoot(states.Count, topologicalOrder, group);
                 var weightsToEnd = ComputeWeightsToEnd(states.Count, topologicalOrder, group);
@@ -103,19 +103,19 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 return weights;
             }
 
-            private static List<State> ComputeTopologicalOrderAndGroupSubgraphs(Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> automaton, out Dictionary<byte, HashSet<int>> groupSubGraphs)
+            private static List<State> ComputeTopologicalOrderAndGroupSubgraphs(Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> automaton, out Dictionary<int, HashSet<int>> groupSubGraphs)
             {
                 var topologicalOrder = new Stack<int>();
                 var states = automaton.states;
                 var temporary = new BitArray(states.Count);
                 var permanent = new BitArray(states.Count);
-                groupSubGraphs = new Dictionary<byte, HashSet<int>>();
+                groupSubGraphs = new Dictionary<int, HashSet<int>>();
 
                 VisitNode(states, automaton.startState.Index, temporary, permanent, groupSubGraphs, topologicalOrder);
                 return topologicalOrder.Select(idx => states[idx]).ToList();
             }
 
-            private static void VisitNode(List<State> states, int stateIdx, BitArray temporary, BitArray permanent, Dictionary<byte, HashSet<int>> groupSubGraphs, Stack<int> topologicalOrder)
+            private static void VisitNode(List<State> states, int stateIdx, BitArray temporary, BitArray permanent, Dictionary<int, HashSet<int>> groupSubGraphs, Stack<int> topologicalOrder)
             {
                 if (temporary[stateIdx])
                 {
@@ -158,7 +158,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// Ending weights are taken into account.
             /// </summary>
             /// <remarks>The weights are computed using dynamic programming, going up from leafs to the root.</remarks>
-            private static Weight[] ComputeWeightsToEnd(int nStates, List<State> topologicalOrder, byte group)
+            private static Weight[] ComputeWeightsToEnd(int nStates, List<State> topologicalOrder, int group)
             {
                 var weights = CreateZeroWeights(nStates);
                 // Iterate in the reverse topological order
@@ -190,7 +190,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// and ending at that state. Ending weights are not taken into account.
             /// </summary>
             /// <remarks>The weights are computed using dynamic programming, going down from the root to leafs.</remarks>
-            private static Weight[] ComputeWeightsFromRoot(int nStates, List<State> topologicalOrder, byte group)
+            private static Weight[] ComputeWeightsFromRoot(int nStates, List<State> topologicalOrder, int group)
             {
                 var weights = CreateZeroWeights(nStates);
                 weights[topologicalOrder[0].Index] = Weight.One;

--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -1127,7 +1127,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 /// <param name="loopWeight">
                 /// The loop weight associated with the generalized element, <see langword="null"/> if the element does not represent a self-loop.
                 /// </param>
-                public GeneralizedElement(TElementDistribution elementDistribution, byte group, Weight? loopWeight)
+                public GeneralizedElement(TElementDistribution elementDistribution, int group, Weight? loopWeight)
                     : this()
                 {
                     Debug.Assert(
@@ -1155,7 +1155,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 /// <summary>
                 /// Gets the group associated with the generalized element.
                 /// </summary>
-                public byte Group { get; private set; }
+                public int Group { get; private set; }
 
                 /// <summary>
                 /// Gets the loop weight associated with the generalized element,

--- a/src/Runtime/Distributions/Automata/Automaton.State.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.State.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// The default capacity of the <see cref="transitions"/>.
             /// </summary>
-            private const int DefaultTransitionArrayCapacity = 3;
+            private const int DefaultTransitionArrayCapacity = 1;
 
             /// <summary>
             /// The array of outgoing transitions.

--- a/src/Runtime/Distributions/Automata/Automaton.State.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.State.cs
@@ -152,7 +152,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// </param>
             /// <param name="group">The group of the added transitions.</param>
             /// <returns>The last state in the added transition series.</returns>
-            public State AddTransitionsForSequence(TSequence sequence, State destinationState = null, byte group = 0)
+            public State AddTransitionsForSequence(TSequence sequence, State destinationState = null, int group = 0)
             {
                 State currentState = this;
                 IEnumerator<TElement> enumerator = sequence.GetEnumerator();
@@ -177,7 +177,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// If the value of this parameter is <see langword="null"/>, a new state will be created.</param>
             /// <param name="group">The group of the added transition.</param>
             /// <returns>The destination state of the added transition.</returns>
-            public State AddTransition(TElement element, Weight weight, State destinationState = null, byte group = 0)
+            public State AddTransition(TElement element, Weight weight, State destinationState = null, int group = 0)
             {
                 return this.AddTransition(new TElementDistribution { Point = element }, weight, destinationState, group);
             }
@@ -191,7 +191,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// If the value of this parameter is <see langword="null"/>, a new state will be created.</param>
             /// <param name="group">The group of the added transition.</param>
             /// <returns>The destination state of the added transition.</returns>
-            public State AddEpsilonTransition(Weight weight, State destinationState = null, byte group = 0)
+            public State AddEpsilonTransition(Weight weight, State destinationState = null, int group = 0)
             {
                 return this.AddTransition(null, weight, destinationState, group);
             }
@@ -209,7 +209,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// If the value of this parameter is <see langword="null"/>, a new state will be created.</param>
             /// <param name="group">The group of the added transition.</param>
             /// <returns>The destination state of the added transition.</returns>
-            public State AddTransition(TElementDistribution elementDistribution, Weight weight, State destinationState = null, byte group = 0)
+            public State AddTransition(TElementDistribution elementDistribution, Weight weight, State destinationState = null, int group = 0)
             {
                 if (destinationState == null)
                 {
@@ -245,7 +245,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <param name="weight">The transition weight.</param>
             /// <param name="group">The group of the added transition.</param>
             /// <returns>The current state.</returns>
-            public State AddSelfTransition(TElement element, Weight weight, byte group = 0)
+            public State AddSelfTransition(TElement element, Weight weight, int group = 0)
             {
                 return this.AddTransition(element, weight, this, group);
             }

--- a/src/Runtime/Distributions/Automata/Automaton.Transition.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Transition.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <param name="destinationStateIndex">The index of the destination state of the transition.</param>
             /// <param name="group">The group this transition belongs to.</param>
             [Construction("ElementDistribution", "Weight", "DestinationStateIndex", "Group")]
-            public Transition(TElementDistribution elementDistribution, Weight weight, int destinationStateIndex, byte group = 0)
+            public Transition(TElementDistribution elementDistribution, Weight weight, int destinationStateIndex, int group = 0)
                 : this()
             {
                 Argument.CheckIfInRange(destinationStateIndex >= 0, "destinationStateIndex", "A destination state index cannot be negative.");
@@ -63,6 +63,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             public int DestinationStateIndex { get; set; }
 
             /// <summary>
+            /// Gets or sets the group this transition belongs to.
+            /// </summary>
+            [DataMember]
+            public int Group { get; set; }
+
+            /// <summary>
             /// Gets or sets the element distribution for this transition.
             /// </summary>
             [DataMember]
@@ -73,12 +79,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// </summary>
             [DataMember]
             public Weight Weight { get; set; }
-            
-            /// <summary>
-            /// Gets or sets the group this transition belongs to.
-            /// </summary>
-            [DataMember]
-            public byte Group { get; set; }
 
             /// <summary>
             /// Gets a value indicating whether this transition is an epsilon transition.
@@ -155,7 +155,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 {
                     res.ElementDistribution = readElementDistribution();
                 }
-                res.Group = (byte)(groupAndHasElementDistribution >> 1);
+                res.Group = groupAndHasElementDistribution >> 1;
                 res.Weight = Weight.Read(readDouble);
                 return res;
             }

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -855,7 +855,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </summary>
         /// <param name="group">The specified group.</param>
         /// <returns>True if it the automaton has this group, false otherwise.</returns>
-        public bool HasGroup(byte group)
+        public bool HasGroup(int group)
         {
             for (int stateIndex = 0; stateIndex < this.states.Count; stateIndex++)
             {
@@ -895,7 +895,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             return false;
         }
 
-        public Dictionary<byte, TThis> GetGroups() => GroupExtractor.ExtractGroups(this);
+        public Dictionary<int, TThis> GetGroups() => GroupExtractor.ExtractGroups(this);
 
         /// <summary>
         /// Clears the group for all transitions.
@@ -909,7 +909,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// Sets all transitions to have the specified group.
         /// </summary>
         /// <param name="group">The specified group.</param>
-        public void SetGroup(byte group)
+        public void SetGroup(int group)
         {
             for (int stateIndex = 0; stateIndex < this.states.Count; stateIndex++)
             {
@@ -1188,7 +1188,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="sequence">The sequence.</param>
         /// <param name="group">The group.</param>
         /// <returns>The created automaton.</returns>
-        public TThis Append(TSequence sequence, byte group = 0)
+        public TThis Append(TSequence sequence, int group = 0)
         {
             return this.Append(ConstantOn(1.0, sequence), group);
         }
@@ -1201,7 +1201,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="automaton">The automaton to append.</param>
         /// <param name="group">The group.</param>
         /// <returns>The created automaton.</returns>
-        public TThis Append(TThis automaton, byte group = 0)
+        public TThis Append(TThis automaton, int group = 0)
         {
             TThis result = this.Clone();
             result.AppendInPlace(automaton, group);
@@ -1214,7 +1214,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </summary>
         /// <param name="sequence">The sequence.</param>
         /// <param name="group">The group.</param>
-        public void AppendInPlace(TSequence sequence, byte group = 0)
+        public void AppendInPlace(TSequence sequence, int group = 0)
         {
             this.AppendInPlace(ConstantOn(1.0, sequence), group);
         }
@@ -1226,7 +1226,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </summary>
         /// <param name="automaton">The automaton to append.</param>
         /// <param name="group">The group.</param>
-        public void AppendInPlace(TThis automaton, byte group = 0)
+        public void AppendInPlace(TThis automaton, int group = 0)
         {
             Argument.CheckIfNotNull(automaton, "automaton");
 
@@ -1646,7 +1646,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="transitionTransform">The transition transformation.</param>
         public void SetToFunction<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton>(
             Automaton<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton> sourceAutomaton,
-            Func<TSrcElementDistribution, Weight, byte, Tuple<TElementDistribution, Weight>> transitionTransform)
+            Func<TSrcElementDistribution, Weight, int, Tuple<TElementDistribution, Weight>> transitionTransform)
             where TSrcElementDistribution : class, IDistribution<TSrcElement>, CanGetLogAverageOf<TSrcElementDistribution>, SettableToProduct<TSrcElementDistribution>, SettableToWeightedSumExact<TSrcElementDistribution>, SettableToPartialUniform<TSrcElementDistribution>, new()
             where TSrcSequence : class, IEnumerable<TSrcElement>
             where TSrcSequenceManipulator : ISequenceManipulator<TSrcSequence, TSrcElement>, new()
@@ -2110,7 +2110,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         }
 
         /// <summary>
-        /// A version of <see cref="AppendInPlace(TThis, byte)"/> that is guaranteed to preserve
+        /// A version of <see cref="AppendInPlace(TThis, int)"/> that is guaranteed to preserve
         /// the states of both the original automaton and the automaton being appended in the result.
         /// </summary>
         /// <param name="automaton">The automaton to append.</param>
@@ -2581,7 +2581,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </summary>
         /// <param name="statesToAdd">The states to add.</param>
         /// <param name="group">The group for the transitions of the states being added.</param>
-        private void AddStates(IEnumerable<State> statesToAdd, byte group = 0)
+        private void AddStates(IEnumerable<State> statesToAdd, int group = 0)
         {
             Debug.Assert(statesToAdd != null, "A valid state collection must be provided.");
 

--- a/src/Runtime/Distributions/Automata/Transducer.cs
+++ b/src/Runtime/Distributions/Automata/Transducer.cs
@@ -107,7 +107,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="automaton">The automaton to weight the sequence.</param>
         /// <param name="group">The group.</param>
         /// <returns>The created transducer.</returns>
-        public static TThis Copy(TAutomaton automaton, byte group = 0)
+        public static TThis Copy(TAutomaton automaton, int group = 0)
         {
             Argument.CheckIfNotNull(automaton, "automaton");
 
@@ -119,6 +119,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     {
                         if (transitionElementDistribution == null)
                         {
+
                             return Tuple.Create<PairDistribution<TElement, TElementDistribution>, Weight>(null, transitionWeight);
                         }
 

--- a/src/Runtime/Distributions/Automata/TransducerBase.cs
+++ b/src/Runtime/Distributions/Automata/TransducerBase.cs
@@ -302,7 +302,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </summary>
         /// <param name="transducer">The transducer to append.</param>
         /// <param name="group">The group.</param>
-        public void AppendInPlace(TThis transducer, byte group = 0)
+        public void AppendInPlace(TThis transducer, int group = 0)
         {
             Argument.CheckIfNotNull(transducer, "transducer");
 

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -647,7 +647,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </list>
         /// </remarks>
         /// <returns>The distribution over the concatenations of sequences and the element.</returns>
-        public TThis Append(TElement element, byte group = 0)
+        public TThis Append(TElement element, int group = 0)
         {
             return this.Append(SingleElement(element), group);
         }
@@ -673,7 +673,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </list>
         /// </remarks>
         /// <returns>The distribution over the concatenations of sequences and elements.</returns>
-        public TThis Append(TElementDistribution elementDistribution, byte group = 0)
+        public TThis Append(TElementDistribution elementDistribution, int group = 0)
         {
             return this.Append(SingleElement(elementDistribution), group);
         }
@@ -695,7 +695,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </list>
         /// </remarks>
         /// <returns>The distribution over the concatenations of sequences.</returns>
-        public TThis Append(TSequence sequence, byte group = 0)
+        public TThis Append(TSequence sequence, int group = 0)
         {
             return this.Append(PointMass(sequence), group);
         }
@@ -721,7 +721,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </list>
         /// </remarks>
         /// <returns>The distribution over the concatenations of sequences.</returns>
-        public TThis Append(TThis dist, byte group = 0)
+        public TThis Append(TThis dist, int group = 0)
         {
             Argument.CheckIfNotNull(dist, "dist");
             
@@ -747,7 +747,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </description></item>
         /// </list>
         /// </remarks>
-        public void AppendInPlace(TElement element, byte group = 0)
+        public void AppendInPlace(TElement element, int group = 0)
         {
             this.AppendInPlace(SingleElement(element), group);
         }
@@ -772,7 +772,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </description></item>
         /// </list>
         /// </remarks>
-        public void AppendInPlace(TElementDistribution elementDistribution, byte group = 0)
+        public void AppendInPlace(TElementDistribution elementDistribution, int group = 0)
         {
             Argument.CheckIfNotNull(elementDistribution, "elementDistribution");
             
@@ -796,7 +796,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </description></item>
         /// </list>
         /// </remarks>
-        public void AppendInPlace(TSequence sequence, byte group = 0)
+        public void AppendInPlace(TSequence sequence, int group = 0)
         {
             Argument.CheckIfNotNull(sequence, "sequence");
             
@@ -823,7 +823,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </description></item>
         /// </list>
         /// </remarks>
-        public void AppendInPlace(TThis dist, byte group = 0)
+        public void AppendInPlace(TThis dist, int group = 0)
         {
             Argument.CheckIfNotNull(dist, "dist");
 
@@ -1029,7 +1029,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
 
         #region Groups
 
-        public bool HasGroup(byte group)
+        public bool HasGroup(int group)
         {
             if (this.IsPointMass)
             {
@@ -1039,11 +1039,11 @@ namespace Microsoft.ML.Probabilistic.Distributions
             return this.sequenceToWeight.HasGroup(group);
         }
    
-        public Dictionary<byte, TThis> GetGroups()
+        public Dictionary<int, TThis> GetGroups()
         {
             if (this.IsPointMass)
             {
-                return new Dictionary<byte, TThis>(); // TODO: get rid of groups or do something about groups + point mass combo
+                return new Dictionary<int, TThis>(); // TODO: get rid of groups or do something about groups + point mass combo
             }
 
             return this.sequenceToWeight.GetGroups().ToDictionary(x => x.Key, x => FromWorkspace(x.Value));

--- a/src/Runtime/Distributions/StringDistribution.cs
+++ b/src/Runtime/Distributions/StringDistribution.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
     {
         /// <summary>
         /// Concatenates the weighted regular languages defined by given distributions
-        /// (see <see cref="SequenceDistribution{TSequence,TElement,TElementDistribution,TSequenceManipulator,TWeightFunction,TThis}.Append(TThis, byte)"/>).
+        /// (see <see cref="SequenceDistribution{TSequence,TElement,TElementDistribution,TSequenceManipulator,TWeightFunction,TThis}.Append(TThis, int)"/>).
         /// </summary>
         /// <param name="first">The first distribution.</param>
         /// <param name="second">The second distribution.</param>

--- a/src/Runtime/Factors/StringFormatOp.cs
+++ b/src/Runtime/Factors/StringFormatOp.cs
@@ -200,7 +200,7 @@ namespace Microsoft.ML.Probabilistic.Factors
                 }
                 else
                 {
-                    var argumentGroup = (byte)(i + 1);
+                    var argumentGroup = i + 1;
                     StringDistribution group;
                     if (!groups.TryGetValue(argumentGroup, out group))
                     {
@@ -420,7 +420,7 @@ namespace Microsoft.ML.Probabilistic.Factors
                 }
 
                 // Replace the placeholder by the argument
-                result.AppendInPlace(allowedArgs[argumentIndex], (byte)(withGroups ? argumentIndex + 1 : 0));
+                result.AppendInPlace(allowedArgs[argumentIndex], withGroups ? argumentIndex + 1 : 0);
 
                 // Mark the argument as 'seen'
                 argumentSeen[argumentIndex] = true;
@@ -467,7 +467,7 @@ namespace Microsoft.ML.Probabilistic.Factors
                 if (!forBackwardMessage)
                 {
                     alternative = StringTransducer.Consume(argNames[argumentIndex]);
-                    alternative.AppendInPlace(StringTransducer.Produce(args[argumentIndex]), (byte)(withGroups ? argumentIndex + 1 : 0));
+                    alternative.AppendInPlace(StringTransducer.Produce(args[argumentIndex]), withGroups ? argumentIndex + 1 : 0);
                 }
                 else
                 {


### PR DESCRIPTION
Did 2 changes:
1. Changed "Group" property type from byte to int. And changed Transition layout from "int, reference, double,byte" (32 bytes) to "int, int, reference, double" (24 bytes).
2. Change DefaultTransitionArrayCapacity from 3 to 1. Most states in real inferred (string) automatons have only 1 transition (verified on real datasets), so we don't waste too much time for reallocations, but save quite a lot of memory per state (2 * sizeof(Transition))

This effectively reduces overhead per state by 72 bytes on our data. That's quite significant.

In my unscientific test of "run StringInferencePerformanceTests 5 times", min and mean execution times go from (27.1, 27.25) to (29.95, 27.1) seconds. Memory consumption on real workloads also decreases.