### PR TITLE
Support value type distributions in Automatons and make DiscreteChar a struct

### DIFF
--- a/src/Runtime/Core/Utils/Argument.cs
+++ b/src/Runtime/Core/Utils/Argument.cs
@@ -18,8 +18,13 @@ namespace Microsoft.ML.Probabilistic.Utilities
         /// <typeparam name="T">The type of the argument.</typeparam>
         /// <param name="argument">The argument.</param>
         /// <param name="argumentName">The name of the argument.</param>
+        /// <remarks>
+        /// There is no "class" restriction on T because in generic code it may be convinient to pass
+        /// value types into <see cref="Argument.CheckIfNotNull{T}(T, string)"/>.
+        /// Even if it is a no-op for them.
+        /// </remarks>
         [DebuggerStepThrough]
-        public static void CheckIfNotNull<T>(T argument, string argumentName) where T : class
+        public static void CheckIfNotNull<T>(T argument, string argumentName)
         {
             if (argument == null)
             {
@@ -34,8 +39,13 @@ namespace Microsoft.ML.Probabilistic.Utilities
         /// <param name="argument">The argument.</param>
         /// <param name="argumentName">The name of the argument.</param>
         /// <param name="message">The exception message.</param>
+        /// <remarks>
+        /// There is no "class" restriction on T because in generic code it may be convinient to pass
+        /// value types into <see cref="Argument.CheckIfNotNull{T}(T, string, string)"/>.
+        /// Even if it is a no-op for them.
+        /// </remarks>
         [DebuggerStepThrough]
-        public static void CheckIfNotNull<T>(T argument, string argumentName, string message) where T : class
+        public static void CheckIfNotNull<T>(T argument, string argumentName, string message)
         {
             if (argument == null)
             {

--- a/src/Runtime/Core/Utils/Option.cs
+++ b/src/Runtime/Core/Utils/Option.cs
@@ -1,0 +1,134 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Utilities
+{
+    using System;
+
+    using Microsoft.ML.Probabilistic.Serialization;
+
+    /// <summary>
+    /// Represents a value type that can be absent
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="Nullable{T}"/> this works with value and reference types.
+    /// </remarks>
+    public struct Option<T>
+    {
+        private readonly T value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Option{T}"/> structure.
+        /// If T is reference type and <see cref="value"/> is null then empty option is crated.
+        /// </summary>
+        [Construction("Value")]
+        public Option(T value)
+        {
+            this.value = value;
+            this.HasValue = value != null;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the current <see cref="Option{T}" /> object
+        /// has a valid value of its underlying type.
+        /// </summary>
+        public bool HasValue { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the current <see cref="Option{T}" /> object
+        /// has no valid value of its underlying type.
+        /// </summary>
+        /// <remarks>
+        /// This property is redundant but is needed for quoting operation.
+        /// </remarks>
+        public bool HasNoValue => !this.HasValue;
+
+        /// <summary>
+        /// Gets the value of the current <see cref="Option{T}" /> object
+        /// if it has been assigned a valid underlying value.
+        /// </summary>
+        /// <returns>
+        /// The value of the current <see cref="Option{T}" /> object if the <see cref="HasValue"/>
+        /// property is true. An exception is thrown otherwise.
+        /// </returns>
+        public T Value =>
+            this.HasValue
+                ? this.value
+                : throw new InvalidOperationException($"Can't get value of empty {nameof(Option<T>)}");
+
+        /// <summary>
+        /// Creates a news <see cref="Option{T}"/> object which holds no value.
+        /// </summary>
+        [Construction(UseWhen = "HasNoValue")]
+        public static Option<T> Empty() => new Option<T>();
+
+        /// <summary>
+        /// Creates a new <see cref="Option{T}" /> object initialized to a specified value.
+        /// </summary>
+        public static implicit operator Option<T>(T value) => new Option<T>(value);
+
+        /// <summary>
+        /// Creates a new empty <see cref="Option{T}" /> object.
+        /// </summary>
+        public static implicit operator Option<T>(Option.NoneType none) => new Option<T>();
+
+        /// <summary>
+        /// Defines an explicit conversion of a <see cref="Option{T}" /> instance to its underlying value.
+        /// </summary>
+        public static explicit operator T(Option<T> value) => value.value;
+
+        public override bool Equals(object other) =>
+            this.HasValue
+                ? other != null && this.value.Equals(other)
+                : other == null;
+
+        public override int GetHashCode() => this.HasValue ? this.value.GetHashCode() : 0;
+
+        public override string ToString() => this.HasValue ? this.value.ToString() : string.Empty;
+    }
+
+    /// <summary>
+    /// Helper static class with constructor methods for <see cref="Option{T}"/>.
+    /// </summary>
+    public static class Option
+    {
+        /// <summary>
+        /// Creates a new empty <see cref="Option{T}" /> object.
+        /// </summary>
+        /// <remarks>
+        /// Since at the call site generic type argument T of the <see cref="Option{T}"/> is not known
+        /// a special sentinel value of <see cref="NoneType"/> is returned. It is implicitly casted
+        /// into any <see cref="Option{T}"/> on demand.
+        /// </remarks>
+        public static NoneType None => default(NoneType);
+
+        /// <summary>
+        /// Creates a new <see cref="Option{T}" /> object initialized to a specified value.
+        /// </summary>
+        /// <remarks>
+        /// Throws <see cref="ArgumentNullException"/> if <paramref name="value"/> is null.
+        /// <see cref="Some{T}"/> constructor should be used only in places where value
+        /// is expected to be non-null.
+        /// </remarks>
+        public static Option<T> Some<T>(T value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(
+                    nameof(value),
+                    $"Option.Some constructor can be used only with non-null values");
+            }
+
+            return new Option<T>(value);
+        }
+
+        /// <summary>
+        /// Helper class to represent "any absent value" which can be converted
+        /// into any <see cref="Option{T}"/>.
+        /// </summary>
+        public struct NoneType
+        {
+        }
+    }
+}

--- a/src/Runtime/Core/Utils/Option.cs
+++ b/src/Runtime/Core/Utils/Option.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.ML.Probabilistic.Utilities
 {
     using System;
@@ -20,7 +22,8 @@ namespace Microsoft.ML.Probabilistic.Utilities
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Option{T}"/> structure.
-        /// If T is reference type and <see cref="value"/> is null then empty option is crated.
+        /// If T is reference type and <paramref cref="value"/> is null then
+        /// object without data is created (<see cref="HasValue"/> will be false).
         /// </summary>
         [Construction("Value")]
         public Option(T value)
@@ -78,14 +81,28 @@ namespace Microsoft.ML.Probabilistic.Utilities
         /// </summary>
         public static explicit operator T(Option<T> value) => value.value;
 
-        public override bool Equals(object other) =>
-            this.HasValue
-                ? other != null && this.value.Equals(other)
+        public static bool operator ==(Option<T> a, Option<T> b) =>
+            a.HasValue
+                ? b.HasValue && EqualityComparer<T>.Default.Equals(a.Value, b.Value)
+                : !b.HasValue;
+
+        public static bool operator !=(Option<T> a, Option<T> b) => !(a == b);
+
+        public override bool Equals(object other)
+        {
+            if (other is Option<T> that)
+            {
+                return this == that;
+            }
+
+            return this.HasValue
+                ? this.Value.Equals(other)
                 : other == null;
+        }
 
         public override int GetHashCode() => this.HasValue ? this.value.GetHashCode() : 0;
 
-        public override string ToString() => this.HasValue ? this.value.ToString() : string.Empty;
+        public override string ToString() => this.HasValue ? this.value.ToString() : "(null)";
     }
 
     /// <summary>

--- a/src/Runtime/Distributions/Automata/Automaton.Condensation.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Condensation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     /// </content>
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
         where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
         where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
         where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {

--- a/src/Runtime/Distributions/Automata/Automaton.EpsilonClosure.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.EpsilonClosure.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     /// </content>
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
         where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
         where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
         where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {

--- a/src/Runtime/Distributions/Automata/Automaton.GroupExtractor.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.GroupExtractor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     /// </content>
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
         where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
         where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
         where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {

--- a/src/Runtime/Distributions/Automata/Automaton.State.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.State.cs
@@ -19,7 +19,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
         where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
         where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
         where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {
@@ -199,7 +199,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <returns>The destination state of the added transition.</returns>
             public State AddEpsilonTransition(Weight weight, State destinationState = default(State), int group = 0)
             {
-                return this.AddTransition(null, weight, destinationState, group);
+                return this.AddTransition(Option.None, weight, destinationState, group);
             }
 
             /// <summary>
@@ -215,7 +215,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// If the value of this parameter is <see langword="null"/>, a new state will be created.</param>
             /// <param name="group">The group of the added transition.</param>
             /// <returns>The destination state of the added transition.</returns>
-            public State AddTransition(TElementDistribution elementDistribution, Weight weight, State destinationState = default(State), int group = 0)
+            public State AddTransition(Option<TElementDistribution> elementDistribution, Weight weight, State destinationState = default(State), int group = 0)
             {
                 if (destinationState.IsNull)
                 {
@@ -270,7 +270,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <param name="weight">The transition weight.</param>
             /// <param name="group">The group of the added transition.</param>
             /// <returns>The current state.</returns>
-            public State AddSelfTransition(TElementDistribution elementDistribution, Weight weight, byte group = 0)
+            public State AddSelfTransition(Option<TElementDistribution> elementDistribution, Weight weight, byte group = 0)
             {
                 return this.AddTransition(elementDistribution, weight, this, group);
             }
@@ -503,7 +503,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                             }
 
                             var destState = this.Owner.States[transition.DestinationStateIndex];
-                            var distWeight = Weight.FromLogValue(transition.ElementDistribution.GetLogProb(element));
+                            var distWeight = Weight.FromLogValue(transition.ElementDistribution.Value.GetLogProb(element));
                             if (!distWeight.IsZero && !transition.Weight.IsZero)
                             {
                                 var destValue = destState.DoGetValue(sequence, sequencePosition + 1, valueCache);

--- a/src/Runtime/Distributions/Automata/Automaton.StateCollection.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.StateCollection.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
         where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
         where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
         where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {

--- a/src/Runtime/Distributions/Automata/Automaton.StateData.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.StateData.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
         where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
         where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
         where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {

--- a/src/Runtime/Distributions/Automata/Automaton.StronglyConnectedComponent.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.StronglyConnectedComponent.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     /// </content>
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
         where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
         where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
         where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {

--- a/src/Runtime/Distributions/Automata/Automaton.Transition.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Transition.cs
@@ -36,7 +36,26 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public struct Transition
         {
             //// This class has been made inner so that the user doesn't have to deal with a lot of generic parameters on it.
-            
+
+            /// Note the order of fields. This struct is densely packed and should take only
+            /// 24 bytes to store all its fields in case of StringAutomaton.Transition.
+            /// Think wisely before you decide to reorder fields or change their types.
+
+            [DataMember]
+            private int destinationStateIndex;
+
+            [DataMember]
+            private short group;
+
+            [DataMember]
+            private short hasElementDistribution;
+
+            [DataMember]
+            private TElementDistribution elementDistribution;
+
+            [DataMember]
+            private Weight weight;
+
             /// <summary>
             /// Initializes a new instance of the <see cref="Transition"/> struct.
             /// </summary>
@@ -64,33 +83,20 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// Gets or sets the destination state index.
             /// </summary>
-            [DataMember]
-            public int DestinationStateIndex { get; set; }
+            public int DestinationStateIndex
+            {
+                get => this.destinationStateIndex;
+                set => this.destinationStateIndex = value;
+            }
 
             /// <summary>
             /// Gets or sets the group this transition belongs to.
             /// </summary>
-            [DataMember]
-            private short group;
-
             public int Group
             {
                 get => this.group;
                 set => this.group = (short)value;
             }
-
-            /// <summary>
-            /// 
-            /// </summary>
-            /// <remarks>
-            /// Chosen type `short` because we want this field to take 2 bytes for structure padding reasons.
-            /// `bool` takes 4 bytes in CLR!
-            /// </remarks>
-            [DataMember]
-            private short hasElementDistribution;
-
-            [DataMember]
-            private TElementDistribution elementDistribution;
 
             /// <summary>
             /// Gets the element distribution for this transition.
@@ -113,8 +119,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// Gets or sets the weight associated with this transition.
             /// </summary>
-            [DataMember]
-            public Weight Weight { get; set; }
+            public Weight Weight
+            {
+                get => this.weight;
+                set => this.weight = value;
+            }
 
             /// <summary>
             /// Replaces the configuration of this transition with the configuration of a given transition.

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     [Serializable]
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> : ISerializable
         where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
         where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
         where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {
@@ -108,14 +108,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         #region Constructors
 
         /// <summary>
-        /// Initializes static members of the <see cref="Automaton{TSequence,TElement,TElementDistribution,TSequenceManipulator,TThis}"/> class.
-        /// </summary>
-        static Automaton()
-        {
-            SequenceManipulator = new TSequenceManipulator();
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Automaton{TSequence,TElement,TElementDistribution,TSequenceManipulator,TThis}"/>
         /// class by setting it to be zero everywhere.
         /// </summary>
@@ -132,11 +124,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <summary>
         /// Gets the sequence manipulator.
         /// </summary>
-        public static TSequenceManipulator SequenceManipulator
-        {
-            get;
-            private set;
-        }
+        public static TSequenceManipulator SequenceManipulator { get; } =
+            new TSequenceManipulator();
 
         /// <summary>
         /// Gets or sets a value that, if not null, will be returned when computing the log value of any sequence
@@ -1004,23 +993,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </remarks>
         public bool IsCanonicConstant()
         {
-            if (this.statesData.Count != 1)
+            if (this.statesData.Count != 1 || this.Start.TransitionCount != 1 || !this.Start.CanEnd)
             {
                 return false;
             }
 
-            if (this.Start.TransitionCount != 1)
-            {
-                return false;
-            }
-
-            if (!this.Start.CanEnd)
-            {
-                return false;
-            }
-
-            var transition = this.Start.GetTransition(0);
-            return transition.ElementDistribution.IsUniform();
+            var transitionDistribution = this.Start.GetTransition(0).ElementDistribution;
+            return transitionDistribution.HasValue && transitionDistribution.Value.IsUniform();
         }
 
         /// <summary>
@@ -1096,8 +1075,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         }
                         else
                         {
-                            transition.ElementDistribution = Distribution.CreatePartialUniform(transition.ElementDistribution);
-                            transition.Weight = Weight.FromLogValue(-transition.ElementDistribution.GetLogAverageOf(transition.ElementDistribution));
+                            transition.ElementDistribution = Distribution.CreatePartialUniform(transition.ElementDistribution.Value);
+                            transition.Weight = Weight.FromLogValue(-transition.ElementDistribution.Value.GetLogAverageOf(transition.ElementDistribution.Value));
                         }
 
                         state.SetTransition(transitionIndex, transition);
@@ -1623,8 +1602,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="transitionTransform">The transition transformation.</param>
         public void SetToFunction<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton>(
             Automaton<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton> sourceAutomaton,
-            Func<TSrcElementDistribution, Weight, int, Tuple<TElementDistribution, Weight>> transitionTransform)
-            where TSrcElementDistribution : class, IDistribution<TSrcElement>, CanGetLogAverageOf<TSrcElementDistribution>, SettableToProduct<TSrcElementDistribution>, SettableToWeightedSumExact<TSrcElementDistribution>, SettableToPartialUniform<TSrcElementDistribution>, new()
+            Func<Option<TSrcElementDistribution>, Weight, int, Tuple<Option<TElementDistribution>, Weight>> transitionTransform)
+            where TSrcElementDistribution : IDistribution<TSrcElement>, CanGetLogAverageOf<TSrcElementDistribution>, SettableToProduct<TSrcElementDistribution>, SettableToWeightedSumExact<TSrcElementDistribution>, SettableToPartialUniform<TSrcElementDistribution>, new()
             where TSrcSequence : class, IEnumerable<TSrcElement>
             where TSrcSequenceManipulator : ISequenceManipulator<TSrcSequence, TSrcElement>, new()
             where TSrcAutomaton : Automaton<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton>, new()
@@ -2360,13 +2339,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         return false;
                     }
                 }
-                else if (!transition.ElementDistribution.IsPointMass)
+                else if (!transition.ElementDistribution.Value.IsPointMass)
                 {
                     return false;
                 }
                 else
                 {
-                    TElement element = transition.ElementDistribution.Point;
+                    TElement element = transition.ElementDistribution.Value.Point;
                     if (currentSequencePos == point.Count)
                     {
                         // It is the first time at this sequence position
@@ -2443,7 +2422,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
                     TElementDistribution product;
                     double productLogNormalizer = Distribution<TElement>.GetLogAverageOf(
-                        transition1.ElementDistribution, transition2.ElementDistribution, out product);
+                        transition1.ElementDistribution.Value, transition2.ElementDistribution.Value, out product);
                     ////if (product is StringDistribution)
                     ////{
                     ////    Console.WriteLine(transition1.ElementDistribution+" x "+transition2.ElementDistribution+" = "+product+" "+productLogNormalizer+" "+transition1.ElementDistribution.Equals(transition1.ElementDistribution)+" "+transition1.ElementDistribution.Equals(transition2.ElementDistribution));
@@ -2671,7 +2650,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 {
                     if (appendRegex != null)
                     {
-                        appendRegex(transition.ElementDistribution, builder);
+                        appendRegex(transition.ElementDistribution.Value, builder);
                     }
                     else
                     {
@@ -2707,7 +2686,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 {
                     if (appendRegex != null)
                     {
-                        appendRegex(transition.ElementDistribution, builder);
+                        appendRegex(transition.ElementDistribution.Value, builder);
                     }
                     else
                     {
@@ -2765,9 +2744,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         yield return support;
                     }
                 }
-                else if (transition.ElementDistribution.IsPointMass)
+                else if (transition.ElementDistribution.Value.IsPointMass)
                 {
-                    prefix.Push(transition.ElementDistribution.Point);
+                    prefix.Push(transition.ElementDistribution.Value.Point);
                     foreach (var support in this.EnumerateSupport(prefix, visitedStates, transition.DestinationStateIndex))
                     {
                         yield return support;
@@ -2777,7 +2756,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 }
                 else
                 {
-                    var supportEnumerator = transition.ElementDistribution as CanEnumerateSupport<TElement>;
+                    var supportEnumerator = transition.ElementDistribution.Value as CanEnumerateSupport<TElement>;
                     if (supportEnumerator == null)
                     {
                         throw new NotImplementedException("Only point mass element distributions or distributions for which we can enumerate support are currently implemented");
@@ -2836,7 +2815,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
                 if (!transition.IsEpsilon)
                 {
-                    prefix.Push(transition.ElementDistribution);
+                    prefix.Push(transition.ElementDistribution.Value);
                 }
 
                 foreach (var support in this.EnumeratePaths(prefix, visitedStates, Weight.Product(weight, transition.Weight), transition.DestinationStateIndex))

--- a/src/Runtime/Distributions/Automata/AutomatonBasedSequenceDistributionFormatBase.cs
+++ b/src/Runtime/Distributions/Automata/AutomatonBasedSequenceDistributionFormatBase.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public string ConvertToString<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction, TSequenceDistribution>(
             TSequenceDistribution sequenceDistribution)
             where TSequence : class, IEnumerable<TElement>
-            where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
+            where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
             where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
             where TWeightFunction : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>, new()
             where TSequenceDistribution : SequenceDistribution<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction, TSequenceDistribution>, new()
@@ -75,7 +75,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         protected abstract string ConvertPointMassToString<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction, TSequenceDistribution>(
             TSequenceDistribution sequenceDistribution)
             where TSequence : class, IEnumerable<TElement>
-            where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>,
+            where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>,
                 CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
             where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
             where TWeightFunction : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>, new()

--- a/src/Runtime/Distributions/Automata/GraphVizAutomatonFormat.cs
+++ b/src/Runtime/Distributions/Automata/GraphVizAutomatonFormat.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public string ConvertToString<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton>(
             Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton> automaton)
             where TSequence : class, IEnumerable<TElement>
-            where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
+            where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
                 SettableToPartialUniform<TElementDistribution>, new()
             where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
             where TAutomaton : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton>, new()
@@ -53,13 +53,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     var transition = state.GetTransition(i);
                     
                     string transitionLabel;
-                    if (transition.ElementDistribution == null)
+                    if (transition.IsEpsilon)
                     {
                         transitionLabel = "eps";
                     }
-                    else if (transition.ElementDistribution.IsPointMass)
+                    else if (transition.ElementDistribution.Value.IsPointMass)
                     {
-                        transitionLabel = EscapeLabel(transition.ElementDistribution.Point.ToString());
+                        transitionLabel = EscapeLabel(transition.ElementDistribution.Value.Point.ToString());
                     }
                     else
                     {

--- a/src/Runtime/Distributions/Automata/IAutomatonFormat.cs
+++ b/src/Runtime/Distributions/Automata/IAutomatonFormat.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         string ConvertToString<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton>(
             Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton> automaton)
             where TSequence : class, IEnumerable<TElement>
-            where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
+            where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
                 SettableToPartialUniform<TElementDistribution>, new()
             where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
             where TAutomaton : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton>, new();

--- a/src/Runtime/Distributions/Automata/ISequenceDistributionFormat.cs
+++ b/src/Runtime/Distributions/Automata/ISequenceDistributionFormat.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         string ConvertToString<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction, TSequenceDistribution>(
             TSequenceDistribution sequenceDistribution)
             where TSequence : class, IEnumerable<TElement>
-            where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
+            where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
                 SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
             where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
             where TWeightFunction : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>, new()

--- a/src/Runtime/Distributions/Automata/ListAutomaton.cs
+++ b/src/Runtime/Distributions/Automata/ListAutomaton.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     public abstract class ListAutomaton<TList, TElement, TElementDistribution, TThis>
         : Automaton<TList, TElement, TElementDistribution, ListManipulator<TList, TElement>, TThis>
         where TList : class, IList<TElement>, new()
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
         where TThis : ListAutomaton<TList, TElement, TElementDistribution, TThis>, new()
     {
         protected ListAutomaton()
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     public class ListAutomaton<TList, TElement, TElementDistribution>
         : ListAutomaton<TList, TElement, TElementDistribution, ListAutomaton<TList, TElement, TElementDistribution>>
         where TList : class, IList<TElement>, new()
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
     {
         public ListAutomaton()
         {
@@ -83,7 +83,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     /// <typeparam name="TElementDistribution">The type of a distribution over a list element.</typeparam>
     public class ListAutomaton<TElement, TElementDistribution>
         : ListAutomaton<List<TElement>, TElement, TElementDistribution, ListAutomaton<TElement, TElementDistribution>>
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>,
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>,
         CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
     {
         public ListAutomaton()
@@ -182,7 +182,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             Transition transition, Weight sourceStateResidualWeight, 
             Dictionary<TElement, List<TransitionElement>> elements, List<TransitionElement> uniformList)
         {
-            var dist = transition.ElementDistribution;
+            var dist = transition.ElementDistribution.Value;
             Weight weightBase = Weight.Product(transition.Weight, sourceStateResidualWeight);
             if (dist.IsPointMass)
             {

--- a/src/Runtime/Distributions/Automata/ListManipulator.cs
+++ b/src/Runtime/Distributions/Automata/ListManipulator.cs
@@ -34,10 +34,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </summary>
         /// <param name="sequence">The list.</param>
         /// <returns>The length of the list.</returns>
-        public int GetLength(TList sequence)
-        {
-            return sequence.Count;
-        }
+        public int GetLength(TList sequence) => sequence.Count;
 
         /// <summary>
         /// Gets the element at a given position in a given list.
@@ -45,10 +42,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="sequence">The list.</param>
         /// <param name="index">The position.</param>
         /// <returns>The element at the given position in the list.</returns>
-        public TElement GetElement(TList sequence, int index)
-        {
-            return sequence[index];
-        }
+        public TElement GetElement(TList sequence, int index) => sequence[index];
 
         /// <summary>
         /// Checks if given lists are equal.
@@ -57,10 +51,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="sequence1">The first list.</param>
         /// <param name="sequence2">The second list.</param>
         /// <returns><see langword="true"/> if the lists are equal, <see langword="false"/> otherwise.</returns>
-        public bool SequencesAreEqual(TList sequence1, TList sequence2)
-        {
-            return Util.ValueEquals(sequence1, sequence2);
-        }
+        public bool SequencesAreEqual(TList sequence1, TList sequence2) => Util.ValueEquals(sequence1, sequence2);
 
         /// <summary>
         /// Creates a list by copying the first list and then appending the second list to it.

--- a/src/Runtime/Distributions/Automata/RegexpAutomatonFormat.cs
+++ b/src/Runtime/Distributions/Automata/RegexpAutomatonFormat.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public string ConvertToString<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton>(
             Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton> automaton)
             where TSequence : class, IEnumerable<TElement>
-            where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
+            where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
                 SettableToPartialUniform<TElementDistribution>, new()
             where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
             where TAutomaton : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton>, new()

--- a/src/Runtime/Distributions/Automata/RegexpTreeBuilder.cs
+++ b/src/Runtime/Distributions/Automata/RegexpTreeBuilder.cs
@@ -67,7 +67,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton> automaton,
             bool collapseAlternatives = true)
             where TSequence : class, IEnumerable<TElement>
-            where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
+            where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
                 SettableToPartialUniform<TElementDistribution>, new()
             where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
             where TAutomaton : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton>, new()
@@ -146,7 +146,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton> automaton,
             bool collapseAlternatives = true)
             where TSequence : class, IEnumerable<TElement>
-            where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
+            where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
                 SettableToPartialUniform<TElementDistribution>, new()
             where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
             where TAutomaton : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton>, new()
@@ -366,7 +366,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         private static RegexpTreeNode<TElement>[,] BuildStronglyConnectedComponentRegexp<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton>(
             Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton>.StronglyConnectedComponent component)
             where TSequence : class, IEnumerable<TElement>
-            where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
+            where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>,
                 SettableToPartialUniform<TElementDistribution>, new()
             where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
             where TAutomaton : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton>, new()

--- a/src/Runtime/Distributions/Automata/RegexpTreeNode.cs
+++ b/src/Runtime/Distributions/Automata/RegexpTreeNode.cs
@@ -128,15 +128,15 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <typeparam name="TElementSet">The type of a sequence element set.</typeparam>
         /// <param name="elementSet">The distribution over sequence elements.</param>
         /// <returns>The created node.</returns>
-        public static RegexpTreeNode<TElement> FromElementSet<TElementSet>(TElementSet elementSet)
-            where TElementSet : class, SettableToPartialUniform<TElementSet>, IDistribution<TElement>, new()
+        public static RegexpTreeNode<TElement> FromElementSet<TElementSet>(Option<TElementSet> elementSet)
+            where TElementSet : SettableToPartialUniform<TElementSet>, IDistribution<TElement>, new()
         {
             Argument.CheckIfNotNull(elementSet, "elementSet");
 
             return new RegexpTreeNode<TElement>
             { 
                 Type = RegexpTreeNodeType.ElementSet, 
-                elementSet = elementSet /* Distribution.CreatePartialUniform(elementSet) */
+                elementSet = elementSet.HasValue ? (IDistribution<TElement>)elementSet.Value : null /* Distribution.CreatePartialUniform(elementSet) */
             };
         }
 
@@ -390,12 +390,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     }
                     else
                     {
-                        var discreteChar = this.elementSet as DiscreteChar;
                         if (this.elementSet.IsPointMass)
                         {
-                            if (discreteChar != null)
+                            if (this.elementSet is DiscreteChar)
                             {
-                                discreteChar.AppendRegex(resultBuilder);
+                                var dc = (DiscreteChar)(object)this.elementSet;
+                                dc.AppendRegex(resultBuilder);
                             }
                             else
                             {
@@ -408,9 +408,10 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         }
                         else
                         {
-                            if (discreteChar != null)
+                            if (this.elementSet is DiscreteChar)
                             {
-                                discreteChar.AppendRegex(resultBuilder);
+                                var dc = (DiscreteChar)(object)this.elementSet;
+                                dc.AppendRegex(resultBuilder);
                             }
                             else
                             {

--- a/src/Runtime/Distributions/Automata/StringAutomaton.cs
+++ b/src/Runtime/Distributions/Automata/StringAutomaton.cs
@@ -137,7 +137,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         private static void AddTransitionCharSegmentBounds(
             Transition transition, Weight sourceStateResidualWeight, List<Tuple<int, TransitionCharSegmentBound>> bounds)
         {
-            var probs = (PiecewiseVector)transition.ElementDistribution.GetProbs();
+            var probs = (PiecewiseVector)transition.ElementDistribution.Value.GetProbs();
             int commonValueStart = char.MinValue;
             Weight commonValue = Weight.FromValue(probs.CommonValue);
             Weight weightBase = Weight.Product(transition.Weight, sourceStateResidualWeight);

--- a/src/Runtime/Distributions/Automata/Transducer.cs
+++ b/src/Runtime/Distributions/Automata/Transducer.cs
@@ -26,8 +26,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     /// <typeparam name="TThis">The type of a concrete transducer class.</typeparam>
     public abstract class Transducer<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton, TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton, TThis> :
         TransducerBase<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton, TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton, PairDistribution<TSrcElement, TSrcElementDistribution, TDestElement, TDestElementDistribution>, TThis>
-        where TSrcElementDistribution : class, IDistribution<TSrcElement>, CanGetLogAverageOf<TSrcElementDistribution>, SettableToProduct<TSrcElementDistribution>, SettableToWeightedSumExact<TSrcElementDistribution>, SettableToPartialUniform<TSrcElementDistribution>, Sampleable<TSrcElement>, new()
-        where TDestElementDistribution : class, IDistribution<TDestElement>, CanGetLogAverageOf<TDestElementDistribution>, SettableToProduct<TDestElementDistribution>, SettableToWeightedSumExact<TDestElementDistribution>, SettableToPartialUniform<TDestElementDistribution>, Sampleable<TDestElement>, new()
+        where TSrcElementDistribution : IDistribution<TSrcElement>, CanGetLogAverageOf<TSrcElementDistribution>, SettableToProduct<TSrcElementDistribution>, SettableToWeightedSumExact<TSrcElementDistribution>, SettableToPartialUniform<TSrcElementDistribution>, Sampleable<TSrcElement>, new()
+        where TDestElementDistribution : IDistribution<TDestElement>, CanGetLogAverageOf<TDestElementDistribution>, SettableToProduct<TDestElementDistribution>, SettableToWeightedSumExact<TDestElementDistribution>, SettableToPartialUniform<TDestElementDistribution>, Sampleable<TDestElement>, new()
         where TSrcSequence : class, IEnumerable<TSrcElement>
         where TDestSequence : class, IEnumerable<TDestElement>
         where TSrcSequenceManipulator : ISequenceManipulator<TSrcSequence, TSrcElement>, new()
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
             var result = new TThat();
             result.sequencePairToWeight.SetToFunction(
-                transducer.sequencePairToWeight, (dist, weight, group) => Tuple.Create(dist == null ? null : dist.Transpose(), weight));
+                transducer.sequencePairToWeight, (dist, weight, group) => Tuple.Create(dist.HasValue ? Option.Some(dist.Value.Transpose()) : Option.None, weight));
             return result;
         }
     }
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     /// <typeparam name="TThis">The type of a concrete transducer class.</typeparam>
     public abstract class Transducer<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton, TThis> :
         TransducerBase<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton, TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton, PairDistribution<TElement, TElementDistribution>, TThis>
-        where TElementDistribution : class, IDistribution<TElement>, CanGetLogAverageOf<TElementDistribution>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
+        where TElementDistribution : IDistribution<TElement>, CanGetLogAverageOf<TElementDistribution>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
         where TSequence : class, IEnumerable<TElement>
         where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
         where TAutomaton : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton>, new()
@@ -117,23 +117,26 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 automaton,
                 (transitionElementDistribution, transitionWeight, transitionGroup) =>
                     {
-                        if (transitionElementDistribution == null)
+                        if (!transitionElementDistribution.HasValue)
                         {
 
-                            return Tuple.Create<PairDistribution<TElement, TElementDistribution>, Weight>(null, transitionWeight);
+                            return Tuple.Create<Option<PairDistribution<TElement, TElementDistribution>>, Weight>(Option.None, transitionWeight);
                         }
 
                         if ((group == 0) || (transitionGroup == group))
                         {
                             // If a target group is specified: copy if this group is the target group
                             return Tuple.Create(
-                                PairDistribution<TElement, TElementDistribution>.Constrained(transitionElementDistribution, Distribution.CreatePartialUniform(transitionElementDistribution)),
+                                Option.Some(
+                                    PairDistribution<TElement, TElementDistribution>.Constrained(
+                                        transitionElementDistribution.Value,
+                                        Distribution.CreatePartialUniform(transitionElementDistribution.Value))),
                                 transitionWeight);
                         }
 
                         // Otherwise consume but don't copy
                         return Tuple.Create(
-                            PairDistribution<TElement, TElementDistribution>.FromFirst(transitionElementDistribution),
+                            Option.Some(PairDistribution<TElement, TElementDistribution>.FromFirst(transitionElementDistribution.Value)),
                             transitionWeight);
                     });
             
@@ -187,14 +190,14 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <returns>The created transducer.</returns>
         public static TThis FromAutomaton(
             TAutomaton automaton,
-            Func<TElementDistribution, Weight, Tuple<PairDistribution<TElement, TElementDistribution>, Weight>> transitionTransform)
+            Func<TElementDistribution, Weight, Tuple<Option<PairDistribution<TElement, TElementDistribution>>, Weight>> transitionTransform)
         {
             Argument.CheckIfNotNull(transitionTransform, "transitionTransform");
             
             var result = new TThis();
             result.sequencePairToWeight.SetToFunction(
                 automaton,
-                (elementDist, weight, group) => transitionTransform(elementDist, weight));
+                (elementDist, weight, group) => transitionTransform(elementDist.Value, weight));
             return result;
         }
 
@@ -209,9 +212,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 for (int j = 0; j < state.TransitionCount; ++j)
                 {
                     var transition = state.GetTransition(j);
-                    if (!transition.IsEpsilon)
+                    if (transition.ElementDistribution.HasValue)
                     {
-                        transition.ElementDistribution = transition.ElementDistribution.Transpose();
+                        transition.ElementDistribution = transition.ElementDistribution.Value.Transpose();
                         state.SetTransition(j, transition);
                     }
                 }

--- a/src/Runtime/Distributions/DiscreteChar.cs
+++ b/src/Runtime/Distributions/DiscreteChar.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
     /// </remarks>
     [Quality(QualityBand.Experimental)]
     [Serializable]
-    public sealed class DiscreteChar
+    public struct DiscreteChar
         : IDistribution<char>, SettableTo<DiscreteChar>, SettableToProduct<DiscreteChar>, SettableToRatio<DiscreteChar>, SettableToPower<DiscreteChar>,
         SettableToWeightedSumExact<DiscreteChar>, SettableToPartialUniform<DiscreteChar>,
         CanGetLogAverageOf<DiscreteChar>, CanGetLogAverageOfPower<DiscreteChar>, CanGetAverageLog<DiscreteChar>, CanGetMode<char>,
@@ -122,12 +122,6 @@ namespace Microsoft.ML.Probabilistic.Distributions
 
         [DataMember]
         private Storage storage;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DiscreteChar"/> class
-        /// by setting it to a uniform distribution.
-        /// </summary>
-        public DiscreteChar() => this.storage = StorageCache.Uniform;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DiscreteChar"/> class
@@ -492,6 +486,11 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </returns>
         public bool IsUniform()
         {
+            if (this.storage == null)
+            {
+                return false;
+            }
+
             foreach (var range in this.storage.Ranges)
             {
                 if (Math.Abs(range.Probability - UniformProb) > Eps)
@@ -520,8 +519,8 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="distribution2">The second distribution.</param>
         public void SetToProduct(DiscreteChar distribution1, DiscreteChar distribution2)
         {
-            Argument.CheckIfNotNull(distribution1, "distribution1");
-            Argument.CheckIfNotNull(distribution2, "distribution2");
+            Argument.CheckIfNotNull(distribution1.storage, nameof(distribution1));
+            Argument.CheckIfNotNull(distribution2.storage, nameof(distribution2));
 
             var probabilityOutsideRanges = distribution1.storage.ProbabilityOutsideRanges * distribution2.storage.ProbabilityOutsideRanges;
             var builder = new StorageBuilder(probabilityOutsideRanges);
@@ -546,8 +545,8 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="distribution2">The second distribution.</param>
         public void SetToSum(double weight1, DiscreteChar distribution1, double weight2, DiscreteChar distribution2)
         {
-            Argument.CheckIfNotNull(distribution1, "distribution1");
-            Argument.CheckIfNotNull(distribution2, "distribution2");
+            Argument.CheckIfNotNull(distribution1.storage, nameof(distribution1));
+            Argument.CheckIfNotNull(distribution2.storage, nameof(distribution2));
 
             if (weight1 + weight2 == 0)
             {
@@ -599,7 +598,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <returns>The logarithm of the probability that distributions would draw the same sample.</returns>
         public double GetLogAverageOf(DiscreteChar distribution)
         {
-            Argument.CheckIfNotNull(distribution, "distribution");
+            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
 
             var result = CharRangePair.CombinedRanges(this, distribution)
                 .Sum(pair => pair.Probability1 * pair.Probability2 * (pair.EndExclusive - pair.StartInclusive));
@@ -618,7 +617,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="distribution">The distribution which support will be used to setup the current distribution.</param>
         public void SetToPartialUniformOf(DiscreteChar distribution)
         {
-            Argument.CheckIfNotNull(distribution, "distribution");
+            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
 
             var builder = new StorageBuilder(distribution.storage.ProbabilityOutsideRanges > Eps ? 1 : 0);
             foreach (var range in distribution.storage.Ranges)
@@ -670,8 +669,8 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="forceProper">Specifies whether the ratio must be proper.</param>
         public void SetToRatio(DiscreteChar numerator, DiscreteChar denominator, bool forceProper = false)
         {
-            Argument.CheckIfNotNull(numerator, "numerator");
-            Argument.CheckIfNotNull(denominator, "denominator");
+            Argument.CheckIfNotNull(numerator.storage, nameof(numerator));
+            Argument.CheckIfNotNull(denominator.storage, nameof(denominator));
 
             var probabilityOutsideRanges = DivideProb(numerator.storage.ProbabilityOutsideRanges, denominator.storage.ProbabilityOutsideRanges);
             var builder = new StorageBuilder(probabilityOutsideRanges);
@@ -695,7 +694,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="power">The power.</param>
         public void SetToPower(DiscreteChar distribution, double power)
         {
-            Argument.CheckIfNotNull(distribution, "distribution");
+            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
 
             var builder = new StorageBuilder(0);
 
@@ -739,7 +738,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </remarks>
         public double GetLogAverageOfPower(DiscreteChar distribution, double power)
         {
-            Argument.CheckIfNotNull(distribution, "distribution");
+            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
 
             double result = 0;
             foreach (var pair in CharRangePair.CombinedRanges(this, distribution))
@@ -763,7 +762,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <remarks>This is also known as the cross entropy.</remarks>
         public double GetAverageLog(DiscreteChar distribution)
         {
-            Argument.CheckIfNotNull(distribution, "distribution");
+            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
 
             double result = 0;
             foreach (var pair in CharRangePair.CombinedRanges(this, distribution, true))
@@ -866,7 +865,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="distribution">The distribution to set this distribution to.</param>
         public void SetTo(DiscreteChar distribution)
         {
-            Argument.CheckIfNotNull(distribution, "distribution");
+            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
             this.storage = distribution.storage;
         }
 
@@ -994,7 +993,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="distribution">The distribution to swap this distribution with.</param>
         public void SwapWith(DiscreteChar distribution)
         {
-            Argument.CheckIfNotNull(distribution, "distribution");
+            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
             Util.Swap(ref this.storage, ref distribution.storage);
         }
 
@@ -1478,8 +1477,8 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <summary>
         /// Reads a discrete character.
         /// </summary>
-        public static DiscreteChar Read(Func<int> readInt32, Func<double> readDouble)
-            => new DiscreteChar(Storage.Read(readInt32, readDouble));
+        public static DiscreteChar Read(Func<int> readInt32, Func<double> readDouble) =>
+            new DiscreteChar(Storage.Read(readInt32, readDouble));
 
         /// <summary>
         /// Constructor used during deserialization by Newtonsoft.Json and BinaryFormatter.
@@ -1487,7 +1486,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         private DiscreteChar(SerializationInfo info, StreamingContext context)
         {
             this.storage = (Storage)info.GetValue(nameof(this.storage), typeof(Storage));
-            if (this.storage.IsPointMass)
+            if (this.storage != null && this.storage.IsPointMass)
             {
                 // reuse storage from cache
                 this.storage = Storage.CreatePoint((char)this.storage.Ranges[0].StartInclusive, this.storage.Ranges);
@@ -1702,7 +1701,6 @@ namespace Microsoft.ML.Probabilistic.Distributions
             public static Storage Read(Func<int> readInt32, Func<double> readDouble)
             {
                 var propertyMask = new BitVector32(readInt32());
-                var res = new DiscreteChar();
                 var idx = 0;
                 var hasRanges = propertyMask[1 << idx++];
                 CharRange[] ranges = null;

--- a/src/Runtime/Distributions/DiscreteChar.cs
+++ b/src/Runtime/Distributions/DiscreteChar.cs
@@ -1465,7 +1465,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         }
 
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) =>
-            info.AddValue(nameof(this.data_), this.data_);
+            info.AddValue(nameof(this.Data), this.Data);
 
         #endregion
 

--- a/src/Runtime/Distributions/DiscreteChar.cs
+++ b/src/Runtime/Distributions/DiscreteChar.cs
@@ -90,11 +90,6 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </summary>
         private const double UniformProb = 1.0 / CharRangeEndExclusive;
 
-        /// <summary>
-        /// The index value used by <see cref="GetRangeIndexForCharacter"/> to indicate that no range has been found.
-        /// </summary>
-        private const int UnknownRange = -1;
-
         private const string DigitRegexRepresentation = @"\d";
         private const string DigitSymbolRepresentation = @"#";
 
@@ -120,8 +115,24 @@ namespace Microsoft.ML.Probabilistic.Distributions
 
         #region Constructors
 
+        /// <summary>
+        /// Stores reference to <see cref="Storage"/> for this distribution.
+        /// </summary>
+        /// <remarks>
+        /// Can be null and shouldn't be used directly. Use <see cref="Data"/> property.
+        /// </remarks>
         [DataMember]
-        private Storage storage;
+        private Storage data_;
+
+        /// <summary>
+        /// Gets or sets reference to <see cref="Storage"/> for this distribution.
+        /// Getter always returns non-null reference.
+        /// </summary>
+        private Storage Data
+        {
+            get => this.data_ ?? StorageCache.Uniform;
+            set => this.data_ = value;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DiscreteChar"/> class
@@ -135,9 +146,9 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// The created objects takes ownership of the character range list.
         /// </remarks>
         private DiscreteChar(double probabilityOutsideRanges, CharRange[] ranges, int rangeCount) =>
-            this.storage = Storage.Create(ranges, probabilityOutsideRanges);
+            this.data_ = Storage.Create(ranges, probabilityOutsideRanges);
 
-        private DiscreteChar(Storage storage) => this.storage = storage;
+        private DiscreteChar(Storage storage) => this.data_ = storage;
 
         #endregion
 
@@ -148,32 +159,32 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <summary>
         /// Gets a value indicating whether this distribution equals the distribution created by <see cref="Digit"/>.
         /// </summary>
-        public bool IsDigit => this.storage.IsDigit;
+        public bool IsDigit => this.Data.IsDigit;
 
         /// <summary>
         /// Gets a value indicating whether this distribution equals the distribution created by <see cref="Lower"/>.
         /// </summary>
-        public bool IsLower => this.storage.IsLower;
+        public bool IsLower => this.Data.IsLower;
 
         /// <summary>
         /// Gets a value indicating whether this distribution equals the distribution created by <see cref="Upper"/>.
         /// </summary>
-        public bool IsUpper => this.storage.IsUpper;
+        public bool IsUpper => this.Data.IsUpper;
 
         /// <summary>
         /// Gets a value indicating whether this distribution equals the distribution created by <see cref="Letter"/>.
         /// </summary>
-        public bool IsLetter => this.storage.IsLetter;
+        public bool IsLetter => this.Data.IsLetter;
 
         /// <summary>
         /// Gets a value indicating whether this distribution equals the distribution created by <see cref="LetterOrDigit"/>.
         /// </summary>
-        public bool IsLetterOrDigit => this.storage.IsLetterOrDigit;
+        public bool IsLetterOrDigit => this.Data.IsLetterOrDigit;
 
         /// <summary>
         /// Gets a value indicating whether this distribution equals the distribution created by <see cref="WordChar"/>.
         /// </summary>
-        public bool IsWordChar => this.storage.IsWordChar;
+        public bool IsWordChar => this.Data.IsWordChar;
 
         #endregion
 
@@ -182,21 +193,21 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <summary>
         /// Gets the probability assigned to characters outside ranges returned by <see cref="GetRanges"/>.
         /// </summary>
-        public double ProbabilityOutsideRanges => this.storage.ProbabilityOutsideRanges;
+        public double ProbabilityOutsideRanges => this.Data.ProbabilityOutsideRanges;
 
         /// <summary>
         /// Gets or sets the point mass represented by the distribution.
         /// </summary>
         public char Point
         {
-            get => this.storage.Point;
-            set => this.storage = StorageCache.GetPointMass(value, null);
+            get => this.Data.Point;
+            set => this.Data = StorageCache.GetPointMass(value, null);
         }
 
         /// <summary>
         /// Gets a value indicating whether this distribution represents a point mass.
         /// </summary>
-        public bool IsPointMass => this.storage.IsPointMass;
+        public bool IsPointMass => this.Data.IsPointMass;
 
         /// <summary>
         /// Gets the probability of a given character under this distribution.
@@ -207,8 +218,16 @@ namespace Microsoft.ML.Probabilistic.Distributions
         {
             get
             {
-                int index = this.GetRangeIndexForCharacter(value);
-                return index == UnknownRange ? this.storage.ProbabilityOutsideRanges : this.storage.Ranges[index].Probability;
+                var data = this.Data;
+                foreach (var range in data.Ranges)
+                {
+                    if (range.StartInclusive <= value && range.EndExclusive > value)
+                    {
+                        return range.Probability;
+                    }
+                }
+
+                return data.ProbabilityOutsideRanges;
             }
         }
 
@@ -457,7 +476,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// Creates a copy of this distribution.
         /// </summary>
         /// <returns>The created copy.</returns>
-        public DiscreteChar Clone() => new DiscreteChar(this.storage);
+        public DiscreteChar Clone() => new DiscreteChar(this.Data);
 
         /// <summary>
         /// Gets the maximum difference between the character probabilities under this distribution and a given one.
@@ -468,14 +487,14 @@ namespace Microsoft.ML.Probabilistic.Distributions
         {
             Argument.CheckIfNotNull(distribution, "distribution");
             return distribution is DiscreteChar thatDist
-                ? this.storage.MaxDiff(thatDist.storage)
+                ? this.Data.MaxDiff(thatDist.Data)
                 : double.PositiveInfinity;
         }
 
         /// <summary>
         /// Sets this distribution to a uniform distribution over all characters.
         /// </summary>
-        public void SetToUniform() => this.storage = StorageCache.Uniform;
+        public void SetToUniform() => this.Data = StorageCache.Uniform;
 
         /// <summary>
         /// Checks whether this distribution is a uniform distribution over all characters.
@@ -486,12 +505,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </returns>
         public bool IsUniform()
         {
-            if (this.storage == null)
-            {
-                return false;
-            }
-
-            foreach (var range in this.storage.Ranges)
+            foreach (var range in this.Data.Ranges)
             {
                 if (Math.Abs(range.Probability - UniformProb) > Eps)
                 {
@@ -519,10 +533,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="distribution2">The second distribution.</param>
         public void SetToProduct(DiscreteChar distribution1, DiscreteChar distribution2)
         {
-            Argument.CheckIfNotNull(distribution1.storage, nameof(distribution1));
-            Argument.CheckIfNotNull(distribution2.storage, nameof(distribution2));
-
-            var probabilityOutsideRanges = distribution1.storage.ProbabilityOutsideRanges * distribution2.storage.ProbabilityOutsideRanges;
+            var probabilityOutsideRanges = distribution1.Data.ProbabilityOutsideRanges * distribution2.Data.ProbabilityOutsideRanges;
             var builder = new StorageBuilder(probabilityOutsideRanges);
             foreach (var pair in CharRangePair.CombinedRanges(distribution1, distribution2))
             {
@@ -533,7 +544,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 }
             }
 
-            this.storage = builder.GetResult();
+            this.Data = builder.GetResult();
         }
 
         /// <summary>
@@ -545,9 +556,6 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="distribution2">The second distribution.</param>
         public void SetToSum(double weight1, DiscreteChar distribution1, double weight2, DiscreteChar distribution2)
         {
-            Argument.CheckIfNotNull(distribution1.storage, nameof(distribution1));
-            Argument.CheckIfNotNull(distribution2.storage, nameof(distribution2));
-
             if (weight1 + weight2 == 0)
             {
                 this.SetToUniform();
@@ -576,7 +584,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 weight1 *= invW;
                 weight2 *= invW;
                 var probabilityOutsideRanges =
-                    (weight1 * distribution1.storage.ProbabilityOutsideRanges) + (weight2 * distribution2.storage.ProbabilityOutsideRanges);
+                    (weight1 * distribution1.Data.ProbabilityOutsideRanges) + (weight2 * distribution2.Data.ProbabilityOutsideRanges);
                 var builder = new StorageBuilder(probabilityOutsideRanges);
                 foreach (var pair in CharRangePair.CombinedRanges(distribution1, distribution2, false))
                 {
@@ -587,7 +595,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                     }
                 }
 
-                this.storage = builder.GetResult();
+                this.Data = builder.GetResult();
             }
         }
 
@@ -598,8 +606,6 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <returns>The logarithm of the probability that distributions would draw the same sample.</returns>
         public double GetLogAverageOf(DiscreteChar distribution)
         {
-            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
-
             var result = CharRangePair.CombinedRanges(this, distribution)
                 .Sum(pair => pair.Probability1 * pair.Probability2 * (pair.EndExclusive - pair.StartInclusive));
 
@@ -617,15 +623,13 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="distribution">The distribution which support will be used to setup the current distribution.</param>
         public void SetToPartialUniformOf(DiscreteChar distribution)
         {
-            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
-
-            var builder = new StorageBuilder(distribution.storage.ProbabilityOutsideRanges > Eps ? 1 : 0);
-            foreach (var range in distribution.storage.Ranges)
+            var builder = new StorageBuilder(distribution.Data.ProbabilityOutsideRanges > Eps ? 1 : 0);
+            foreach (var range in distribution.Data.Ranges)
             {
                 builder.AddRange(new CharRange(range.StartInclusive, range.EndExclusive, range.Probability > Eps ? 1 : 0));
             }
 
-            this.storage = builder.GetResult();
+            this.Data = builder.GetResult();
         }
 
         /// <summary>
@@ -637,9 +641,9 @@ namespace Microsoft.ML.Probabilistic.Distributions
             double? commonProb = null;
             bool hasCommonValues = false;
             int prevRangeEnd = 0;
-            for (int i = 0; i < this.storage.Ranges.Length; ++i)
+            var data = this.Data;
+            foreach (var range in data.Ranges)
             {
-                var range = this.storage.Ranges[i];
                 if (commonProb.HasValue && range.Probability > Eps && Math.Abs(commonProb.Value - range.Probability) > Eps)
                 {
                     return false;
@@ -652,8 +656,8 @@ namespace Microsoft.ML.Probabilistic.Distributions
 
             hasCommonValues |= prevRangeEnd < CharRangeEndExclusive;
 
-            if (hasCommonValues && commonProb.HasValue && this.storage.ProbabilityOutsideRanges > Eps &&
-                Math.Abs(commonProb.Value - this.storage.ProbabilityOutsideRanges) > Eps)
+            if (hasCommonValues && commonProb.HasValue && data.ProbabilityOutsideRanges > Eps &&
+                Math.Abs(commonProb.Value - data.ProbabilityOutsideRanges) > Eps)
             {
                 return false;
             }
@@ -669,10 +673,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="forceProper">Specifies whether the ratio must be proper.</param>
         public void SetToRatio(DiscreteChar numerator, DiscreteChar denominator, bool forceProper = false)
         {
-            Argument.CheckIfNotNull(numerator.storage, nameof(numerator));
-            Argument.CheckIfNotNull(denominator.storage, nameof(denominator));
-
-            var probabilityOutsideRanges = DivideProb(numerator.storage.ProbabilityOutsideRanges, denominator.storage.ProbabilityOutsideRanges);
+            var probabilityOutsideRanges = DivideProb(numerator.Data.ProbabilityOutsideRanges, denominator.Data.ProbabilityOutsideRanges);
             var builder = new StorageBuilder(probabilityOutsideRanges);
 
             foreach (var pair in CharRangePair.CombinedRanges(numerator, denominator))
@@ -684,7 +685,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 }
             }
 
-            this.storage = builder.GetResult();
+            this.Data = builder.GetResult();
         }
 
         /// <summary>
@@ -694,13 +695,11 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="power">The power.</param>
         public void SetToPower(DiscreteChar distribution, double power)
         {
-            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
-
             var builder = new StorageBuilder(0);
 
             bool hasCommonValues = false;
             int prevRangeEnd = 0;
-            foreach (var range in distribution.storage.Ranges)
+            foreach (var range in distribution.Data.Ranges)
             {
                 if (range.Probability < Eps && power < 0)
                 {
@@ -716,15 +715,15 @@ namespace Microsoft.ML.Probabilistic.Distributions
             hasCommonValues |= prevRangeEnd < CharRangeEndExclusive;
             if (hasCommonValues)
             {
-                if (distribution.storage.ProbabilityOutsideRanges < Eps && power < 0)
+                if (distribution.Data.ProbabilityOutsideRanges < Eps && power < 0)
                 {
                     throw new DivideByZeroException();
                 }
 
-                builder.ProbabilityOutsideRanges = Math.Pow(distribution.storage.ProbabilityOutsideRanges, power);
+                builder.ProbabilityOutsideRanges = Math.Pow(distribution.Data.ProbabilityOutsideRanges, power);
             }
 
-            this.storage = builder.GetResult();
+            this.Data = builder.GetResult();
         }
 
         /// <summary>
@@ -738,8 +737,6 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </remarks>
         public double GetLogAverageOfPower(DiscreteChar distribution, double power)
         {
-            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
-
             double result = 0;
             foreach (var pair in CharRangePair.CombinedRanges(this, distribution))
             {
@@ -762,8 +759,6 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <remarks>This is also known as the cross entropy.</remarks>
         public double GetAverageLog(DiscreteChar distribution)
         {
-            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
-
             double result = 0;
             foreach (var pair in CharRangePair.CombinedRanges(this, distribution, true))
             {
@@ -790,9 +785,9 @@ namespace Microsoft.ML.Probabilistic.Distributions
             char mode = '\0';
             char charOutOfRanges = '\0';
             double maxProb = 0;
-            for (int i = 0; i < this.storage.Ranges.Length; ++i)
+            var data = this.Data;
+            foreach (var range in data.Ranges)
             {
-                var range = this.storage.Ranges[i];
                 if (range.Probability > maxProb)
                 {
                     mode = (char)range.StartInclusive;
@@ -814,7 +809,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 charOutOfRanges = (char)prevRangeEnd;
             }
 
-            return hasCommonValues && this.storage.ProbabilityOutsideRanges > maxProb ? charOutOfRanges : mode;
+            return hasCommonValues && data.ProbabilityOutsideRanges > maxProb ? charOutOfRanges : mode;
         }
 
         /// <summary>
@@ -842,14 +837,16 @@ namespace Microsoft.ML.Probabilistic.Distributions
         private IEnumerable<CharRange> EnumerateCharRanges()
         {
             var prevRangeEnd = 0;
-            foreach (var range in this.storage.Ranges)
+            var data = this.Data;
+            var probabilityOutsideRanges = data.ProbabilityOutsideRanges;
+            foreach (var range in data.Ranges)
             {
-                yield return new CharRange(prevRangeEnd, range.StartInclusive, this.storage.ProbabilityOutsideRanges);
+                yield return new CharRange(prevRangeEnd, range.StartInclusive, probabilityOutsideRanges);
                 yield return new CharRange(range.StartInclusive, range.EndExclusive, range.Probability);
                 prevRangeEnd = range.EndExclusive;
             }
 
-            yield return new CharRange(prevRangeEnd, CharRangeEndExclusive, this.storage.ProbabilityOutsideRanges);
+            yield return new CharRange(prevRangeEnd, CharRangeEndExclusive, probabilityOutsideRanges);
         }
 
         /// <summary>
@@ -863,11 +860,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// Sets this distribution to be equal to a given distribution.
         /// </summary>
         /// <param name="distribution">The distribution to set this distribution to.</param>
-        public void SetTo(DiscreteChar distribution)
-        {
-            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
-            this.storage = distribution.storage;
-        }
+        public void SetTo(DiscreteChar distribution) => this.Data = distribution.Data;
 
         /// <summary>
         /// Enumerates over the support of the distribution instance.
@@ -877,10 +870,12 @@ namespace Microsoft.ML.Probabilistic.Distributions
         {
             int prevRangeEnd = 0;
 
-            for (int i = 0; i < this.storage.Ranges.Length; ++i)
+            var data = this.Data;
+            var probabilityOutsideRanges = data.ProbabilityOutsideRanges;
+
+            foreach (var range in data.Ranges)
             {
-                var range = this.storage.Ranges[i];
-                if (this.storage.ProbabilityOutsideRanges > 0.0)
+                if (probabilityOutsideRanges > 0.0)
                 {
                     for (int j = prevRangeEnd; j < range.StartInclusive; j++)
                     {
@@ -899,7 +894,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 prevRangeEnd = range.EndExclusive;
             }
 
-            if (this.storage.ProbabilityOutsideRanges > 0.0)
+            if (probabilityOutsideRanges > 0.0)
             {
                 for (int j = prevRangeEnd; j < CharRangeEndExclusive; j++)
                 {
@@ -921,7 +916,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         public CharRange[] GetRanges()
         {
             // TODO: use immutable arrays and get rid of clone
-            return (CharRange[])this.storage.Ranges.Clone();
+            return (CharRange[])this.Data.Ranges.Clone();
         }
 
         /// <summary>
@@ -934,14 +929,14 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// e.g. not a letter or not a word character.
         /// </remarks>
         /// <returns>The created distribution.</returns>
-        public DiscreteChar Complement() => new DiscreteChar(this.storage.Complement());
+        public DiscreteChar Complement() => new DiscreteChar(this.Data.Complement());
 
         public static DiscreteChar ToLower(DiscreteChar unnormalizedCharDist)
         {
-            switch (unnormalizedCharDist.storage.CharClasses)
+            switch (unnormalizedCharDist.Data.CharClasses)
             {
                 case CharClasses.Unknown:
-                    var ranges = unnormalizedCharDist.storage.Ranges;
+                    var ranges = unnormalizedCharDist.Data.Ranges;
                     var probVector = PiecewiseVector.Zero(CharRangeEndExclusive);
                     foreach (var range in ranges)
                     {
@@ -978,8 +973,9 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <returns>A vector of character probabilities.</returns>
         public PiecewiseVector GetProbs()
         {
-            var result = PiecewiseVector.Constant(CharRangeEndExclusive, this.storage.ProbabilityOutsideRanges);
-            foreach (var range in this.storage.Ranges)
+            var data = this.Data;
+            var result = PiecewiseVector.Constant(CharRangeEndExclusive, data.ProbabilityOutsideRanges);
+            foreach (var range in data.Ranges)
             {
                 result.Pieces.Add(new ConstantVector(range.StartInclusive, range.EndExclusive - 1, range.Probability));
             }
@@ -991,11 +987,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// Swaps this distribution with a given one.
         /// </summary>
         /// <param name="distribution">The distribution to swap this distribution with.</param>
-        public void SwapWith(DiscreteChar distribution)
-        {
-            Argument.CheckIfNotNull(distribution.storage, nameof(distribution));
-            Util.Swap(ref this.storage, ref distribution.storage);
-        }
+        public void SwapWith(DiscreteChar distribution) => Util.Swap(ref this.data_, ref distribution.data_);
 
         #endregion
 
@@ -1007,9 +999,9 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <returns>
         /// A string that represents this distribution.
         /// </returns>
-        public override string ToString() => this.storage.ToString();
+        public override string ToString() => this.Data.ToString();
 
-        public void AppendToString(StringBuilder stringBuilder) => this.storage.AppendToString(stringBuilder);
+        public void AppendToString(StringBuilder stringBuilder) => this.Data.AppendToString(stringBuilder);
 
         /// <summary>
         /// Appends a regex expression that represents this character to the supplied string builder.
@@ -1017,20 +1009,20 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="stringBuilder">The string builder to append to</param>
         /// <param name="useFriendlySymbols">Whether to use friendly symbols."</param>
         public void AppendRegex(StringBuilder stringBuilder, bool useFriendlySymbols = false) =>
-            this.storage.AppendRegex(stringBuilder, useFriendlySymbols);
+            this.Data.AppendRegex(stringBuilder, useFriendlySymbols);
 
         /// <summary>
         /// Checks if <paramref name="obj"/> equals to this distribution (i.e. represents the same distribution over characters).
         /// </summary>
         /// <param name="obj">The object to compare this distribution with.</param>
         /// <returns><see langword="true"/> if this distribution is equal to <paramref name="obj"/>, false otherwise.</returns>
-        public override bool Equals(object obj) => obj is DiscreteChar other && this.storage.Equals(other.storage);
+        public override bool Equals(object obj) => obj is DiscreteChar other && this.Data.Equals(other.Data);
 
         /// <summary>
         /// Gets the hash code of this distribution.
         /// </summary>
         /// <returns>The hash code.</returns>
-        public override int GetHashCode() => this.storage.GetHashCode();
+        public override int GetHashCode() => this.Data.GetHashCode();
 
         #endregion
 
@@ -1081,27 +1073,6 @@ namespace Microsoft.ML.Probabilistic.Distributions
         }
 
         #endregion
-
-        /// <summary>
-        /// Gets the index of the character range containing a given character, if any.
-        /// </summary>
-        /// <param name="value">The character.</param>
-        /// <returns>
-        /// The index of the character range containing <paramref name="value"/>,
-        /// or <see cref="UnknownRange"/> if no range has been found.
-        /// </returns>
-        private int GetRangeIndexForCharacter(char value)
-        {
-            for (int i = 0; i < this.storage.Ranges.Length; ++i)
-            {
-                if (this.storage.Ranges[i].StartInclusive <= value && this.storage.Ranges[i].EndExclusive > value)
-                {
-                    return i;
-                }
-            }
-
-            return UnknownRange;
-        }
 
         #endregion
 
@@ -1305,7 +1276,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
             /// <param name="excludeZeroProb">Whether to exclude non-intersectng ranges in the case where both distibrutions have zero probability outside their ranges.</param>
             /// <returns></returns>
             public static IEnumerable<CharRangePair> CombinedRanges(DiscreteChar distribution1, DiscreteChar distribution2, bool excludeZeroProb = true) =>
-                CombinedRanges(distribution1.storage, distribution2.storage, excludeZeroProb);
+                CombinedRanges(distribution1.Data, distribution2.Data, excludeZeroProb);
 
             internal static IEnumerable<CharRangePair> CombinedRanges(Storage state1, Storage state2, bool excludeZeroProb)
             {
@@ -1472,7 +1443,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// Writes a discrete character.
         /// </summary>
         public void Write(Action<int> writeInt32, Action<double> writeDouble) =>
-            this.storage.Write(writeInt32, writeDouble);
+            this.Data.Write(writeInt32, writeDouble);
 
         /// <summary>
         /// Reads a discrete character.
@@ -1485,16 +1456,16 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </summary>
         private DiscreteChar(SerializationInfo info, StreamingContext context)
         {
-            this.storage = (Storage)info.GetValue(nameof(this.storage), typeof(Storage));
-            if (this.storage != null && this.storage.IsPointMass)
+            this.data_ = (Storage)info.GetValue(nameof(this.Data), typeof(Storage));
+            if (this.data_?.IsPointMass ?? false)
             {
                 // reuse storage from cache
-                this.storage = Storage.CreatePoint((char)this.storage.Ranges[0].StartInclusive, this.storage.Ranges);
+                this.data_ = Storage.CreatePoint((char)this.Data.Ranges[0].StartInclusive, this.Data.Ranges);
             }
         }
 
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) =>
-            info.AddValue(nameof(this.storage), this.storage);
+            info.AddValue(nameof(this.data_), this.data_);
 
         #endregion
 
@@ -1654,7 +1625,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
             private bool IsCharClass(CharClasses charClass, Func<DiscreteChar> classConstructor)
             {
                 // TODO: optimize via reuse
-                if (CharClasses == CharClasses.Unknown && this.Equals(classConstructor().storage))
+                if (CharClasses == CharClasses.Unknown && this.Equals(classConstructor().Data))
                 {
                     this.CharClasses = charClass;
                 }

--- a/src/Runtime/Distributions/Distribution.cs
+++ b/src/Runtime/Distributions/Distribution.cs
@@ -1413,7 +1413,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </returns>
         public static double GetLogAverageOf<T, TDistribution>(
             TDistribution distribution1, TDistribution distribution2, out TDistribution product)
-            where TDistribution : class, IDistribution<T>, SettableToProduct<TDistribution>, CanGetLogAverageOf<TDistribution>, new()
+            where TDistribution : IDistribution<T>, SettableToProduct<TDistribution>, CanGetLogAverageOf<TDistribution>, new()
         {
             if (distribution2.IsPointMass)
             {
@@ -1439,6 +1439,17 @@ namespace Microsoft.ML.Probabilistic.Distributions
             }
 
             return logNormalizer;
+        }
+
+        /// <summary>
+        /// Helper method that creates new distribution that is equal to product of 2 given distributions.
+        /// </summary>
+        public static TDistribution Product<T, TDistribution>(TDistribution distribution1, TDistribution distribution2)
+            where TDistribution : IDistribution<T>, SettableToProduct<TDistribution>, new()
+        {
+            var result = new TDistribution();
+            result.SetToProduct(distribution1, distribution2);
+            return result;
         }
 
         /// <summary>
@@ -1600,7 +1611,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// The log-probability that two distributions would draw the same sample.
         /// </returns>
         public static double GetLogAverageOf<TDistribution>(TDistribution distribution1, TDistribution distribution2, out TDistribution product)
-            where TDistribution : class, IDistribution<T>, SettableToProduct<TDistribution>, CanGetLogAverageOf<TDistribution>, new()
+            where TDistribution : IDistribution<T>, SettableToProduct<TDistribution>, CanGetLogAverageOf<TDistribution>, new()
         {
             return Distribution.GetLogAverageOf<T, TDistribution>(distribution1, distribution2, out product);
         }

--- a/src/Runtime/Distributions/ListDistribution.cs
+++ b/src/Runtime/Distributions/ListDistribution.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
     public abstract class ListDistribution<TList, TElement, TElementDistribution, TThis> :
         SequenceDistribution<TList, TElement, TElementDistribution, ListManipulator<TList, TElement>, ListAutomaton<TList, TElement, TElementDistribution>, TThis>
         where TList : class, IList<TElement>, new()
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
         where TThis : ListDistribution<TList, TElement, TElementDistribution, TThis>, new()
     {
     }
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
     public class ListDistribution<TList, TElement, TElementDistribution> :
         ListDistribution<TList, TElement, TElementDistribution, ListDistribution<TList, TElement, TElementDistribution>>
         where TList : class, IList<TElement>, new()
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
     {
     }
 
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
     [Quality(QualityBand.Experimental)]
     public class ListDistribution<TElement, TElementDistribution> :
         SequenceDistribution<List<TElement>, TElement, TElementDistribution, ListManipulator<List<TElement>, TElement>, ListAutomaton<TElement, TElementDistribution>, ListDistribution<TElement, TElementDistribution>>
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
     {
     }
 }

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         Sampleable<TSequence>
         where TSequence : class, IEnumerable<TElement>
         where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
-        where TElementDistribution : class, IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
+        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, Sampleable<TElement>, new()
         where TWeightFunction : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>, new()
         where TThis : SequenceDistribution<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction, TThis>, new()
     {
@@ -397,7 +397,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <returns>The created distribution.</returns>
         public static TThis Repeat(TElementDistribution allowedElements, int minTimes = 1, int? maxTimes = null, DistributionKind uniformity = DistributionKind.UniformOverValue)
         {
-            Argument.CheckIfNotNull(allowedElements, "allowedElements");
+            Argument.CheckIfNotNull(allowedElements, nameof(allowedElements));
             Argument.CheckIfInRange(minTimes >= 0, "minTimes", "The minimum number of times to repeat must be non-negative.");
             Argument.CheckIfInRange(!maxTimes.HasValue || maxTimes.Value >= 0, "maxTimes", "The maximum number of times to repeat must be non-negative.");
             Argument.CheckIfValid(!maxTimes.HasValue || minTimes <= maxTimes.Value, "The minimum length cannot be greater than the maximum length.");
@@ -774,7 +774,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </remarks>
         public void AppendInPlace(TElementDistribution elementDistribution, int group = 0)
         {
-            Argument.CheckIfNotNull(elementDistribution, "elementDistribution");
+            Argument.CheckIfValid(elementDistribution != null, nameof(elementDistribution));
             
             this.AppendInPlace(SingleElement(elementDistribution), group);
         }
@@ -1453,7 +1453,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                     {
                         if (!transition.IsEpsilon)
                         {
-                            sampledElements.Add(transition.ElementDistribution.Sample());
+                            sampledElements.Add(transition.ElementDistribution.Value.Sample());
                         }
 
                         currentState = dist.sequenceToWeight.States[transition.DestinationStateIndex];

--- a/src/Runtime/Factors/SingleOp.cs
+++ b/src/Runtime/Factors/SingleOp.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.Probabilistic.Factors
                         if (!destStateClosure.EndWeight.IsZero)
                         {
                             Weight weight = Weight.Product(stateLogWeight, transition.Weight, destStateClosure.EndWeight);
-                            var logProbs = transition.ElementDistribution.GetProbs();
+                            var logProbs = transition.ElementDistribution.Value.GetProbs();
                             logProbs.SetToFunction(logProbs, Math.Log);
                             resultLogProb = LogSumExp(resultLogProb, logProbs, weight);
                         }

--- a/src/Runtime/Factors/StringOfLengthOp.cs
+++ b/src/Runtime/Factors/StringOfLengthOp.cs
@@ -21,7 +21,6 @@ namespace Microsoft.ML.Probabilistic.Factors
         /// <include file='FactorDocs.xml' path='factor_docs/message_op_class[@name="StringOfLengthOp"]/message_doc[@name="StrAverageConditional(DiscreteChar, int)"]/*'/>
         public static StringDistribution StrAverageConditional(DiscreteChar allowedChars, int length)
         {
-            Argument.CheckIfNotNull(allowedChars, "allowedChars");
             Argument.CheckIfValid(allowedChars.IsPartialUniform(), "allowedChars", "The set of allowed characters must be passed as a partial uniform distribution.");
             
             return StringDistribution.Repeat(allowedChars, length, length);
@@ -30,7 +29,6 @@ namespace Microsoft.ML.Probabilistic.Factors
         /// <include file='FactorDocs.xml' path='factor_docs/message_op_class[@name="StringOfLengthOp"]/message_doc[@name="StrAverageConditional(DiscreteChar, Discrete)"]/*'/>
         public static StringDistribution StrAverageConditional(DiscreteChar allowedChars, Discrete length)
         {
-            Argument.CheckIfNotNull(allowedChars, "allowedChars");
             Argument.CheckIfNotNull(length, "length");
             Argument.CheckIfValid(allowedChars.IsPartialUniform(), "allowedChars", "The set of allowed characters must be passed as a partial uniform distribution.");
 

--- a/test/Tests/Strings/LoopyAutomatonTests.cs
+++ b/test/Tests/Strings/LoopyAutomatonTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using Microsoft.ML.Probabilistic.Distributions;
     using Microsoft.ML.Probabilistic.Distributions.Automata;
     using Microsoft.ML.Probabilistic.Math;
+    using Microsoft.ML.Probabilistic.Utilities;
 
     /// <summary>
     /// Contains a set of tests for automata with non-trivial loops,
@@ -543,7 +544,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         public void NormalizeWithInfiniteEpsilon1()
         {
             StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.One).AddSelfTransition(null, Weight.FromValue(3)).SetEndWeight(Weight.One);
+            automaton.Start.AddTransition('a', Weight.One).AddSelfTransition(Option.None, Weight.FromValue(3)).SetEndWeight(Weight.One);
 
             // The automaton takes an infinite value on "a", and yet the normalization must work
             Assert.True(automaton.TryNormalizeValues());
@@ -559,8 +560,8 @@ namespace Microsoft.ML.Probabilistic.Tests
         public void NormalizeWithInfiniteEpsilon2()
         {
             StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.One).AddSelfTransition(null, Weight.FromValue(2)).SetEndWeight(Weight.One);
-            automaton.Start.AddTransition('b', Weight.One).AddSelfTransition(null, Weight.FromValue(1)).SetEndWeight(Weight.One);
+            automaton.Start.AddTransition('a', Weight.One).AddSelfTransition(Option.None, Weight.FromValue(2)).SetEndWeight(Weight.One);
+            automaton.Start.AddTransition('b', Weight.One).AddSelfTransition(Option.None, Weight.FromValue(1)).SetEndWeight(Weight.One);
 
             // "a" branch infinitely dominates over the "b" branch
             Assert.True(automaton.TryNormalizeValues());
@@ -715,7 +716,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         private static double GetLogNormalizerByGetValue(StringAutomaton automaton)
         {
             var epsilonAutomaton = new StringAutomaton();
-            epsilonAutomaton.SetToFunction(automaton, (dist, weight, group) => Tuple.Create<DiscreteChar, Weight>(null, weight)); // Convert all the edges to epsilon edges
+            epsilonAutomaton.SetToFunction(automaton, (dist, weight, group) => Tuple.Create<Option<DiscreteChar>, Weight>(Option.None, weight)); // Convert all the edges to epsilon edges
             return epsilonAutomaton.GetLogValue(string.Empty); // Now this will be exactly the normalizer
         }
 

--- a/test/Tests/Strings/TransducerTests.cs
+++ b/test/Tests/Strings/TransducerTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;
     using Microsoft.ML.Probabilistic.Distributions;
     using Microsoft.ML.Probabilistic.Distributions.Automata;
+    using Microsoft.ML.Probabilistic.Utilities;
 
     /// <summary>
     /// Tests for transducers.
@@ -26,8 +27,8 @@ namespace Microsoft.ML.Probabilistic.Tests
             StringAutomaton.MaxStateCount = 1200000; // Something big
             StringAutomaton bigAutomaton = StringAutomaton.Zero();
             bigAutomaton.AddStates(StringAutomaton.MaxStateCount - bigAutomaton.States.Count);
-            Func<DiscreteChar, Weight, Tuple<PairDistribution<char, DiscreteChar>, Weight>> transitionConverter =
-                (dist, weight) => Tuple.Create(PairDistribution<char, DiscreteChar>.FromFirstSecond(dist, dist), weight);
+            Func<DiscreteChar, Weight, Tuple<Option<PairDistribution<char, DiscreteChar>>, Weight>> transitionConverter =
+                (dist, weight) => Tuple.Create(Option.Some(PairDistribution<char, DiscreteChar>.FromFirstSecond(dist, dist)), weight);
             
             Assert.Throws<AutomatonTooLargeException>(() => StringTransducer.FromAutomaton(bigAutomaton, transitionConverter));
 


### PR DESCRIPTION
Automatons didn't support value types for TElementDistribution because they used
null values as a sentinel for epsilon transitions. PairDistributions (and Transducers)
didn't support them because one element of pair can be null.

General idea of this PR: wrap distributions into a struct that can answer if it's value is null.
Like `Nullable<T>` but also suitable for reference types.


Changes done:
  1. `Utilities.Option<T>` is introduced. It behaves like `Nullable<T>` but can be constructed
     from (null) references. It has the same guarantee - if `HasValue` returns true then
     `Value` is guaranteed to return valid non-null result.
  2. `Argument.CheckIfNotNull` can have value type as a generic parameter. Obviosly
     for value types this function is a no-op. But it allows to write generic code that
     checks if argument is not null if it is a reference type, and does not check anything
     otherwise.
  3. `Utilities.Option<T>` is used everywhere in `Automaton` interfaces. But the
     `ElementDistribution` inside `Automaton.Transition` is stored as 2 fields:
     `hasElementDistribution` and `elementDistribution`. Due to careful structure
     layout (`hasElementDistribution` is packed with `group` field), this takes
     8 bytes less space then simple `Option<TElementDistribution>`.

All these changes are done with single purpose - to convert DiscreteChar from class
to struct. That saves 24 bytes per transition in StringAutomaton. That is a lot.

Benchmarking shows no performance penalty for introducing Optional<>.
JIT does a good job of optimizing it away.