### PR TITLE
Convert Automaton.StateData to value type

### DIFF
--- a/src/Runtime/Core/Collections/Option.cs
+++ b/src/Runtime/Core/Collections/Option.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.ML.Probabilistic.Core.Collections
+namespace Microsoft.ML.Probabilistic.Collections
 {
     using System;
     using System.Collections.Generic;

--- a/src/Runtime/Core/Collections/Option.cs
+++ b/src/Runtime/Core/Collections/Option.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-
-namespace Microsoft.ML.Probabilistic.Utilities
+namespace Microsoft.ML.Probabilistic.Core.Collections
 {
     using System;
+    using System.Collections.Generic;
 
     using Microsoft.ML.Probabilistic.Serialization;
 
@@ -88,6 +87,7 @@ namespace Microsoft.ML.Probabilistic.Utilities
 
         public static bool operator !=(Option<T> a, Option<T> b) => !(a == b);
 
+        /// <inheritdoc/>
         public override bool Equals(object other)
         {
             if (other is Option<T> that)
@@ -100,8 +100,10 @@ namespace Microsoft.ML.Probabilistic.Utilities
                 : other == null;
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode() => this.HasValue ? this.value.GetHashCode() : 0;
 
+        /// <inheritdoc/>
         public override string ToString() => this.HasValue ? this.value.ToString() : "(null)";
     }
 
@@ -138,6 +140,18 @@ namespace Microsoft.ML.Probabilistic.Utilities
             }
 
             return new Option<T>(value);
+        }
+
+        /// <summary>
+        /// Helper function to create <see cref="Option{T}"/> from <see cref="Nullable{T}"/>.
+        /// </summary>
+        public static Option<T> FromNullable<T>(T? nullable)
+            where T : struct
+        {
+            return
+                nullable == null
+                    ? new Option<T>()
+                    : new Option<T>(nullable.Value);
         }
 
         /// <summary>

--- a/src/Runtime/Core/Collections/ReadOnlyArray.cs
+++ b/src/Runtime/Core/Collections/ReadOnlyArray.cs
@@ -163,7 +163,7 @@ namespace Microsoft.ML.Probabilistic.Collections
         /// <summary>
         /// Initializes a new instance of <see cref="ReadOnlyArraySegment{T}"/> structure.
         /// </summary>
-        internal ReadOnlyArraySegmentEnumerator(T[] array, int begin, int end)
+        internal ReadOnlyArraySegmentEnumerator(ReadOnlyArray<T> array, int begin, int end)
         {
             this.array = array;
             this.begin = begin;

--- a/src/Runtime/Core/Collections/ReadOnlyArray.cs
+++ b/src/Runtime/Core/Collections/ReadOnlyArray.cs
@@ -10,6 +10,7 @@ namespace Microsoft.ML.Probabilistic.Collections
     using System.Runtime.Serialization;
 
     using Microsoft.ML.Probabilistic.Serialization;
+    using Microsoft.ML.Probabilistic.Utilities;
 
     /// <summary>
     /// Represents a read only array.
@@ -59,16 +60,16 @@ namespace Microsoft.ML.Probabilistic.Collections
         /// <remarks>
         /// This is value-type non-virtual version of enumerator that is used by compiler in foreach loops.
         /// </remarks>
-        public ReadOnlySegmentEnumerator<T> GetEnumerator() =>
-            new ReadOnlySegmentEnumerator<T>(this, 0, this.array.Length);
+        public ReadOnlyArraySegmentEnumerator<T> GetEnumerator() =>
+            new ReadOnlyArraySegmentEnumerator<T>(this, 0, this.array.Length);
 
         /// <inheritdoc/>
         IEnumerator<T> IEnumerable<T>.GetEnumerator() =>
-            new ReadOnlySegmentEnumerator<T>(this, 0, this.array.Length);
+            new ReadOnlyArraySegmentEnumerator<T>(this, 0, this.array.Length);
 
         /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator() =>
-            new ReadOnlySegmentEnumerator<T>(this, 0, this.array.Length);
+            new ReadOnlyArraySegmentEnumerator<T>(this, 0, this.array.Length);
 
         /// <summary>
         /// Helper method which allows to cast regular arrays to read only versions implicitly.
@@ -101,6 +102,10 @@ namespace Microsoft.ML.Probabilistic.Collections
         /// </summary>
         public ReadOnlyArraySegment(ReadOnlyArray<T> array, int begin, int end)
         {
+            Argument.CheckIfValid(array.IsNull, nameof(array));
+            Argument.CheckIfInRange(end >= 0 && end <= array.Count, nameof(end), "Segment end should be in the range [0, array.Count]");
+            Argument.CheckIfInRange(begin >= 0 && begin <= end, nameof(begin), "Segment begin should be in the range [0, end]");
+
             this.array = array;
             this.begin = begin;
             this.end = end;
@@ -118,22 +123,22 @@ namespace Microsoft.ML.Probabilistic.Collections
         /// <remarks>
         /// This is value-type non-virtual version of enumerator that is used by compiler in foreach loops.
         /// </remarks>
-        public ReadOnlySegmentEnumerator<T> GetEnumerator() =>
-            new ReadOnlySegmentEnumerator<T>(this.array, this.begin, this.end);
+        public ReadOnlyArraySegmentEnumerator<T> GetEnumerator() =>
+            new ReadOnlyArraySegmentEnumerator<T>(this.array, this.begin, this.end);
 
         /// <inheritdoc/>
         IEnumerator<T> IEnumerable<T>.GetEnumerator() =>
-            new ReadOnlySegmentEnumerator<T>(this.array, this.begin, this.end);
+            new ReadOnlyArraySegmentEnumerator<T>(this.array, this.begin, this.end);
 
         /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator() =>
-            new ReadOnlySegmentEnumerator<T>(this.array, this.begin, this.end);
+            new ReadOnlyArraySegmentEnumerator<T>(this.array, this.begin, this.end);
     }
 
     /// <summary>
     /// Enumerator for read only arrays and read only array segments.
     /// </summary>
-    public struct ReadOnlySegmentEnumerator<T> : IEnumerator<T>
+    public struct ReadOnlyArraySegmentEnumerator<T> : IEnumerator<T>
     {
         /// <summary>
         /// Underlying read-only array.
@@ -158,7 +163,7 @@ namespace Microsoft.ML.Probabilistic.Collections
         /// <summary>
         /// Initializes a new instance of <see cref="ReadOnlyArraySegment{T}"/> structure.
         /// </summary>
-        public ReadOnlySegmentEnumerator(ReadOnlyArray<T> array, int begin, int end)
+        internal ReadOnlyArraySegmentEnumerator(T[] array, int begin, int end)
         {
             this.array = array;
             this.begin = begin;

--- a/src/Runtime/Core/Collections/ReadOnlyArray.cs
+++ b/src/Runtime/Core/Collections/ReadOnlyArray.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.ML.Probabilistic.Core.Collections
+namespace Microsoft.ML.Probabilistic.Collections
 {
     using System;
     using System.Collections;

--- a/src/Runtime/Core/Collections/ReadOnlyArray.cs
+++ b/src/Runtime/Core/Collections/ReadOnlyArray.cs
@@ -102,7 +102,7 @@ namespace Microsoft.ML.Probabilistic.Collections
         /// </summary>
         public ReadOnlyArraySegment(ReadOnlyArray<T> array, int begin, int end)
         {
-            Argument.CheckIfValid(array.IsNull, nameof(array));
+            Argument.CheckIfValid(!array.IsNull, nameof(array));
             Argument.CheckIfInRange(end >= 0 && end <= array.Count, nameof(end), "Segment end should be in the range [0, array.Count]");
             Argument.CheckIfInRange(begin >= 0 && begin <= end, nameof(begin), "Segment begin should be in the range [0, end]");
 

--- a/src/Runtime/Core/Collections/ReadOnlyArray.cs
+++ b/src/Runtime/Core/Collections/ReadOnlyArray.cs
@@ -1,0 +1,193 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Core.Collections
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+
+    using Microsoft.ML.Probabilistic.Serialization;
+
+    /// <summary>
+    /// Represents a read only array.
+    /// </summary>
+    /// <remarks>
+    /// It is implemented as struct because it avoids extra allocations on heap.
+    /// <see cref="ReadOnlyArray{T}"/> doesn't have space overhead compared to regular arrays.
+    /// </remarks>
+    [Serializable]
+    [DataContract]
+    public struct ReadOnlyArray<T> : IReadOnlyList<T>
+    {
+        /// <summary>
+        /// Regular array that holds data.
+        /// </summary>
+        [DataMember]
+        private readonly T[] array;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadOnlyArray{T}"/> structure.
+        /// </summary>
+        [Construction("CloneArray")]
+        public ReadOnlyArray(T[] array)
+        {
+            this.array = array;
+        }
+
+        /// <summary>
+        /// Gets a boolean value which is true if this ReadOnlyArray wraps null array.
+        /// </summary>
+        public bool IsNull => this.array == null;
+
+        /// <inheritdoc/>
+        public T this[int index] => this.array[index];
+
+        /// <inheritdoc/>
+        public int Count => this.array.Length;
+
+        /// <summary>
+        /// Creates a mutable copy of this array.
+        /// </summary>
+        public T[] CloneArray() => (T[])this.array.Clone();
+
+        /// <summary>
+        /// Returns enumerator over elements of array.
+        /// </summary>
+        /// <remarks>
+        /// This is value-type non-virtual version of enumerator that is used by compiler in foreach loops.
+        /// </remarks>
+        public ReadOnlySegmentEnumerator<T> GetEnumerator() =>
+            new ReadOnlySegmentEnumerator<T>(this, 0, this.array.Length);
+
+        /// <inheritdoc/>
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() =>
+            new ReadOnlySegmentEnumerator<T>(this, 0, this.array.Length);
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() =>
+            new ReadOnlySegmentEnumerator<T>(this, 0, this.array.Length);
+
+        /// <summary>
+        /// Helper method which allows to cast regular arrays to read only versions implicitly.
+        /// </summary>
+        public static implicit operator ReadOnlyArray<T>(T[] array) => new ReadOnlyArray<T>(array);
+    }
+
+    /// <summary>
+    /// A version if <see cref="ArraySegment{T}"/> which can not be mutated.
+    /// </summary>
+    public struct ReadOnlyArraySegment<T> : IReadOnlyList<T>
+    {
+        /// <summary>
+        /// Underlying read-only array.
+        /// </summary>
+        private readonly ReadOnlyArray<T> array;
+
+        /// <summary>
+        /// Index of the first element which belongs to this segment.
+        /// </summary>
+        private readonly int begin;
+
+        /// <summary>
+        /// Index of the first element which does not belong to this segment.
+        /// </summary>
+        private readonly int end;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ReadOnlyArraySegment{T}"/> structure.
+        /// </summary>
+        public ReadOnlyArraySegment(ReadOnlyArray<T> array, int begin, int end)
+        {
+            this.array = array;
+            this.begin = begin;
+            this.end = end;
+        }
+
+        /// <inheritdoc/>
+        public T this[int index] => this.array[this.begin + index];
+
+        /// <inheritdoc/>
+        public int Count => this.end - this.begin;
+
+        /// <summary>
+        /// Returns enumerator over elements of array.
+        /// </summary>
+        /// <remarks>
+        /// This is value-type non-virtual version of enumerator that is used by compiler in foreach loops.
+        /// </remarks>
+        public ReadOnlySegmentEnumerator<T> GetEnumerator() =>
+            new ReadOnlySegmentEnumerator<T>(this.array, this.begin, this.end);
+
+        /// <inheritdoc/>
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() =>
+            new ReadOnlySegmentEnumerator<T>(this.array, this.begin, this.end);
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() =>
+            new ReadOnlySegmentEnumerator<T>(this.array, this.begin, this.end);
+    }
+
+    /// <summary>
+    /// Enumerator for read only arrays and read only array segments.
+    /// </summary>
+    public struct ReadOnlySegmentEnumerator<T> : IEnumerator<T>
+    {
+        /// <summary>
+        /// Underlying read-only array.
+        /// </summary>
+        private readonly ReadOnlyArray<T> array;
+
+        /// <summary>
+        /// Index of the first element which belongs segment begin enumerated.
+        /// </summary>
+        private readonly int begin;
+
+        /// <summary>
+        /// Index of the first element which does not belong segment begin enumerated.
+        /// </summary>
+        private readonly int end;
+
+        /// <summary>
+        /// Index of the current element
+        /// </summary>
+        private int pointer;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ReadOnlyArraySegment{T}"/> structure.
+        /// </summary>
+        public ReadOnlySegmentEnumerator(ReadOnlyArray<T> array, int begin, int end)
+        {
+            this.array = array;
+            this.begin = begin;
+            this.end = end;
+            this.pointer = begin - 1;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+        }
+
+        /// <inheritdoc/>
+        public bool MoveNext()
+        {
+            ++this.pointer;
+            return this.pointer < this.end;
+        }
+
+        /// <inheritdoc/>
+        public T Current => this.array[this.pointer];
+
+        /// <inheritdoc/>
+        object IEnumerator.Current => this.Current;
+
+        /// <inheritdoc/>
+        void IEnumerator.Reset()
+        {
+            this.pointer = this.begin - 1;
+        }
+    }
+}

--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -8,7 +8,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System.Collections.Generic;
     using System.Diagnostics;
 
-    using Microsoft.ML.Probabilistic.Core.Collections;
+    using Microsoft.ML.Probabilistic.Collections;
 
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
     {

--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -421,7 +421,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             #region Helpers
 
             /// <summary>
-            /// 
+            /// Removes all states and transitions from builder returning it to empty state.
             /// </summary>
             public void Clear()
             {
@@ -659,7 +659,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             }
 
             /// <summary>
-            /// Helper struct for 
+            /// Helper struct for iterating over currently constructed list of transitions for state.
+            /// Unlike standard enumerator pattern through this iterator elements can be changed and removed.
             /// </summary>
             /// <remarks>
             /// Implemented as a value type to minimize amount of GC.
@@ -777,8 +778,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             }
 
             /// <summary>
-            /// Wrapper aro
+            /// Linked list node for representing transitions for state.
             /// </summary>
+            /// <remarks>
+            /// Fields are mutable, because they are changed during automaton construction.
+            /// </remarks>
             private struct LinkedTransitionNode
             {
                 /// <summary>

--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -1,0 +1,810 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Distributions.Automata
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+
+    using Microsoft.ML.Probabilistic.Core.Collections;
+
+    public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
+    {
+        /// <summary>
+        /// Helper class which is used to construct new automaton interactively using the builder pattern.
+        /// </summary>
+        public class Builder
+        {
+            /// <summary>
+            /// States created so far.
+            /// </summary>
+            private readonly List<StateData> states;
+
+            /// <summary>
+            /// Transitions created so far.
+            /// </summary>
+            /// <remarks>
+            /// Unlike in <see cref="StateCollection.transitions"/>, transitions
+            /// for single entity are not represented by contiguous segment of array, but rather as a linked
+            /// list. It is done this way, because transitions can be added at any moment and inserting
+            /// transition into a middle of array is not feasible. <see cref="StateData.FirstTransition"/>
+            /// references head of list and <see cref="StateData.LastTransition"/> references last element of list.
+            /// </remarks>
+            private readonly List<LinkedTransitionNode> transitions;
+
+            /// <summary>
+            /// Number of transitions marked as removed. We maintain this count to calculate finaly transitions
+            /// array size without need to traverse all transitions.
+            /// </summary>
+            private int numRemovedTransitions = 0;
+
+            /// <summary>
+            /// Creates a new empty <see cref="Builder"/>.
+            /// </summary>
+            public Builder()
+            {
+                this.states = new List<StateData>();
+                this.transitions = new List<LinkedTransitionNode>();
+            }
+
+            #region Properties
+
+            /// <summary>
+            /// Index of the start state.
+            /// </summary>
+            public int StartStateIndex { get; set; }
+
+            /// <summary>
+            /// Number of states which were created so far.
+            /// </summary>
+            public int StatesCount => this.states.Count;
+
+            /// <summary>
+            /// Number of transitions which were created so far.
+            /// </summary>
+            public int TransitionsCount => this.transitions.Count - this.numRemovedTransitions;
+
+            /// <summary>
+            /// Returns <see cref="StateBuilder"/> object for specified state.
+            /// </summary>
+            public StateBuilder this[int index] => new StateBuilder(this, index);
+
+            /// <summary>
+            /// Returns <see cref="StateBuilder"/> object for start state.
+            /// </summary>
+            public StateBuilder Start => this[this.StartStateIndex];
+
+            #endregion
+
+            # region Factory methods
+
+            /// <summary>
+            /// Factory method which creates <see cref="Builder"/> with single state.
+            /// </summary>
+            public static Builder Zero()
+            {
+                var builder = new Builder();
+                builder.SetToZero();
+                return builder;
+            }
+
+            /// <summary>
+            /// Factory method which creates <see cref="Builder"/> which contains all states and transitions
+            /// from given <paramref name="automaton"/>.
+            /// </summary>
+            public static Builder FromAutomaton(Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> automaton)
+            {
+                var result = new Builder();
+                result.AddStates(automaton.States);
+                result.StartStateIndex = automaton.Start.Index;
+                return result;
+            }
+
+            /// <summary>
+            /// Factory method which creates <see cref="Builder"/> and inserts into it an automaton
+            /// matching given <paramref name="sequence"/> with some <paramref name="weight"/>.
+            /// </summary>
+            public static Builder ConstantOn(Weight weight, TSequence sequence)
+            {
+                var result = Builder.Zero();
+                result.Start.AddTransitionsForSequence(sequence).SetEndWeight(weight);
+                return result;
+            }
+
+            #endregion
+
+            #region States manipulation (AddState and RemoveState methods state family)
+
+            /// <summary>
+            /// Adds new state and returns <see cref="StateBuilder"/> for it.
+            /// </summary>
+            public StateBuilder AddState()
+            {
+                if (this.states.Count >= maxStateCount)
+                {
+                    throw new AutomatonTooLargeException(MaxStateCount);
+                }
+
+                var index = this.states.Count;
+                this.states.Add(
+                    new StateData
+                    {
+                        FirstTransition = -1,
+                        LastTransition = -1,
+                        EndWeight = Weight.Zero,
+                    });
+                return new StateBuilder(this, index);
+            }
+
+            /// <summary>
+            /// Adds <paramref name="count"/> new states/
+            /// </summary>
+            public void AddStates(int count)
+            {
+                for (var i = 0; i < count; ++i)
+                {
+                    AddState();
+                }
+            }
+
+            /// <summary>
+            /// Adds all states and transitions from some <see cref="StateCollection"/>.
+            /// </summary>
+            public void AddStates(StateCollection states)
+            {
+                var oldStateCount = this.states.Count;
+                foreach (var state in states)
+                {
+                    var stateBuilder = this.AddState();
+                    stateBuilder.SetEndWeight(state.EndWeight);
+                    foreach (var transition in state.Transitions)
+                    {
+                        var updatedTransition = transition;
+                        updatedTransition.DestinationStateIndex += oldStateCount;
+                        stateBuilder.AddTransition(updatedTransition);
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Removes state with given <paramref name="stateIndex"/> and all incoming transitions.
+            /// </summary>
+            public void RemoveState(int stateIndex)
+            {
+                // After state is removed, all its transitions will be dead
+                for (var iterator = this[stateIndex].TransitionIterator; iterator.Ok; iterator.Next())
+                {
+                    iterator.Remove();
+                }
+
+                this.states.RemoveAt(stateIndex);
+
+                for (var i = 0; i < this.states.Count; ++i)
+                {
+                    for (var iterator = this[i].TransitionIterator; iterator.Ok; iterator.Next())
+                    {
+                        var transition = iterator.Value;
+                        if (transition.DestinationStateIndex > stateIndex)
+                        {
+                            transition.DestinationStateIndex -= 1;
+                            iterator.Value = transition;
+                        }
+                        else if (transition.DestinationStateIndex == stateIndex)
+                        {
+                            iterator.Remove();
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Removes a set of states from the automaton where the set is defined by labels not matching
+            /// the <paramref name="removeLabel"/>.
+            /// </summary>
+            /// <param name="labels">State labels</param>
+            /// <param name="removeLabel">Label which marks states which should be deleted</param>
+            public int RemoveStates(bool[] labels, bool removeLabel)
+            {
+                var oldToNewStateIdMapping = new int[this.states.Count];
+                var newStateId = 0;
+                var deadStateCount = 0;
+                for (var stateId = 0; stateId < this.states.Count; ++stateId)
+                {
+                    if (labels[stateId] != removeLabel)
+                    {
+                        oldToNewStateIdMapping[stateId] = newStateId++;
+                    }
+                    else
+                    {
+                        oldToNewStateIdMapping[stateId] = -1;
+                        ++deadStateCount;
+                    }
+                }
+
+                this.StartStateIndex = oldToNewStateIdMapping[this.StartStateIndex];
+                if (this.StartStateIndex == -1)
+                {
+                    // Cannot reach any end state from the start state => the automaton is zero everywhere
+                    this.SetToZero();
+                    return deadStateCount;
+                }
+
+                for (var i = 0; i < this.states.Count; ++i)
+                {
+                    var newId = oldToNewStateIdMapping[i];
+                    if (newId == -1)
+                    {
+                        // remove all transitions
+                        for (var iterator = this[i].TransitionIterator; iterator.Ok; iterator.Next())
+                        {
+                            iterator.Remove();
+                        }
+
+                        continue;
+                    }
+
+                    Debug.Assert(newId <= i);
+
+                    this.states[newId] = this.states[i];
+
+                    // Remap transitions
+                    for (var iterator = this[newId].TransitionIterator; iterator.Ok; iterator.Next())
+                    {
+                        var transition = iterator.Value;
+                        transition.DestinationStateIndex = oldToNewStateIdMapping[transition.DestinationStateIndex];
+                        if (transition.DestinationStateIndex == -1)
+                        {
+                            iterator.Remove();
+                        }
+                        else
+                        {
+                            iterator.Value = transition;
+                        }
+                    }
+                }
+
+                this.states.RemoveRange(newStateId, this.states.Count - newStateId);
+
+                return deadStateCount;
+            }
+
+           
+            /// <summary>
+            /// Creates an automaton <c>f'(s) = sum_{tu=s} f(t)g(u)</c>, where <c>f(t)</c> is the current
+            /// automaton (in builder) and <c>g(u)</c> is the given automaton.
+            /// The resulting automaton is also known as the Cauchy product of two automata.
+            /// </summary>
+            public void Append(
+                Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> automaton,
+                int group = 0,
+                bool avoidEpsilonTransitions = true)
+            {
+                var oldStateCount = this.states.Count;
+
+                foreach (var state in automaton.States)
+                {
+                    var stateBuilder = this.AddState();
+                    stateBuilder.SetEndWeight(state.EndWeight);
+                    foreach (var transition in state.Transitions)
+                    {
+                        var updatedTransition = transition;
+                        updatedTransition.DestinationStateIndex += oldStateCount;
+                        if (group != 0)
+                        {
+                            updatedTransition.Group = group;
+                        }
+
+                        stateBuilder.AddTransition(updatedTransition);
+                    }
+                }
+
+                var secondStartState = this[oldStateCount + automaton.Start.Index];
+
+                if (avoidEpsilonTransitions &&
+                    (AllEndStatesHaveNoTransitions() || !automaton.Start.HasIncomingTransitions))
+                {
+                    // Remove start state of appended automaton and copy all its transitions to previous end states
+                    for (var i = 0; i < oldStateCount; ++i)
+                    {
+                        var endState = this[i];
+                        if (!endState.CanEnd)
+                        {
+                            continue;
+                        }
+
+                        for (var iterator = secondStartState.TransitionIterator; iterator.Ok; iterator.Next())
+                        {
+                            var transition = iterator.Value;
+
+                            if (group != 0)
+                            {
+                                transition.Group = group;
+                            }
+
+                            if (transition.DestinationStateIndex == secondStartState.Index)
+                            {
+                                transition.DestinationStateIndex = endState.Index;
+                            }
+                            else
+                            {
+                                transition.Weight = Weight.Product(transition.Weight, endState.EndWeight);
+                            }
+
+                            endState.AddTransition(transition);
+                        }
+
+                        endState.SetEndWeight(Weight.Product(endState.EndWeight, secondStartState.EndWeight));
+                    }
+
+                    this.RemoveState(secondStartState.Index);
+                }
+                else
+                {
+                    // Just connect all end states with start state of appended automaton
+                    for (var i = 0; i < oldStateCount; i++)
+                    {
+                        var state = this[i];
+                        if (state.CanEnd)
+                        {
+                            state.AddEpsilonTransition(state.EndWeight, secondStartState.Index, group);
+                            state.SetEndWeight(Weight.Zero);
+                        }
+                    }
+                }
+
+                bool AllEndStatesHaveNoTransitions()
+                {
+                    for (var i = 0; i < oldStateCount; ++i)
+                    {
+                        var state = this.states[i];
+                        if (state.CanEnd && state.FirstTransition != -1)
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+            }
+
+            #endregion
+
+            #region Result getters
+
+            /// <summary>
+            /// Builds new automaton object.
+            /// </summary>
+            public TThis GetAutomaton() => new TThis() { Data = this.GetData() };
+
+            /// <summary>
+            /// Stores built automaton in pre-allocated <see cref="Automaton{TSequence,TElement,TElementDistribution,TSequenceManipulator,TThis}"/> object.
+            /// </summary>
+            public DataContainer GetData()
+            {
+                if (this.StartStateIndex < 0 || this.StartStateIndex >= this.states.Count)
+                {
+                    throw new InvalidOperationException(
+                        $"Built automaton must have a valid start state. StartStateIndex = {this.StartStateIndex}, states.Count = {this.states.Count}");
+                }
+
+                var hasEpsilonTransitions = false;
+                var resultStates = new StateData[this.states.Count];
+                var resultTransitions = new Transition[this.transitions.Count - this.numRemovedTransitions];
+                var nextResultTransitionIndex = 0;
+
+                for (var i = 0; i < resultStates.Length; ++i)
+                {
+                    var state = this.states[i];
+                    var transitionIndex = state.FirstTransition;
+                    state.FirstTransition = nextResultTransitionIndex;
+                    while (transitionIndex != -1)
+                    {
+                        var node = this.transitions[transitionIndex];
+                        var transition = node.Transition;
+                        Debug.Assert(
+                            transition.DestinationStateIndex < resultStates.Length,
+                            "Destination indexes must be in valid range");
+                        resultTransitions[nextResultTransitionIndex] = transition;
+                        ++nextResultTransitionIndex;
+                        hasEpsilonTransitions = hasEpsilonTransitions || transition.IsEpsilon;
+
+                        transitionIndex = node.Next;
+                    }
+
+                    state.LastTransition = nextResultTransitionIndex;
+                    resultStates[i] = state;
+                }
+
+                Debug.Assert(
+                    nextResultTransitionIndex == resultTransitions.Length,
+                    "number of copied transitions must match result array size");
+
+                return new DataContainer(this.StartStateIndex, !hasEpsilonTransitions, resultStates, resultTransitions);
+            }
+
+            #endregion
+
+            #region Helpers
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public void SetToZero()
+            {
+                this.states.Clear();
+                this.transitions.Clear();
+                this.numRemovedTransitions = 0;
+                this.StartStateIndex = 0;
+                this.AddState();
+            }
+
+            #endregion
+
+            /// <summary>
+            /// Builder struct for a state
+            /// </summary>
+            /// <remarks>
+            /// Implemented as value type to minimize gc.
+            /// </remarks>
+            public struct StateBuilder
+            {
+                /// <summary>
+                /// Builder for whole automaton.
+                /// </summary>
+                private readonly Builder builder;
+
+                /// <summary>
+                /// Index of current state.
+                /// </summary>
+                public int Index { get; }
+
+                /// <summary>
+                /// Gets a value indicating whether the ending weight of this state is greater than zero.
+                /// </summary>
+                public bool CanEnd => this.builder.states[this.Index].CanEnd;
+
+                /// <summary>
+                /// Gets or sets the ending weight of the state.
+                /// </summary>
+                public Weight EndWeight => this.builder.states[this.Index].EndWeight;
+
+                /// <summary>
+                /// Gets a value indicating whether this state is a start state for any transitions.
+                /// </summary>
+                public bool HasTransitions => this.builder[this.Index].TransitionIterator.Ok;
+
+                /// <summary>
+                /// Gets <see cref="TransitionIterator"/> over transitions of this state.
+                /// </summary>
+                public TransitionIterator TransitionIterator =>
+                    new TransitionIterator(this.builder, this.Index, this.builder.states[this.Index].FirstTransition);
+
+                /// <summary>
+                /// Initializes a new instance of <see cref="StateBuilder"/> struct.
+                /// </summary>
+                internal StateBuilder(Builder builder, int index)
+                {
+                    this.builder = builder;
+                    this.Index = index;
+                }
+
+                /// <summary>
+                /// Sets a new end weight for this state.
+                /// </summary>
+                public void SetEndWeight(Weight weight)
+                {
+                    var state = this.builder.states[this.Index];
+                    state.EndWeight = weight;
+                    this.builder.states[this.Index] = state;
+                }
+
+                #region AddTransition variants
+
+                /// <summary>
+                /// Adds a transition to the current state.
+                /// </summary>
+                /// <remarks>
+                /// Transitions are stored in linked list over an array. This function updates this linked
+                /// list and pointers into it. It involves a lot of bookkeeping.
+                /// </remarks>
+                public StateBuilder AddTransition(Transition transition)
+                {
+                    var state = this.builder.states[this.Index];
+                    var transitionIndex = this.builder.transitions.Count;
+                    this.builder.transitions.Add(
+                        new LinkedTransitionNode
+                        {
+                            Transition = transition,
+                            Next = -1,
+                            Prev = state.LastTransition,
+                        });
+
+                    if (state.LastTransition != -1)
+                    {
+                        // update "next" field in old tail
+                        var oldTail = this.builder.transitions[state.LastTransition];
+                        oldTail.Next = transitionIndex;
+                        this.builder.transitions[state.LastTransition] = oldTail;
+                    }
+                    else
+                    {
+                        state.FirstTransition = transitionIndex;
+                    }
+
+                    state.LastTransition = transitionIndex;
+                    this.builder.states[this.Index] = state;
+
+                    
+                    return new StateBuilder(this.builder, transition.DestinationStateIndex);
+                }
+
+                /// <summary>
+                /// Adds a transition to the current state.
+                /// </summary>
+                /// <param name="elementDistribution">
+                /// The element distribution associated with the transition.
+                /// If the value of this parameter is <see langword="null"/>, an epsilon transition will be created.
+                /// </param>
+                /// <param name="weight">The transition weight.</param>
+                /// <param name="destinationStateIndex">
+                /// The destination state of the added transition.
+                /// If the value of this parameter is <see langword="null"/>, a new state will be created.</param>
+                /// <param name="group">The group of the added transition.</param>
+                /// <returns>The destination state of the added transition.</returns>
+                public StateBuilder AddTransition(
+                    Option<TElementDistribution> elementDistribution,
+                    Weight weight,
+                    int? destinationStateIndex = null,
+                    int group = 0)
+                {
+                    if (destinationStateIndex == null)
+                    {
+                        destinationStateIndex = this.builder.AddState().Index;
+                    }
+
+                    return this.AddTransition(
+                        new Transition(elementDistribution, weight, destinationStateIndex.Value, group));
+                }
+
+                /// <summary>
+                /// Adds a transition labeled with a given element to the current state.
+                /// </summary>
+                /// <param name="element">The element.</param>
+                /// <param name="weight">The transition weight.</param>
+                /// <param name="destinationStateIndex">
+                /// The destination state of the added transition.
+                /// If the value of this parameter is <see langword="null"/>, a new state will be created.</param>
+                /// <param name="group">The group of the added transition.</param>
+                /// <returns>The destination state of the added transition.</returns>
+                public StateBuilder AddTransition(
+                    TElement element,
+                    Weight weight,
+                    int? destinationStateIndex = null,
+                    int group = 0)
+                {
+                    return this.AddTransition(
+                        new TElementDistribution {Point = element}, weight, destinationStateIndex, group);
+                }
+
+                /// <summary>
+                /// Adds an epsilon transition to the current state.
+                /// </summary>
+                /// <param name="weight">The transition weight.</param>
+                /// <param name="destinationStateIndex">
+                /// The destination state of the added transition.
+                /// If the value of this parameter is <see langword="null"/>, a new state will be created.</param>
+                /// <param name="group">The group of the added transition.</param>
+                /// <returns>The destination state of the added transition.</returns>
+                public StateBuilder AddEpsilonTransition(
+                    Weight weight, int? destinationStateIndex = null, int group = 0)
+                {
+                    return this.AddTransition(Option.None, weight, destinationStateIndex, group);
+                }
+
+                /// <summary>
+                /// Adds a self-transition labeled with a given element to the current state.
+                /// </summary>
+                /// <param name="element">The element.</param>
+                /// <param name="weight">The transition weight.</param>
+                /// <param name="group">The group of the added transition.</param>
+                /// <returns>The current state.</returns>
+                public StateBuilder AddSelfTransition(TElement element, Weight weight, int group = 0)
+                {
+                    return this.AddTransition(element, weight, this.Index, group);
+                }
+
+                /// <summary>
+                /// Adds a self-transition to the current state.
+                /// </summary>
+                /// <param name="elementDistribution">
+                /// The element distribution associated with the transition.
+                /// If the value of this parameter is <see langword="null"/>, an epsilon transition will be created.
+                /// </param>
+                /// <param name="weight">The transition weight.</param>
+                /// <param name="group">The group of the added transition.</param>
+                /// <returns>The current state.</returns>
+                public StateBuilder AddSelfTransition(
+                    Option<TElementDistribution> elementDistribution, Weight weight, byte group = 0)
+                {
+                    return this.AddTransition(elementDistribution, weight, this.Index, group);
+                }
+
+
+                /// <summary>
+                /// Adds a series of transitions labeled with the elements of a given sequence to the current state,
+                /// as well as the intermediate states. All the added transitions have unit weight.
+                /// </summary>
+                /// <param name="sequence">The sequence.</param>
+                /// <param name="destinationStateIndex">
+                /// The last state in the transition series.
+                /// If the value of this parameter is <see langword="null"/>, a new state will be created.
+                /// </param>
+                /// <param name="group">The group of the added transitions.</param>
+                /// <returns>The last state in the added transition series.</returns>
+                public StateBuilder AddTransitionsForSequence(
+                    TSequence sequence,
+                    int? destinationStateIndex = null,
+                    int group = 0)
+                {
+                    var currentState = this;
+                    using (var enumerator = sequence.GetEnumerator())
+                    {
+                        var moveNext = enumerator.MoveNext();
+                        while (moveNext)
+                        {
+                            var element = enumerator.Current;
+                            moveNext = enumerator.MoveNext();
+                            currentState = currentState.AddTransition(
+                                element, Weight.One, moveNext ? null : destinationStateIndex, group);
+                        }
+                    }
+
+                    return currentState;
+                }
+
+                #endregion
+            }
+
+            /// <summary>
+            /// Helper struct for 
+            /// </summary>
+            /// <remarks>
+            /// Implemented as a value type to minimize amount of GC.
+            /// </remarks>
+            /// <remarks>
+            /// Implementation does not follow common due to three reasons.
+            /// - Items are mutable through this iterator (unlike enumerators)
+            /// - Implementation-wise initializing iterator in "valid" state is easier than in the one which
+            ///   requires MoveNext() call
+            /// - Iterator with this interface can conveniently be used in a for-loop unlike traditional
+            ///   enumerators which will require 3 lines in a while-loop
+            /// </remarks>
+            public struct TransitionIterator
+            {
+                /// <summary>
+                /// Automaton builder which contains transitions array.
+                /// </summary>
+                private readonly Builder builder;
+
+                /// <summary>
+                /// Index of state to which this transition belongs.
+                /// </summary>
+                private int stateIndex;
+
+                /// <summary>
+                /// Index of current transition in this.builder.transitions array.
+                /// </summary>
+                private int index;
+
+                /// <summary>
+                /// Initializes new instance of <see cref="TransitionIterator"/> struct.
+                /// </summary>
+                public TransitionIterator(Builder builder, int stateIndex, int index)
+                {
+                    this.builder = builder;
+                    this.stateIndex = stateIndex;
+                    this.index = index;
+                }
+
+                /// <summary>
+                /// Gets or sets current transition value.
+                /// </summary>
+                public Transition Value
+                {
+                    get => this.builder.transitions[this.index].Transition;
+                    set
+                    {
+                        var node = this.builder.transitions[this.index];
+                        node.Transition = value;
+                        this.builder.transitions[this.index] = node;
+                    }
+                }
+
+                /// <summary>
+                /// Marks current transition as removed. This transition will not be visible during further
+                /// iterations.
+                /// </summary>
+                /// <remarks>
+                /// <see cref="Remove()"/> can be called only once until <see cref="Next()"/> call.
+                /// </remarks>
+                public void Remove()
+                {
+                    var state = this.builder.states[this.stateIndex];
+                    var node = this.builder.transitions[this.index];
+
+                    // unlink from previous node
+                    if (node.Prev != -1)
+                    {
+                        var prevNode = builder.transitions[node.Prev];
+                        prevNode.Next = node.Next;
+                        builder.transitions[node.Prev] = prevNode;
+                    }
+
+                    // unlink from next node
+                    if (node.Next != -1)
+                    {
+                        var nextNode = builder.transitions[node.Next];
+                        nextNode.Prev = node.Prev;
+                        builder.transitions[node.Next] = nextNode;
+                    }
+
+                    // update references in state
+                    if (state.FirstTransition == this.index || state.LastTransition == this.index)
+                    {
+                        if (state.FirstTransition == this.index)
+                        {
+                            state.FirstTransition = node.Next;
+                        }
+
+                        if (state.LastTransition == this.index)
+                        {
+                            state.LastTransition = node.Prev;
+                        }
+
+                        this.builder.states[this.stateIndex] = state;
+                    }
+
+                    ++this.builder.numRemovedTransitions;
+                }
+
+                /// <summary>
+                /// Gets a value indicating whether iterator is dereferenceable - its Value can be get or set.
+                /// Once iteration is finished property will become false.
+                /// </summary>
+                public bool Ok => this.index != -1;
+
+                /// <summary>
+                /// Moves iterator to next transition in list.
+                /// </summary>
+                public void Next()
+                {
+                    this.index = this.builder.transitions[this.index].Next;
+                }
+
+            }
+
+            /// <summary>
+            /// Wrapper aro
+            /// </summary>
+            private struct LinkedTransitionNode
+            {
+                /// <summary>
+                /// Stored transition.
+                /// </summary>
+                public Transition Transition;
+
+                /// <summary>
+                /// Index of next transition in list.
+                /// </summary>
+                public int Next;
+
+                /// <summary>
+                /// Index of previous transition in list.
+                /// </summary>
+                public int Prev;
+            }
+        }
+    }
+}

--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -43,10 +43,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// Creates a new empty <see cref="Builder"/>.
             /// </summary>
-            public Builder()
+            public Builder(int startStateCount = 1)
             {
                 this.states = new List<StateData>();
                 this.transitions = new List<LinkedTransitionNode>();
+                this.AddStates(startStateCount);
             }
 
             #region Properties
@@ -81,22 +82,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             # region Factory methods
 
             /// <summary>
-            /// Factory method which creates <see cref="Builder"/> with single state.
-            /// </summary>
-            public static Builder Zero()
-            {
-                var builder = new Builder();
-                builder.SetToZero();
-                return builder;
-            }
-
-            /// <summary>
             /// Factory method which creates <see cref="Builder"/> which contains all states and transitions
             /// from given <paramref name="automaton"/>.
             /// </summary>
             public static Builder FromAutomaton(Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> automaton)
             {
-                var result = new Builder();
+                var result = new Builder(0);
                 result.AddStates(automaton.States);
                 result.StartStateIndex = automaton.Start.Index;
                 return result;
@@ -108,7 +99,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// </summary>
             public static Builder ConstantOn(Weight weight, TSequence sequence)
             {
-                var result = Builder.Zero();
+                var result = new Builder();
                 result.Start.AddTransitionsForSequence(sequence).SetEndWeight(weight);
                 return result;
             }
@@ -227,7 +218,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 if (this.StartStateIndex == -1)
                 {
                     // Cannot reach any end state from the start state => the automaton is zero everywhere
-                    this.SetToZero();
+                    this.Clear();
+                    this.AddState();
                     return deadStateCount;
                 }
 
@@ -431,13 +423,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// 
             /// </summary>
-            public void SetToZero()
+            public void Clear()
             {
                 this.states.Clear();
                 this.transitions.Clear();
                 this.numRemovedTransitions = 0;
                 this.StartStateIndex = 0;
-                this.AddState();
             }
 
             #endregion

--- a/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
@@ -35,7 +35,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             public readonly ReadOnlyArray<StateData> States;
 
             /// <summary>
-            /// All automaton transitions. Transitions for the same state are organizes
+            /// All automaton transitions. Transitions for the same state are stored as a contiguous block
+            /// inside this array.
             /// </summary>
             public readonly ReadOnlyArray<Transition> Transitions;
 

--- a/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
@@ -1,0 +1,126 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Probabilistic.Serialization;
+
+namespace Microsoft.ML.Probabilistic.Distributions.Automata
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    using Microsoft.ML.Probabilistic.Core.Collections;
+
+    public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
+    {
+        /// <summary>
+        /// Immutable container for automaton data - states and transitions.
+        /// </summary>
+        public struct DataContainer : ISerializable
+        {
+            /// <summary>
+            /// Index of start state of automaton.
+            /// </summary>
+            public readonly int StartStateIndex;
+
+            /// <summary>
+            /// Value indicating whether this automaton is epsilon-free.
+            /// </summary>
+            public readonly bool IsEpsilonFree;
+
+            /// <summary>
+            /// All automaton states.
+            /// </summary>
+            public readonly ReadOnlyArray<StateData> States;
+
+            /// <summary>
+            /// All automaton transitions. Transitions for the same state are organizes
+            /// </summary>
+            public readonly ReadOnlyArray<Transition> Transitions;
+
+            /// <summary>
+            /// Initializes instance of <see cref="DataContainer"/>.
+            /// </summary>
+            [Construction("StartStateIndex", "IsEpsilonFree", "States", "Transitions")]
+            public DataContainer(
+                int startStateIndex,
+                bool isEpsilonFree,
+                ReadOnlyArray<StateData> states,
+                ReadOnlyArray<Transition> transitions)
+            {
+                this.StartStateIndex = startStateIndex;
+                this.IsEpsilonFree = isEpsilonFree;
+                this.States = states;
+                this.Transitions = transitions;
+            }
+
+            /// <summary>
+            /// Returns true if indices assigned to given states and their transitions are consistent with each other.
+            /// </summary>
+            public bool IsConsistent()
+            {
+                if (this.StartStateIndex < 0 || this.StartStateIndex >= this.States.Count)
+                {
+                    return false;
+                }
+
+                var isEpsilonFree = true;
+
+                foreach (var state in this.States)
+                {
+                    if (state.FirstTransition < 0 || state.LastTransition > this.Transitions.Count)
+                    {
+                        return false;
+                    }
+
+                    for (var i = state.FirstTransition; i < state.LastTransition; ++i)
+                    {
+                        var transition = this.Transitions[i];
+                        if (transition.DestinationStateIndex < 0 ||
+                            transition.DestinationStateIndex >= this.States.Count)
+                        {
+                            return false;
+                        }
+
+                        if (transition.IsEpsilon)
+                        {
+                            isEpsilonFree = false;
+                        }
+                    }
+                }
+
+                return this.IsEpsilonFree == isEpsilonFree;
+            }
+
+            #region Serialization
+
+            /// <summary>
+            /// Constructor used by Json and BinaryFormatter serializers. Informally needed to be
+            /// implemented for <see cref="ISerializable"/> interface.
+            /// </summary>
+            internal DataContainer(SerializationInfo info, StreamingContext context)
+            {
+                this.StartStateIndex = (int)info.GetValue(nameof(this.StartStateIndex), typeof(int));
+                this.IsEpsilonFree = (bool)info.GetValue(nameof(this.IsEpsilonFree), typeof(bool));
+                this.States = (StateData[])info.GetValue(nameof(this.States), typeof(StateData[]));
+                this.Transitions = (Transition[])info.GetValue(nameof(this.Transitions), typeof(Transition[]));
+
+                if (!IsConsistent())
+                {
+                    throw new Exception("Deserialized automaton is inconsistent!");
+                }
+            }
+
+            /// <inheritdoc/>
+            void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+                info.AddValue(nameof(this.States), this.States.CloneArray());
+                info.AddValue(nameof(this.Transitions), this.Transitions.CloneArray());
+                info.AddValue(nameof(this.StartStateIndex), this.StartStateIndex);
+                info.AddValue(nameof(this.IsEpsilonFree), this.IsEpsilonFree);
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System;
     using System.Runtime.Serialization;
 
-    using Microsoft.ML.Probabilistic.Core.Collections;
+    using Microsoft.ML.Probabilistic.Collections;
 
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
     {

--- a/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
@@ -16,6 +16,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <summary>
         /// Immutable container for automaton data - states and transitions.
         /// </summary>
+        [Serializable]
         public struct DataContainer : ISerializable
         {
             /// <summary>

--- a/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             // Such pairs correspond to states of the resulting automaton.
             var weightedStateSetQueue = new Queue<Determinization.WeightedStateSet>();
             var weightedStateSetToNewState = new Dictionary<Determinization.WeightedStateSet, int>();
-            var builder = Builder.Zero();
+            var builder = new Builder();
 
             var startWeightedStateSet = new Determinization.WeightedStateSet { { this.Start.Index, Weight.One } };
             weightedStateSetQueue.Enqueue(startWeightedStateSet);

--- a/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
@@ -1,0 +1,319 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Distributions.Automata
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    using Microsoft.ML.Probabilistic.Utilities;
+
+    /// <content>
+    /// Contains classes and methods for automata simplification.
+    /// </content>
+    public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
+    {
+        /// <summary>
+        /// Attempts to determinize the automaton,
+        /// i.e. modify it such that for every state and every element there is at most one transition that allows for that element,
+        /// and there are no epsilon transitions.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if the determinization attempt was successful and the automaton is now deterministic,
+        /// <see langword="false"/> otherwise.
+        /// </returns>
+        /// <remarks>See <a href="http://www.cs.nyu.edu/~mohri/pub/hwa.pdf"/> for algorithm details.</remarks>
+        public bool TryDeterminize()
+        {
+            // We'd like to break if the determinized automaton is much larger than the original one,
+            // or the original automaton is not determinizable at all.
+            int maxStatesBeforeStop = Math.Min(this.States.Count * 3, MaxStateCount);
+            return this.TryDeterminize(maxStatesBeforeStop);
+        }
+
+        /// <summary>
+        /// Attempts to determinize the automaton,
+        /// i.e. modify it such that for every state and every element there is at most one transition that allows for that element,
+        /// and there are no epsilon transitions.
+        /// </summary>
+        /// <param name="maxStatesBeforeStop">
+        /// The maximum number of states the resulting automaton can have. If the number of states exceeds the value
+        /// of this parameter during determinization, the process is aborted.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the determinization attempt was successful and the automaton is now deterministic,
+        /// <see langword="false"/> otherwise.
+        /// </returns>
+        /// <remarks>See <a href="http://www.cs.nyu.edu/~mohri/pub/hwa.pdf"/> for algorithm details.</remarks>
+        public bool TryDeterminize(int maxStatesBeforeStop)
+        {
+            Argument.CheckIfInRange(
+                maxStatesBeforeStop > 0 && maxStatesBeforeStop <= MaxStateCount,
+                "maxStatesBeforeStop",
+                "The maximum number of states must be positive and not greater than the maximum number of states allowed in an automaton.");
+
+            this.MakeEpsilonFree(); // Deterministic automata cannot have epsilon-transitions
+
+            if (this.UsesGroups())
+            {
+                // Determinization will result in lost of group information, which we cannot allow
+                return false;
+            }
+
+            // Weighted state set is a set of (stateId, weight) pairs, where state ids correspond to states of the original automaton..
+            // Such pairs correspond to states of the resulting automaton.
+            var weightedStateSetQueue = new Queue<Determinization.WeightedStateSet>();
+            var weightedStateSetToNewState = new Dictionary<Determinization.WeightedStateSet, int>();
+            var builder = Builder.Zero();
+
+            var startWeightedStateSet = new Determinization.WeightedStateSet { { this.Start.Index, Weight.One } };
+            weightedStateSetQueue.Enqueue(startWeightedStateSet);
+            weightedStateSetToNewState.Add(startWeightedStateSet, builder.StartStateIndex);
+            builder.Start.SetEndWeight(this.Start.EndWeight);
+
+            while (weightedStateSetQueue.Count > 0)
+            {
+                // Take one unprocessed state of the resulting automaton
+                Determinization.WeightedStateSet currentWeightedStateSet = weightedStateSetQueue.Dequeue();
+                var currentStateIndex = weightedStateSetToNewState[currentWeightedStateSet];
+                var currentState = builder[currentStateIndex];
+
+                // Find out what transitions we should add for this state
+                var outgoingTransitionInfos = this.GetOutgoingTransitionsForDeterminization(currentWeightedStateSet);
+
+                // For each transition to add
+                foreach ((TElementDistribution, Weight, Determinization.WeightedStateSet) outgoingTransitionInfo in outgoingTransitionInfos)
+                {
+                    TElementDistribution elementDistribution = outgoingTransitionInfo.Item1;
+                    Weight weight = outgoingTransitionInfo.Item2;
+                    Determinization.WeightedStateSet destWeightedStateSet = outgoingTransitionInfo.Item3;
+
+                    int destinationStateIndex;
+                    if (!weightedStateSetToNewState.TryGetValue(destWeightedStateSet, out destinationStateIndex))
+                    {
+                        if (builder.StatesCount == maxStatesBeforeStop)
+                        {
+                            // Too many states, determinization attempt failed
+                            return false;
+                        }
+
+                        // Add new state to the result
+                        var destinationState = builder.AddState();
+                        weightedStateSetToNewState.Add(destWeightedStateSet, destinationState.Index);
+                        weightedStateSetQueue.Enqueue(destWeightedStateSet);
+
+                        // Compute its ending weight
+                        destinationState.SetEndWeight(Weight.Zero);
+                        foreach (KeyValuePair<int, Weight> stateIdWithWeight in destWeightedStateSet)
+                        {
+                            destinationState.SetEndWeight(Weight.Sum(
+                                destinationState.EndWeight,
+                                Weight.Product(stateIdWithWeight.Value, this.States[stateIdWithWeight.Key].EndWeight)));
+                        }
+
+                        destinationStateIndex = destinationState.Index;
+                    }
+
+                    // Add transition to the destination state
+                    currentState.AddTransition(elementDistribution, weight, destinationStateIndex);
+                }
+            }
+
+            var simplification = new Simplification(builder, this.PruneTransitionsWithLogWeightLessThan);
+            simplification.MergeParallelTransitions(); // Determinization produces a separate transition for each segment
+
+            var result = builder.GetAutomaton();
+            result.PruneTransitionsWithLogWeightLessThan = this.PruneTransitionsWithLogWeightLessThan;
+            result.LogValueOverride = this.LogValueOverride;
+            this.SwapWith(result);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Overridden in the derived classes to compute a set of outgoing transitions
+        /// from a given state of the determinization result.
+        /// </summary>
+        /// <param name="sourceState">The source state of the determinized automaton represented as 
+        /// a set of (stateId, weight) pairs, where state ids correspond to states of the original automaton.</param>
+        /// <returns>
+        /// A collection of (element distribution, weight, weighted state set) triples corresponding to outgoing transitions from <paramref name="sourceState"/>.
+        /// The first two elements of a tuple define the element distribution and the weight of a transition.
+        /// The third element defines the outgoing state.
+        /// </returns>
+        protected abstract List<(TElementDistribution, Weight, Determinization.WeightedStateSet)> GetOutgoingTransitionsForDeterminization(
+            Determinization.WeightedStateSet sourceState);
+
+        
+        /// <summary>
+        /// Groups together helper classes used for automata determinization.
+        /// </summary>
+        protected static class Determinization
+        {
+            /// <summary>
+            /// Represents a state of the resulting automaton in the power set construction.
+            /// It is essentially a set of (stateId, weight) pairs of the source automaton, where each state id is unique.
+            /// Supports a quick lookup of the weight by state id.
+            /// </summary>
+            public class WeightedStateSet : IEnumerable<KeyValuePair<int, Weight>>
+            {
+                /// <summary>
+                /// A mapping from state ids to weights.
+                /// </summary>
+                private readonly Dictionary<int, Weight> stateIdToWeight;
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="WeightedStateSet"/> class.
+                /// </summary>
+                public WeightedStateSet() =>
+                    this.stateIdToWeight = new Dictionary<int, Weight>();
+                
+                /// <summary>
+                /// Initializes a new instance of the <see cref="WeightedStateSet"/> class.
+                /// </summary>
+                /// <param name="stateIdToWeight">A collection of (stateId, weight) pairs.
+                /// </param>
+                public WeightedStateSet(IEnumerable<KeyValuePair<int, Weight>> stateIdToWeight) =>
+                    this.stateIdToWeight = stateIdToWeight.ToDictionary(kv => kv.Key, kv => kv.Value);
+
+                /// <summary>
+                /// Gets or sets the weight for a given state id.
+                /// </summary>
+                /// <param name="stateId">The state id.</param>
+                /// <returns>The weight.</returns>
+                public Weight this[int stateId]
+                {
+                    get => this.stateIdToWeight[stateId];
+                    set => this.stateIdToWeight[stateId] = value;
+                }
+
+                /// <summary>
+                /// Adds a given state id and a weight to the set.
+                /// </summary>
+                /// <param name="stateId">The state id.</param>
+                /// <param name="weight">The weight.</param>
+                public void Add(int stateId, Weight weight) =>
+                    this.stateIdToWeight.Add(stateId, weight);
+
+                /// <summary>
+                /// Attempts to retrieve the weight corresponding to a given state id from the set.
+                /// </summary>
+                /// <param name="stateId">The state id.</param>
+                /// <param name="weight">When the method returns, contains the retrieved weight.</param>
+                /// <returns>
+                /// <see langword="true"/> if the given state id was present in the set,
+                /// <see langword="false"/> otherwise.
+                /// </returns>
+                public bool TryGetWeight(int stateId, out Weight weight) =>
+                    this.stateIdToWeight.TryGetValue(stateId, out weight);
+
+                /// <summary>
+                /// Checks whether the state with a given id is present in the set.
+                /// </summary>
+                /// <param name="stateId">The state id,</param>
+                /// <returns>
+                /// <see langword="true"/> if the given state id was present in the set,
+                /// <see langword="false"/> otherwise.
+                /// </returns>
+                public bool ContainsState(int stateId) =>
+                    this.stateIdToWeight.ContainsKey(stateId);
+
+                /// <summary>
+                /// Checks whether this object is equal to a given one.
+                /// </summary>
+                /// <param name="obj">The object to compare this object with.</param>
+                /// <returns>
+                /// <see langword="true"/> if the objects are equal,
+                /// <see langword="false"/> otherwise.
+                /// </returns>
+                public override bool Equals(object obj)
+                {
+                    if (obj == null || obj.GetType() != typeof(WeightedStateSet))
+                    {
+                        return false;
+                    }
+
+                    var other = (WeightedStateSet)obj;
+
+                    if (this.stateIdToWeight.Count != other.stateIdToWeight.Count)
+                    {
+                        return false;
+                    }
+
+                    foreach (KeyValuePair<int, Weight> pair in this.stateIdToWeight)
+                    {
+                        // TODO: Should we allow for some tolerance? But what about hashing then?
+                        Weight otherWeight;
+                        if (!other.stateIdToWeight.TryGetValue(pair.Key, out otherWeight) || otherWeight != pair.Value)
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+
+                /// <summary>
+                /// Computes the hash code of this instance.
+                /// </summary>
+                /// <returns>The computed hash code.</returns>
+                public override int GetHashCode()
+                {
+                    int result = 0;
+                    foreach (KeyValuePair<int, Weight> pair in this.stateIdToWeight)
+                    {
+                        int pairHash = Hash.Start;
+                        pairHash = Hash.Combine(pairHash, pair.Key.GetHashCode());
+                        pairHash = Hash.Combine(pairHash, pair.Value.GetHashCode());
+
+                        // Use commutative hashing combination because dictionaries are not ordered
+                        result ^= pairHash;
+                    }
+
+                    return result;
+                }
+
+                /// <summary>
+                /// Returns a string representation of the instance.
+                /// </summary>
+                /// <returns>A string representation of the instance.</returns>
+                public override string ToString()
+                {
+                    StringBuilder builder = new StringBuilder();
+                    foreach (var kvp in this.stateIdToWeight)
+                    {
+                        builder.AppendLine(kvp.ToString());
+                    }
+
+                    return builder.ToString();
+                }
+
+                #region IEnumerable implementation
+
+                /// <summary>
+                /// Gets the enumerator.
+                /// </summary>
+                /// <returns>
+                /// The enumerator.
+                /// </returns>
+                public IEnumerator<KeyValuePair<int, Weight>> GetEnumerator() =>
+                    this.stateIdToWeight.GetEnumerator();
+
+                /// <summary>
+                /// Gets the enumerator.
+                /// </summary>
+                /// <returns>
+                /// The enumerator.
+                /// </returns>
+                IEnumerator IEnumerable.GetEnumerator() =>
+                    this.GetEnumerator();
+
+                #endregion
+            }
+        }
+    }
+}

--- a/src/Runtime/Distributions/Automata/Automaton.EpsilonClosure.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.EpsilonClosure.cs
@@ -2,24 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-
 namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
     using System.Collections.Generic;
     using Microsoft.ML.Probabilistic.Collections;
-    using Microsoft.ML.Probabilistic.Distributions;
-    using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Utilities;
 
     /// <content>
     /// Contains the class used to represent the epsilon closure of a state of an automaton.
     /// </content>
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
-        where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
-        where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
-        where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {
         /// <summary>
         /// Represents the epsilon closure of a state.
@@ -42,14 +34,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <param name="state">The state, which epsilon closure this instance will represent.</param>
             internal EpsilonClosure(State state)
             {
-                Argument.CheckIfValid(!state.IsNull, nameof(state));
-
                 // Optimize for a very common case: a single-node closure
                 bool singleNodeClosure = true;
                 Weight selfLoopWeight = Weight.Zero;
-                for (int i = 0; i < state.TransitionCount; ++i)
+                foreach (var transition in state.Transitions)
                 {
-                    Transition transition = state.GetTransition(i);
                     if (transition.IsEpsilon)
                     {
                         if (transition.DestinationStateIndex != state.Index)
@@ -81,7 +70,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         }
                     }
 
-                    this.EndWeight = condensation.GetWeightToEnd(state);
+                    this.EndWeight = condensation.GetWeightToEnd(state.Index);
                 }
             }
 

--- a/src/Runtime/Distributions/Automata/Automaton.GroupExtractor.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.GroupExtractor.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             {
                 var weightsFromRoot = ComputeWeightsFromRoot(states.Count, topologicalOrder, group);
                 var weightsToEnd = ComputeWeightsToEnd(states.Count, topologicalOrder, group);
-                var subautomaton = Builder.Zero();
+                var subautomaton = new Builder();
                 var stateMapping = subgraph.ToDictionary(x => x, _ => subautomaton.AddState());
                 var hasNoIncomingTransitions = new HashSet<int>(subgraph);
 

--- a/src/Runtime/Distributions/Automata/Automaton.GroupExtractor.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.GroupExtractor.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             {
                 var weightsFromRoot = ComputeWeightsFromRoot(states.Count, topologicalOrder, group);
                 var weightsToEnd = ComputeWeightsToEnd(states.Count, topologicalOrder, group);
-                var subautomaton = new Builder();
+                var subautomaton = Builder.Zero();
                 var stateMapping = subgraph.ToDictionary(x => x, _ => subautomaton.AddState());
                 var hasNoIncomingTransitions = new HashSet<int>(subgraph);
 

--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -2,833 +2,762 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Probabilistic.Collections;
+
 namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
-    using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
     using System.Text;
 
-    using Microsoft.ML.Probabilistic.Collections;
-    using Microsoft.ML.Probabilistic.Distributions;
-    using Microsoft.ML.Probabilistic.Math;
+    using Microsoft.ML.Probabilistic.Core.Collections;
     using Microsoft.ML.Probabilistic.Utilities;
 
     /// <content>
     /// Contains classes and methods for automata simplification.
     /// </content>
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
-        where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
-        where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
-        where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {
-        /// <summary>
-        /// Tests whether the automaton is deterministic,
-        /// i.e. it's epsilon free and for every state and every element there is at most one transition that allows for that element.
-        /// </summary>
-        /// <returns>
-        /// <see langword="true"/> if the automaton is deterministic,
-        /// <see langword="false"/> otherwise.
-        /// </returns>
-        public bool IsDeterministic()
-        {
-            //// We can't track whether the automaton is deterministic while adding/updating transitions
-            //// because element distributions are not immutable.
-            
-            if (!this.IsEpsilonFree)
-            {
-                return false;
-            }
-            
-            for (int stateId = 0; stateId < this.States.Count; ++stateId)
-            {
-                var state = this.States[stateId];
-                
-                // There should be no epsilon transitions
-                for (int transitionIndex = 0; transitionIndex < state.TransitionCount; ++transitionIndex)
-                {
-                    if (state.GetTransition(transitionIndex).IsEpsilon)
-                    {
-                        return false;
-                    }
-                }
-                
-                // Element distributions should not intersect
-                for (int transitionIndex1 = 0; transitionIndex1 < state.TransitionCount; ++transitionIndex1)
-                {
-                    var transition1 = state.GetTransition(transitionIndex1);
-                    for (int transitionIndex2 = transitionIndex1 + 1; transitionIndex2 < state.TransitionCount; ++transitionIndex2)
-                    {
-                        var transition2 = state.GetTransition(transitionIndex2);
-                        double logProductNormalizer = transition1.ElementDistribution.Value.GetLogAverageOf(transition2.ElementDistribution.Value);
-                        if (!double.IsNegativeInfinity(logProductNormalizer))
-                        {
-                            return false;
-                        }
-                    }
-                }
-            }
-
-            return true;
-        }
-        
-        /// <summary>
-        /// Attempts to determinize the automaton,
-        /// i.e. modify it such that for every state and every element there is at most one transition that allows for that element,
-        /// and there are no epsilon transitions.
-        /// </summary>
-        /// <returns>
-        /// <see langword="true"/> if the determinization attempt was successful and the automaton is now deterministic,
-        /// <see langword="false"/> otherwise.
-        /// </returns>
-        /// <remarks>See <a href="http://www.cs.nyu.edu/~mohri/pub/hwa.pdf"/> for algorithm details.</remarks>
-        public bool TryDeterminize()
-        {
-            // We'd like to break if the determinized automaton is much larger than the original one,
-            // or the original automaton is not determinizable at all.
-            int maxStatesBeforeStop = Math.Min(this.States.Count * 3, MaxStateCount);
-            return this.TryDeterminize(maxStatesBeforeStop);
-        }
-
-        /// <summary>
-        /// Attempts to determinize the automaton,
-        /// i.e. modify it such that for every state and every element there is at most one transition that allows for that element,
-        /// and there are no epsilon transitions.
-        /// </summary>
-        /// <param name="maxStatesBeforeStop">
-        /// The maximum number of states the resulting automaton can have. If the number of states exceeds the value
-        /// of this parameter during determinization, the process is aborted.
-        /// </param>
-        /// <returns>
-        /// <see langword="true"/> if the determinization attempt was successful and the automaton is now deterministic,
-        /// <see langword="false"/> otherwise.
-        /// </returns>
-        /// <remarks>See <a href="http://www.cs.nyu.edu/~mohri/pub/hwa.pdf"/> for algorithm details.</remarks>
-        public bool TryDeterminize(int maxStatesBeforeStop)
-        {
-            Argument.CheckIfInRange(
-                maxStatesBeforeStop > 0 && maxStatesBeforeStop <= MaxStateCount,
-                "maxStatesBeforeStop",
-                "The maximum number of states must be positive and not greater than the maximum number of states allowed in an automaton.");
-
-            this.MakeEpsilonFree(); // Deterministic automata cannot have epsilon-transitions
-            ////using (var writer = new System.IO.StreamWriter(@"\GraphViz\graphviz-2.38\release\bin\epsfree.txt"))
-            ////{
-            ////    writer.WriteLine(this.ToString(AutomatonFormats.GraphViz));
-            ////}
-
-            if (this.UsesGroups())
-            {
-                // Determinization will result in lost of group information, which we cannot allow
-                return false;
-            }
-
-            // Weighted state set is a set of (stateId, weight) pairs, where state ids correspond to states of the original automaton..
-            // Such pairs correspond to states of the resulting automaton.
-            var weightedStateSetQueue = new Queue<Determinization.WeightedStateSet>();
-            var weightedStateSetToNewState = new Dictionary<Determinization.WeightedStateSet, State>();
-            var result = Zero();
-
-            var startWeightedStateSet = new Determinization.WeightedStateSet { { this.Start.Index, Weight.One } };
-            weightedStateSetQueue.Enqueue(startWeightedStateSet);
-            weightedStateSetToNewState.Add(startWeightedStateSet, result.Start);
-            result.Start.SetEndWeight(this.Start.EndWeight);
-
-            while (weightedStateSetQueue.Count > 0)
-            {
-                // Take one unprocessed state of the resulting automaton
-                Determinization.WeightedStateSet currentWeightedStateSet = weightedStateSetQueue.Dequeue();
-                var currentState = weightedStateSetToNewState[currentWeightedStateSet];
-
-                // Find out what transitions we should add for this state
-                IEnumerable<Tuple<TElementDistribution, Weight, Determinization.WeightedStateSet>> outgoingTransitionInfos =
-                    this.GetOutgoingTransitionsForDeterminization(currentWeightedStateSet);
-
-                // For each transition to add
-                foreach (Tuple<TElementDistribution, Weight, Determinization.WeightedStateSet> outgoingTransitionInfo in outgoingTransitionInfos)
-                {
-                    TElementDistribution elementDistribution = outgoingTransitionInfo.Item1;
-                    Weight weight = outgoingTransitionInfo.Item2;
-                    Determinization.WeightedStateSet destWeightedStateSet = outgoingTransitionInfo.Item3;
-
-                    if (!weightedStateSetToNewState.TryGetValue(destWeightedStateSet, out State destinationState))
-                    {
-                        if (result.States.Count == maxStatesBeforeStop)
-                        {
-                            // Too many states, determinization attempt failed
-                            return false;
-                        }
-
-                        // Add new state to the result
-                        destinationState = result.AddState();
-                        weightedStateSetToNewState.Add(destWeightedStateSet, destinationState);
-                        weightedStateSetQueue.Enqueue(destWeightedStateSet);
-
-                        // Compute its ending weight
-                        destinationState.SetEndWeight(Weight.Zero);
-                        foreach (KeyValuePair<int, Weight> stateIdWithWeight in destWeightedStateSet)
-                        {
-                            destinationState.SetEndWeight(Weight.Sum(
-                                destinationState.EndWeight,
-                                Weight.Product(stateIdWithWeight.Value, this.States[stateIdWithWeight.Key].EndWeight)));
-                        }
-                    }
-
-                    // Add transition to the destination state
-                    currentState.AddTransition(elementDistribution, weight, destinationState);
-                }
-            }
-
-            ////using (var writer = new System.IO.StreamWriter(@"\GraphViz\graphviz-2.38\release\bin\detpremerge.txt"))
-            ////{
-            ////    writer.WriteLine(result.ToString(AutomatonFormats.GraphViz));
-            ////}
-
-            result.MergeParallelTransitions(); // Determinization produces a separate transition for each segment
-            result.PruneTransitionsWithLogWeightLessThan = this.PruneTransitionsWithLogWeightLessThan;
-            result.LogValueOverride = this.LogValueOverride;
-            // Determinization was successful, we can replace the current automaton with its deterministic version
-            this.SwapWith(result);
-            return true;
-        }
-
-        /// <summary>
-        /// Attempts to simplify the automaton using <see cref="Simplify"/> if the number of states
-        /// exceeds <see cref="MaxStateCountBeforeSimplification"/>.
-        /// </summary>
-        public void SimplifyIfNeeded()
-        {
-            if (this.States.Count > MaxStateCountBeforeSimplification || this.PruneTransitionsWithLogWeightLessThan != null)
-            {
-                ////Console.WriteLine(this.ToString(AutomatonFormats.GraphViz));
-                this.Simplify();
-                ////Console.WriteLine(this.ToString(AutomatonFormats.GraphViz));
-            }
-        }
-
         /// <summary>
         /// Attempts to simplify the structure of the automaton, reducing the number of states and transitions.
         /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The simplification procedure works as follows:
-        /// <list type="number">
-        /// <item><description>
-        /// If a pair of states has more than one transition between them, the transitions get merged.
-        /// </description></item>
-        /// <item><description>
-        /// A part of the automaton that is a tree is found.
-        /// </description></item>
-        /// <item><description>
-        /// States and transitions that don't belong to the found tree part are simply copied to the result.
-        /// </description></item>
-        /// <item><description>
-        /// The found tree part is rebuild from scratch. The new tree is essentially a trie:
-        /// for example, if the original tree has two paths accepting <c>"abc"</c> and one path accepting <c>"ab"</c>,
-        /// the resulting tree has a single path accepting both <c>"ab"</c> and <c>"abc"</c>.
-        /// </description></item>
-        /// </list>
-        /// </para>
-        /// <para>The simplification procedure doesn't support automata with non-trivial loops.</para>
-        /// </remarks>
-        public void Simplify()
+        public bool Simplify()
         {
-            this.MergeParallelTransitions();
-
-            if (this.HasNonTrivialLoops())
+            var builder = Builder.FromAutomaton(this);
+            var simplification = new Simplification(builder, this.PruneTransitionsWithLogWeightLessThan);
+            if (simplification.Simplify())
             {
-                return; // TODO: make this stuff work with non-trivial loops
-            }
-
-            ArrayDictionary<bool> stateLabels = this.LabelStatesForSimplification();
-
-            TThis result = this.CopyNonSimplifiable(stateLabels);
-            int firstNonCopiedStateIndex = result.States.Count;
-
-            IEnumerable<Simplification.WeightedSequence> sequenceToLogWeight = this.BuildAcceptedSequenceList(stateLabels);
-
-            // Before we rebuild the tree part, we prune out the low probability sequences
-            if (this.PruneTransitionsWithLogWeightLessThan != null)
-            {
-                double logNorm = this.GetLogNormalizer();
-                if (!double.IsInfinity(logNorm))
-                {
-                    sequenceToLogWeight = sequenceToLogWeight.Where(
-                        s => s.Weight.LogValue - logNorm >= this.PruneTransitionsWithLogWeightLessThan.Value).ToList();
-                }
-            }
-
-            foreach (Simplification.WeightedSequence weightedSequence in sequenceToLogWeight)
-            {
-                result.AddGeneralizedSequence(firstNonCopiedStateIndex, weightedSequence.Sequence, weightedSequence.Weight);
-            }
-
-            this.SwapWith(result);
-        }
-        
-        /// <summary>
-        /// Optimizes the automaton by removing all states unreachable from the end state.
-        /// </summary>
-        public void RemoveDeadStates()
-        {
-            if (this.IsCanonicZero())
-            {
-                return;
-            }
-            
-            bool[] isEndStateReachable = this.ComputeEndStateReachability();
-            RemoveStates(isEndStateReachable, MaxDeadStateCount);
-        }
-
-        /// <summary>
-        /// Optimizes the automaton by removing all states unreachable from the start state.
-        /// </summary>
-        public void RemoveOrphanStates()
-        {
-            if (this.IsCanonicZero())
-            {
-                return;
-            }
-
-            bool[] isStateReachable = this.ComputeStartStateReachability();
-            RemoveStates(isStateReachable, 0);
-        }
-
-        /// <summary>
-        /// Removes a set of states from the automaton where the set is defined by
-        /// the indices of the false elements in the supplied bool array.
-        /// </summary>
-        /// <param name="statesToKeep">The bool array specifying states to keep</param>
-        /// <param name="minStatesToActuallyRemove">If the number of stats to remove is less than this value, the removal will not be done.</param>
-        private void RemoveStates(bool[] statesToKeep, int minStatesToActuallyRemove)
-        {
-            int[] oldToNewStateIdMapping = new int[this.States.Count];
-            int newStateId = 0;
-            int deadStateCount = 0;
-            for (int stateId = 0; stateId < this.States.Count; ++stateId)
-            {
-                if (statesToKeep[stateId])
-                {
-                    oldToNewStateIdMapping[stateId] = newStateId++;
-                }
-                else
-                {
-                    oldToNewStateIdMapping[stateId] = -1;
-                    ++deadStateCount;
-                }
-            }
-
-            if (oldToNewStateIdMapping[this.Start.Index] == -1)
-            {
-                // Cannot reach any end state from the start state => the automaton is zero everywhere
-                this.SetToZero();
-                return;
-            }
-
-            if (deadStateCount <= minStatesToActuallyRemove)
-            {
-                // Not enough dead states => no additional work needs to be done
-                return;
-            }
-
-            TThis funcWithoutStates = Zero();
-            funcWithoutStates.AddStates(newStateId - 1);
-            funcWithoutStates.Start = funcWithoutStates.States[oldToNewStateIdMapping[this.Start.Index]];
-            funcWithoutStates.LogValueOverride = this.LogValueOverride;
-            funcWithoutStates.PruneTransitionsWithLogWeightLessThan = this.PruneTransitionsWithLogWeightLessThan;
-            for (int i = 0; i < this.States.Count; ++i)
-            {
-                if (oldToNewStateIdMapping[i] == -1)
-                {
-                    continue;
-                }
-
-                State oldState = this.States[i];
-                State newState = funcWithoutStates.States[oldToNewStateIdMapping[i]];
-                newState.SetEndWeight(oldState.EndWeight);
-                for (int transitionIndex = 0; transitionIndex < oldState.TransitionCount; ++transitionIndex)
-                {
-                    Transition transition = oldState.GetTransition(transitionIndex);
-                    int newDestStateId = oldToNewStateIdMapping[transition.DestinationStateIndex];
-                    if (newDestStateId != -1)
-                    {
-                        State newDestState = funcWithoutStates.States[newDestStateId];
-                        newState.AddTransition(transition.ElementDistribution, transition.Weight, newDestState, transition.Group);
-                    }
-                }
-            }
-
-            this.SwapWith(funcWithoutStates);
-        }
-
-        /// <summary>
-        /// Removes transitions in the automaton whose log weight is less than the specified threshold.
-        /// </summary>
-        /// <remarks>
-        /// Any states which are unreachable in the resulting automaton are also removed.
-        /// </remarks>
-        /// <param name="logWeightThreshold">The smallest log weight that a transition can have and not be removed.</param>
-        public void RemoveTransitionsWithSmallWeights(double logWeightThreshold)
-        {
-            foreach (var state in this.States)
-            {
-                for (int i = state.TransitionCount-1; i >=0; i--)
-                {
-                    if (state.GetTransition(i).Weight.LogValue < logWeightThreshold)
-                    {
-                        state.RemoveTransition(i);
-                    }
-                }
-            }
-            RemoveOrphanStates();
-        }
-        
-        /// <summary>
-        /// Overridden in the derived classes to compute a set of outgoing transitions
-        /// from a given state of the determinization result.
-        /// </summary>
-        /// <param name="sourceState">The source state of the determinized automaton represented as 
-        /// a set of (stateId, weight) pairs, where state ids correspond to states of the original automaton.</param>
-        /// <returns>
-        /// A collection of (element distribution, weight, weighted state set) triples corresponding to outgoing transitions from <paramref name="sourceState"/>.
-        /// The first two elements of a tuple define the element distribution and the weight of a transition.
-        /// The third element defines the outgoing state.
-        /// </returns>
-        protected abstract IEnumerable<Tuple<TElementDistribution, Weight, Determinization.WeightedStateSet>> GetOutgoingTransitionsForDeterminization(
-            Determinization.WeightedStateSet sourceState);
-
-        /// <summary>
-        /// Labels each state with a value indicating whether the automaton having that state as the start state is a
-        /// generalized tree (i.e. a tree with self-loops), which is also unreachable from previously traversed states.
-        /// </summary>
-        /// <returns>A dictionary mapping state indices to the computed labels.</returns>
-        private ArrayDictionary<bool> LabelStatesForSimplification()
-        {
-            var result = new ArrayDictionary<bool>();
-            this.DoLabelStatesForSimplification(this.Start, result);
-            return result;
-        }
-
-        /// <summary>
-        /// Recursively labels each state with a value indicating whether the automaton having that state as the start state
-        /// is a generalized tree (i.e. a tree with self-loops), which is also unreachable from previously traversed states.
-        /// </summary>
-        /// <param name="currentState">The currently traversed state.</param>
-        /// <param name="stateLabels">A dictionary mapping state indices to the computed labels.</param>
-        /// <returns>
-        /// <see langword="true"/> if the automaton having <paramref name="currentState"/> having that state as the start state
-        /// is a generalized tree and it was the first visit to it, <see langword="false"/> otherwise.
-        /// </returns>
-        private bool DoLabelStatesForSimplification(State currentState, ArrayDictionary<bool> stateLabels)
-        {
-            if (stateLabels.ContainsKey(currentState.Index))
-            {
-                // This is not the first visit to the state
-                return false;
-            }
-
-            stateLabels.Add(currentState.Index, true);
-
-            bool isGeneralizedTree = true;
-            for (int i = 0; i < currentState.TransitionCount; ++i)
-            {
-                Transition transition = currentState.GetTransition(i);
-
-                // Self-loops are allowed
-                if (transition.DestinationStateIndex != currentState.Index)
-                {
-                    isGeneralizedTree &= this.DoLabelStatesForSimplification(this.States[transition.DestinationStateIndex], stateLabels);
-                }
-            }
-
-            // It was the first visit to the state
-            stateLabels[currentState.Index] = isGeneralizedTree;
-            return isGeneralizedTree;
-        }
-
-        /// <summary>
-        /// Merges outgoing transitions with the same destination state.
-        /// </summary>
-        private void MergeParallelTransitions()
-        {
-            for (int stateIndex = 0; stateIndex < this.States.Count; ++stateIndex)
-            {
-                State state = this.States[stateIndex];
-                for (int transitionIndex1 = 0; transitionIndex1 < state.TransitionCount; ++transitionIndex1)
-                {
-                    Transition transition1 = state.GetTransition(transitionIndex1);
-                    for (int transitionIndex2 = transitionIndex1 + 1; transitionIndex2 < state.TransitionCount; ++transitionIndex2)
-                    {
-                        Transition transition2 = state.GetTransition(transitionIndex2);
-                        if (transition1.DestinationStateIndex == transition2.DestinationStateIndex && transition1.Group == transition2.Group)
-                        {
-                            bool removeTransition2 = false;
-                            if (transition1.IsEpsilon && transition2.IsEpsilon)
-                            {
-                                transition1.Weight = Weight.Sum(transition1.Weight, transition2.Weight);
-                                state.SetTransition(transitionIndex1, transition1);
-                                removeTransition2 = true;
-                            }
-                            else if (!transition1.IsEpsilon && !transition2.IsEpsilon)
-                            {
-                                var newElementDistribution = new TElementDistribution();
-                                if (double.IsInfinity(transition1.Weight.Value) && double.IsInfinity(transition2.Weight.Value))
-                                {
-                                    newElementDistribution.SetToSum(1.0, transition1.ElementDistribution.Value, 1.0, transition2.ElementDistribution.Value);
-                                }
-                                else
-                                {
-                                    newElementDistribution.SetToSum(transition1.Weight.Value, transition1.ElementDistribution.Value, transition2.Weight.Value, transition2.ElementDistribution.Value);
-                                }
-
-                                transition1.ElementDistribution = newElementDistribution;
-                                transition1.Weight = Weight.Sum(transition1.Weight, transition2.Weight);
-                                state.SetTransition(transitionIndex1, transition1);
-                                removeTransition2 = true;
-                            }
-
-                            if (removeTransition2)
-                            {
-                                state.RemoveTransition(transitionIndex2);
-                                --transitionIndex2;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Creates a copy of the non-simplifiable part of the automaton (states labeled with
-        /// <see langword="false"/> by <see cref="LabelStatesForSimplification"/> and their children).
-        /// </summary>
-        /// <param name="stateLabels">The state labels obtained from <see cref="LabelStatesForSimplification"/>.</param>
-        /// <returns>The copied part of the automaton.</returns>
-        private TThis CopyNonSimplifiable(ArrayDictionary<bool> stateLabels)
-        {
-            TThis result = Zero();
-            if (!stateLabels[this.Start.Index])
-            {
-                var copiedStateCache = new ArrayDictionary<State>();
-                result.Start = result.DoCopyNonSimplifiable(this.Start, stateLabels, true, copiedStateCache);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Recursively creates a copy of the non-simplifiable part of the automaton
-        /// (states labeled with <see langword="false"/> by <see cref="LabelStatesForSimplification"/>).
-        /// </summary>
-        /// <param name="stateToCopy">The currently traversed state that needs to be copied.</param>
-        /// <param name="stateLabels">The state labels obtained from <see cref="LabelStatesForSimplification"/>.</param>
-        /// <param name="lookAtLabels">Whether or not labels should be ignored because one of the ancestors was labeled with <see langword="false"/>.</param>
-        /// <param name="copiedStateCache">Cache of the state copies to avoid creating redundant states when traversing diamond-like structures.</param>
-        /// <returns>The copied part of the automaton.</returns>
-        private State DoCopyNonSimplifiable(
-            State stateToCopy, ArrayDictionary<bool> stateLabels, bool lookAtLabels, ArrayDictionary<State> copiedStateCache)
-        {
-            Debug.Assert(!lookAtLabels || !stateLabels[stateToCopy.Index], "States that are not supposed to be copied should not be visited.");
-
-            if (copiedStateCache.TryGetValue(stateToCopy.Index, out State copiedState))
-            {
-                return copiedState;
-            }
-
-            copiedState = this.AddState();
-            copiedState.SetEndWeight(stateToCopy.EndWeight);
-            copiedStateCache.Add(stateToCopy.Index, copiedState);
-
-            for (int i = 0; i < stateToCopy.TransitionCount; ++i)
-            {
-                Transition transitionToCopy = stateToCopy.GetTransition(i);
-                State destStateToCopy = stateToCopy.Owner.States[transitionToCopy.DestinationStateIndex];
-                if (!lookAtLabels || !stateLabels[destStateToCopy.Index])
-                {
-                    State copiedDestState = this.DoCopyNonSimplifiable(destStateToCopy, stateLabels, false, copiedStateCache);
-                    copiedState.AddTransition(transitionToCopy.ElementDistribution, transitionToCopy.Weight, copiedDestState, transitionToCopy.Group);
-                }
-            }
-
-            return copiedState;
-        }
-
-        /// <summary>
-        /// Builds a complete list of generalized sequences accepted by the simplifiable part of the automaton.
-        /// </summary>
-        /// <param name="stateLabels">The state labels obtained from <see cref="LabelStatesForSimplification"/>.</param>
-        /// <returns>The list of generalized sequences accepted by the simplifiable part of the automaton.</returns>
-        private List<Simplification.WeightedSequence> BuildAcceptedSequenceList(ArrayDictionary<bool> stateLabels)
-        {
-            var sequenceToWeight = new List<Simplification.WeightedSequence>();
-            this.DoBuildAcceptedSequenceList(this.Start, stateLabels, sequenceToWeight, new List<Simplification.GeneralizedElement>(), Weight.One);
-            return sequenceToWeight;
-        }
-
-
-        private class StackItem
-        {
-        }
-
-        private class ElementItem : StackItem
-        {
-            public readonly Simplification.GeneralizedElement? Element;
-
-            public ElementItem(Simplification.GeneralizedElement? element)
-            {
-                this.Element = element;
-            }
-            public override string ToString()
-            {
-                return Element.ToString();
-            }
-        }
-
-        private class StateWeight : StackItem
-        {
-            public StateWeight(State state, Weight weight)
-            {
-                this.State = state;
-                this.Weight = weight;
-            }
-
-            public readonly State State;
-            public readonly Weight Weight;
-
-            public override string ToString()
-            {
-                return $"State: {State}, Weight: {Weight}";
-            }
-        }
-
-        /// <summary>
-        /// Recursively builds a complete list of generalized sequences accepted by the simplifiable part of the automaton.
-        /// </summary>
-        /// <param name="state">The currently traversed state.</param>
-        /// <param name="stateLabels">The state labels obtained from <see cref="LabelStatesForSimplification"/>.</param>
-        /// <param name="weightedSequences">The sequence list being built.</param>
-        /// <param name="currentSequenceElements">The list of elements of the sequence currently being built.</param>
-        /// <param name="currentWeight">The weight of the sequence currently being built.</param>
-        private void DoBuildAcceptedSequenceList(
-            State state,
-            ArrayDictionary<bool> stateLabels,
-            List<Simplification.WeightedSequence> weightedSequences,
-            List<Simplification.GeneralizedElement> currentSequenceElements,
-            Weight currentWeight)
-        {
-            var stack = new Stack<StackItem>();
-            stack.Push(new StateWeight(state, currentWeight));
-
-            while (stack.Count > 0)
-            {
-                var stackItem = stack.Pop();
-
-                if (stackItem is ElementItem elementItem)
-                {
-                    if (elementItem.Element != null)
-                        currentSequenceElements.Add(elementItem.Element.Value);
-                    else
-                        currentSequenceElements.RemoveAt(currentSequenceElements.Count - 1);
-                    continue;
-                }
-
-                var stateAndWeight = stackItem as StateWeight;
-
-                state = stateAndWeight.State;
-                currentWeight = stateAndWeight.Weight;
-
-                // Find a non-epsilon self-loop if there is one
-                var selfLoopIndex = -1;
-                for (var i = 0; i < state.TransitionCount; ++i)
-                {
-                    var transition = state.GetTransition(i);
-                    if (transition.DestinationStateIndex != state.Index) continue;
-                    if (selfLoopIndex == -1)
-                    {
-                        selfLoopIndex = i;
-                    }
-                    else
-                    {
-                        Debug.Fail("Multiple self-loops should have been merged by MergeParallelTransitions()");
-                    }
-                }
-
-                // Push the found self-loop to the end of the current sequence
-                if (selfLoopIndex != -1)
-                {
-                    var transition = state.GetTransition(selfLoopIndex);
-                    currentSequenceElements.Add(new Simplification.GeneralizedElement(
-                        transition.ElementDistribution, transition.Group, transition.Weight));
-                    stack.Push(new ElementItem(null));
-                }
-
-                // Can this state produce a sequence?
-                if (state.CanEnd && stateLabels[state.Index])
-                {
-                    var sequence = new Simplification.GeneralizedSequence(currentSequenceElements);
-                        // TODO: use immutable data structure instead of copying sequences
-                    weightedSequences.Add(new Simplification.WeightedSequence(sequence, Weight.Product(currentWeight, state.EndWeight)));
-                }
-
-                // Traverse the outgoing transitions
-                for (var i = 0; i < state.TransitionCount; ++i)
-                {
-                    var transition = state.GetTransition(i);
-
-                    // Skip self-loops & disallowed states
-                    if (transition.DestinationStateIndex == state.Index ||
-                        !stateLabels[transition.DestinationStateIndex])
-                    {
-                        continue;
-                    }
-
-                    if (!transition.IsEpsilon)
-                    {
-                        // Non-epsilon transitions contribute to the sequence
-                        stack.Push(new ElementItem(null));
-                    }
-
-                    stack.Push(
-                        new StateWeight(
-                            States[transition.DestinationStateIndex],
-                            Weight.Product(currentWeight, transition.Weight)));
-
-                    if (!transition.IsEpsilon)
-                    {
-                        stack.Push(
-                            new ElementItem(new Simplification.GeneralizedElement(transition.ElementDistribution,
-                                transition.Group, null)));
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Increases the value of this automaton on <paramref name="sequence"/> by <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="firstAllowedStateIndex">The minimum index of an existing state that can be used for the sequence.</param>
-        /// <param name="sequence">The generalized sequence.</param>
-        /// <param name="weight">The weight of the sequence.</param>
-        /// <remarks>
-        /// This function attempts to add as few new states and transitions as possible.
-        /// Its implementation is conceptually similar to adding string to a trie.
-        /// </remarks>
-        private void AddGeneralizedSequence(int firstAllowedStateIndex, Simplification.GeneralizedSequence sequence, Weight weight)
-        {
-            // First, try to add at start state
-            bool isFreshStartState = this.IsCanonicZero();
-            if (this.DoAddGeneralizedSequence(this.Start, isFreshStartState, false, firstAllowedStateIndex, 0, sequence, weight))
-            {
-                return;
-            }
-
-            // Branch the start state
-            State oldStart = this.Start;
-            this.Start = this.AddState();
-            State otherBranch = this.AddState();
-            this.Start.AddEpsilonTransition(Weight.One, oldStart);
-            this.Start.AddEpsilonTransition(Weight.One, otherBranch);
-
-            // This should always work
-            bool success = this.DoAddGeneralizedSequence(otherBranch, true, false, firstAllowedStateIndex, 0, sequence, weight);
-            Debug.Assert(success, "This call must always succeed.");
-        }
-
-        /// <summary>
-        /// Recursively increases the value of this automaton on <paramref name="sequence"/> by <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="state">The currently traversed state.</param>
-        /// <param name="isNewState">Indicates whether <paramref name="state"/> was just created.</param>
-        /// <param name="selfLoopAlreadyMatched">Indicates whether self-loop on <paramref name="state"/> was just matched.</param>
-        /// <param name="firstAllowedStateIndex">The minimum index of an existing state that can be used for the sequence.</param>
-        /// <param name="currentSequencePos">The current position in the generalized sequence.</param>
-        /// <param name="sequence">The generalized sequence.</param>
-        /// <param name="weight">The weight of the sequence.</param>
-        /// <returns>
-        /// <see langword="true"/> if the subsequence starting at <paramref name="currentSequencePos"/> has been successfully merged in,
-        /// <see langword="false"/> otherwise.
-        /// </returns>
-        /// <remarks>
-        /// This function attempts to add as few new states and transitions as possible.
-        /// Its implementation is conceptually similar to adding string to a trie.
-        /// </remarks>
-        private bool DoAddGeneralizedSequence(
-            State state,
-            bool isNewState,
-            bool selfLoopAlreadyMatched,
-            int firstAllowedStateIndex,
-            int currentSequencePos,
-            Simplification.GeneralizedSequence sequence,
-            Weight weight)
-        {
-            bool success;
-
-            if (currentSequencePos == sequence.Count)
-            {
-                if (!selfLoopAlreadyMatched)
-                {
-                    // We can't finish in a state with a self-loop
-                    for (int i = 0; i < state.TransitionCount; ++i)
-                    {
-                        Transition transition = state.GetTransition(i);
-                        if (transition.DestinationStateIndex == state.Index)
-                        {
-                            return false;
-                        }
-                    }
-                }
-
-                state.SetEndWeight(Weight.Sum(state.EndWeight, weight));
+                this.Data = builder.GetData();
                 return true;
             }
 
-            Simplification.GeneralizedElement element = sequence[currentSequencePos];
+            return false;
+        }
 
-            // Treat self-loops elements separately
-            if (element.LoopWeight.HasValue)
+        /// <summary>
+        /// Optimizes the automaton by removing all states which can't reach end states.
+        /// </summary>
+        public bool RemoveDeadStates()
+        {
+            var builder = Builder.FromAutomaton(this);
+            var simplification = new Simplification(builder, this.PruneTransitionsWithLogWeightLessThan);
+            if (simplification.RemoveDeadStates())
             {
-                if (selfLoopAlreadyMatched)
+                this.Data = builder.GetData();
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Helper class which which implements automaton simplification.
+        /// </summary>
+        public class Simplification
+        {
+            /// <summary>
+            /// Automaton builder which contains automaton during simplification procedure.
+            /// </summary>
+            private readonly Builder builder;
+
+            /// <summary>
+            /// Gets or sets a value for truncating small weights.
+            /// If non-null, any transition whose weight falls below this value in a normalized
+            /// automaton will be removed.
+            /// </summary>
+            private readonly double? pruneTransitionsWithLogWeightLessThan;
+
+            /// <summary>
+            /// Initializes new instance of <see cref="Simplification"/> class.
+            /// </summary>
+            public Simplification(Builder builder, double? pruneTransitionsWithLogWeightLessThan)
+            {
+                this.builder = builder;
+                this.pruneTransitionsWithLogWeightLessThan = pruneTransitionsWithLogWeightLessThan;
+            }
+
+            /// <summary>
+            /// Attempts to simplify the automaton using <see cref="Simplify"/> if the number of states
+            /// exceeds <see cref="MaxStateCountBeforeSimplification"/>.
+            /// </summary>
+            public bool SimplifyIfNeeded()
+            {
+                if (this.builder.StatesCount > MaxStateCountBeforeSimplification ||
+                    this.pruneTransitionsWithLogWeightLessThan != null)
                 {
-                    // Previous element was also a self-loop, we should try to find an espilon transition
-                    for (int i = 0; i < state.TransitionCount; ++i)
+                    return this.Simplify();
+                }
+
+                return false;
+            }
+
+            /// <summary>
+            /// Attempts to simplify the structure of the automaton, reducing the number of states and transitions.
+            /// </summary>
+            /// <remarks>
+            /// <para>
+            /// The simplification procedure works as follows:
+            /// <list type="number">
+            /// <item><description>
+            /// If a pair of states has more than one transition between them, the transitions get merged.
+            /// </description></item>
+            /// <item><description>
+            /// A part of the automaton that is a tree is found.
+            /// </description></item>
+            /// <item><description>
+            /// States and transitions that don't belong to the found tree part are simply copied to the result.
+            /// </description></item>
+            /// <item><description>
+            /// The found tree part is rebuild from scratch. The new tree is essentially a trie:
+            /// for example, if the original tree has two paths accepting <c>"abc"</c> and one path accepting <c>"ab"</c>,
+            /// the resulting tree has a single path accepting both <c>"ab"</c> and <c>"abc"</c>.
+            /// </description></item>
+            /// </list>
+            /// </para>
+            /// <para>The simplification procedure doesn't support automata with non-trivial loops.</para>
+            /// </remarks>
+            public bool Simplify()
+            {
+                this.MergeParallelTransitions();
+
+                if (AutomatonHasNonTrivialLoops())
+                {
+                    return false; // TODO: make this stuff work with non-trivial loops
+                }
+
+                var generalizedTreeNodes = this.FindGeneralizedTrees();
+                var sequenceToLogWeight = this.BuildAcceptedSequenceList(generalizedTreeNodes);
+                this.builder.RemoveStates(generalizedTreeNodes, true);
+
+                var firstNonCopiedStateIndex = this.builder.StatesCount;
+
+                // Before we rebuild the tree part, we prune out the low probability sequences
+                if (this.pruneTransitionsWithLogWeightLessThan != null)
+                {
+                    double logNorm = this.builder.GetAutomaton().GetLogNormalizer();
+                    if (!double.IsInfinity(logNorm))
                     {
-                        Transition transition = state.GetTransition(i);
-                        if (transition.DestinationStateIndex != state.Index && transition.IsEpsilon && transition.DestinationStateIndex >= firstAllowedStateIndex)
+                        sequenceToLogWeight = sequenceToLogWeight
+                            .Where(s => s.Weight.LogValue - logNorm >= this.pruneTransitionsWithLogWeightLessThan.Value)
+                            .ToList();
+                    }
+                }
+
+                foreach (var weightedSequence in sequenceToLogWeight)
+                {
+                    this.AddGeneralizedSequence(firstNonCopiedStateIndex, weightedSequence.Sequence, weightedSequence.Weight);
+                }
+
+                return true;
+            }
+
+            /// <summary>
+            /// Optimizes the automaton by removing all states which can't reach end states.
+            /// </summary>
+            /// <remarks>
+            /// This function looks a lot like <see cref="ComputeEndStateReachability"/>. But unfortunately operates on
+            /// a different graph representation.
+            /// </remarks>
+            public bool RemoveDeadStates()
+            {
+                var builder = this.builder;
+                var visited = new bool[builder.StatesCount];
+                var (edgesStart, edges) = BuildReversedGraph();
+
+                for (var i = 0; i < builder.StatesCount; ++i)
+                {
+                    if (builder[i].CanEnd)
+                    {
+                        Traverse(i);
+                    }
+                }
+
+                return this.builder.RemoveStates(visited, false) > 0;
+
+                void Traverse(int index)
+                {
+                    if (!visited[index])
+                    {
+                        visited[index] = true;
+                        for (var i = edgesStart[index]; i < edgesStart[index + 1]; ++i)
                         {
-                            if (this.DoAddGeneralizedSequence(
-                                this.States[transition.DestinationStateIndex],
-                                false,
-                                false,
-                                firstAllowedStateIndex,
-                                currentSequencePos,
-                                sequence,
-                                Weight.Product(weight, Weight.Inverse(transition.Weight))))
+                            Traverse(edges[i]);
+                        }
+                    }
+                }
+
+                (int[] edgesStart, int[] edges) BuildReversedGraph()
+                {
+                    // [edgesStart[i]; edgesStart[i+1]) is a range `edges` array which corresponds to incoming edges for state `i`
+                    var edgesStart1 = new int[builder.StatesCount + 1];
+
+                    // incomming edges for state. Represented as index of source state
+                    var edges1 = new int[builder.TransitionsCount];
+
+                    // first populate edges
+                    for (var i = 0; i < builder.StatesCount; ++i)
+                    {
+                        for (var iterator = builder[i].TransitionIterator; iterator.Ok; iterator.Next())
+                        {
+                            ++edgesStart1[iterator.Value.DestinationStateIndex];
+                        }
+                    }
+
+                    // calculate commutative sums. Now edgesStart[i] contains end of range
+                    for (var i = 0; i < builder.StatesCount; ++i)
+                    {
+                        edgesStart1[i + 1] += edgesStart1[i];
+                    }
+
+                    // Fill ranges and adjust start indices. Now edgesStart[i] contains begining of the range
+                    for (var i = 0; i < builder.StatesCount; ++i)
+                    {
+                        for (var iterator = builder[i].TransitionIterator; iterator.Ok; iterator.Next())
+                        {
+                            var index = --edgesStart1[iterator.Value.DestinationStateIndex];
+                            edges1[index] = i;
+                        }
+                    }
+
+                    return (edgesStart1, edges1);
+                }
+            }
+
+            /// <summary>
+            /// Removes transitions in the automaton whose log weight is less than the specified threshold.
+            /// </summary>
+            /// <remarks>
+            /// Any states which are unreachable in the resulting automaton are also removed.
+            /// </remarks>
+            /// <param name="logWeightThreshold">The smallest log weight that a transition can have and not be removed.</param>
+            public void RemoveTransitionsWithSmallWeights(double logWeightThreshold)
+            {
+                for (var i = 0; i < this.builder.StatesCount; ++i)
+                {
+                    var state = this.builder[i];
+                    for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
+                    {
+                        if (iterator.Value.Weight.LogValue < logWeightThreshold)
+                        {
+                            iterator.Remove();
+                        }
+                    }
+                }
+
+                // Calculate reachable states and remove unreachable
+                var visited = new bool[this.builder.StatesCount];
+                Traverse(this.builder.StartStateIndex);
+                this.builder.RemoveStates(visited, false);
+
+                void Traverse(int stateIndex)
+                {
+                    if (!visited[stateIndex])
+                    {
+                        visited[stateIndex] = true;
+                        var state = this.builder[stateIndex];
+                        for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
+                        {
+                            Traverse(iterator.Value.DestinationStateIndex);
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Recursively checks if the automaton has non-trivial loops
+            /// (i.e. loops consisting of more than one transition).
+            /// </summary>
+            /// <returns>
+            /// <see langword="true"/> if a non-trivial loop has been found,
+            /// <see langword="false"/> otherwise.
+            /// </returns>
+            private bool AutomatonHasNonTrivialLoops()
+            {
+                var stateInStack = new ArrayDictionary<bool>(this.builder.StatesCount);
+                return HasNonTrivialLoops(this.builder.StartStateIndex);
+
+                bool HasNonTrivialLoops(int stateIndex)
+                {
+                    if (stateInStack.TryGetValue(stateIndex, out var inStack))
+                    {
+                        return inStack;
+                    }
+
+                    stateInStack[stateIndex] = true;
+                    for (var iterator = this.builder[stateIndex].TransitionIterator; iterator.Ok; iterator.Next())
+                    {
+                        var transition = iterator.Value;
+                        if (transition.DestinationStateIndex != stateIndex)
+                        {
+                            if (HasNonTrivialLoops(transition.DestinationStateIndex))
                             {
                                 return true;
                             }
                         }
                     }
 
-                    // Epsilon transition not found, let's create a new one
-                    State destination = state.AddEpsilonTransition(Weight.One);
-                    success = this.DoAddGeneralizedSequence(destination, true, false, firstAllowedStateIndex, currentSequencePos, sequence, weight);
+                    stateInStack[stateIndex] = false;
+                    return false;
+                }
+            }
+
+            /// <summary>
+            /// Labels each state with a value indicating whether the automaton having that state as the start state is a
+            /// generalized tree (i.e. a tree with self-loops), which has single path from root leading to it
+            /// (excluding the self-loops).
+            /// </summary>
+            /// <returns>A dictionary mapping state indices to the computed labels.</returns>
+            private bool[] FindGeneralizedTrees()
+            {
+                var inDegree = CalcInDegree();
+                var isGeneralizedTree = new bool[this.builder.StatesCount];
+                Traverse(this.builder.StartStateIndex);
+                return isGeneralizedTree;
+
+                bool Traverse(int currentStateIndex)
+                {
+                    if (inDegree[currentStateIndex] > 1)
+                    {
+                        // Valid states can't have more than one incoming edge. Having more than one edge
+                        // means that there's more than one path from root or that there's a loop somewhere.
+                        // Both these cases are not considered generalized trees.
+                        return false;
+                    }
+
+                    var currentIsGeneralizedTree = true;
+                    for (var iterator = this.builder[currentStateIndex].TransitionIterator; iterator.Ok; iterator.Next())
+                    {
+                        var transition = iterator.Value;
+
+                        // Self-loops are allowed
+                        if (transition.DestinationStateIndex != currentStateIndex)
+                        {
+                            currentIsGeneralizedTree &= Traverse(transition.DestinationStateIndex);
+                        }
+                    }
+
+                    // if current node is not generalized tree then all transitions from it are also not trees
+                    if (!currentIsGeneralizedTree)
+                    {
+                        for (var iterator = this.builder[currentStateIndex].TransitionIterator; iterator.Ok; iterator.Next())
+                        {
+                            MarkAsNonTree(iterator.Value.DestinationStateIndex);
+                        }
+                    }
+
+                    isGeneralizedTree[currentStateIndex] = currentIsGeneralizedTree;
+                    return currentIsGeneralizedTree;
+                }
+
+                void MarkAsNonTree(int currentStateIndex)
+                {
+                    if (isGeneralizedTree[currentStateIndex])
+                    {
+                        isGeneralizedTree[currentStateIndex] = false;
+                        for (var iterator = this.builder[currentStateIndex].TransitionIterator; iterator.Ok; iterator.Next())
+                        {
+                            MarkAsNonTree(iterator.Value.DestinationStateIndex);
+                        }
+                    }
+                }
+
+                int[] CalcInDegree()
+                {
+                    var result = new int[this.builder.StatesCount];
+                    for (var i = 0; i < this.builder.StatesCount; ++i)
+                    {
+                        for (var iterator = this.builder[i].TransitionIterator; iterator.Ok; iterator.Next())
+                        {
+                            // do not count self-loops
+                            var destination = iterator.Value.DestinationStateIndex;
+                            if (destination != i)
+                            {
+                                ++result[destination];
+                            }
+                        }
+                    }
+
+                    return result;
+                }
+            }
+
+            /// <summary>
+            /// Merges outgoing transitions with the same destination state.
+            /// </summary>
+            public void MergeParallelTransitions()
+            {
+                for (var stateIndex = 0; stateIndex < this.builder.StatesCount; ++stateIndex)
+                {
+                    var state = this.builder[stateIndex];
+                    for (var iterator1 = state.TransitionIterator; iterator1.Ok; iterator1.Next())
+                    {
+                        var transition1 = iterator1.Value;
+                        var iterator2 = iterator1;
+                        iterator2.Next();
+                        for (; iterator2.Ok; iterator2.Next())
+                        {
+                            var transition2 = iterator2.Value;
+                            if (transition1.DestinationStateIndex == transition2.DestinationStateIndex && transition1.Group == transition2.Group)
+                            {
+                                var removeTransition2 = false;
+                                if (transition1.IsEpsilon && transition2.IsEpsilon)
+                                {
+                                    transition1.Weight = Weight.Sum(transition1.Weight, transition2.Weight);
+                                    iterator1.Value = transition1;
+                                    removeTransition2 = true;
+                                }
+                                else if (!transition1.IsEpsilon && !transition2.IsEpsilon)
+                                {
+                                    var newElementDistribution = new TElementDistribution();
+                                    if (double.IsInfinity(transition1.Weight.Value) && double.IsInfinity(transition2.Weight.Value))
+                                    {
+                                        newElementDistribution.SetToSum(
+                                            1.0, transition1.ElementDistribution.Value, 1.0, transition2.ElementDistribution.Value);
+                                    }
+                                    else
+                                    {
+                                        newElementDistribution.SetToSum(
+                                            transition1.Weight.Value, transition1.ElementDistribution.Value, transition2.Weight.Value, transition2.ElementDistribution.Value);
+                                    }
+
+                                    transition1.ElementDistribution = newElementDistribution;
+                                    transition1.Weight = Weight.Sum(transition1.Weight, transition2.Weight);
+                                    iterator1.Value = transition1;
+                                    removeTransition2 = true;
+                                }
+
+                                if (removeTransition2)
+                                {
+                                    iterator2.Remove();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Builds a complete list of generalized sequences accepted by the simplifiable part of the automaton.
+            /// </summary>
+            /// <param name="generalizedTreeNodes">The state labels obtained from <see cref="FindGeneralizedTrees"/>.</param>
+            /// <returns>The list of generalized sequences accepted by the simplifiable part of the automaton.</returns>
+            private List<WeightedSequence> BuildAcceptedSequenceList(bool[] generalizedTreeNodes)
+            {
+                var sequenceToWeight = new List<WeightedSequence>();
+                this.DoBuildAcceptedSequenceList(
+                    this.builder.StartStateIndex,
+                    generalizedTreeNodes,
+                    sequenceToWeight,
+                    new List<GeneralizedElement>(),
+                    Weight.One);
+                return sequenceToWeight;
+            }
+
+
+            private class StackItem
+            {
+            }
+
+            private class ElementItem : StackItem
+            {
+                public readonly GeneralizedElement? Element;
+
+                public ElementItem(GeneralizedElement? element) => this.Element = element;
+
+                public override string ToString() => this.Element.ToString();
+            }
+
+            private class StateWeight : StackItem
+            {
+                public readonly int StateIndex;
+                public readonly Weight Weight;
+
+                public StateWeight(int stateIndexIndex, Weight weight)
+                {
+                    this.StateIndex = stateIndexIndex;
+                    this.Weight = weight;
+                }
+
+                public override string ToString() => $"StateIndex: {this.StateIndex}, Weight: {Weight}";
+            }
+
+            /// <summary>
+            /// Recursively builds a complete list of generalized sequences accepted by the simplifiable part of the automaton.
+            /// </summary>
+            /// <param name="stateIndex">The currently traversed state.</param>
+            /// <param name="generalizedTreeNodes">The state labels obtained from <see cref="FindGeneralizedTrees"/>.</param>
+            /// <param name="weightedSequences">The sequence list being built.</param>
+            /// <param name="currentSequenceElements">The list of elements of the sequence currently being built.</param>
+            /// <param name="currentWeight">The weight of the sequence currently being built.</param>
+            private void DoBuildAcceptedSequenceList(
+                int stateIndex,
+                bool[] generalizedTreeNodes,
+                List<WeightedSequence> weightedSequences,
+                List<GeneralizedElement> currentSequenceElements,
+                Weight currentWeight)
+            {
+                var stack = new Stack<StackItem>();
+                stack.Push(new StateWeight(stateIndex, currentWeight));
+
+                while (stack.Count > 0)
+                {
+                    var stackItem = stack.Pop();
+
+                    if (stackItem is ElementItem elementItem)
+                    {
+                        if (elementItem.Element != null)
+                            currentSequenceElements.Add(elementItem.Element.Value);
+                        else
+                            currentSequenceElements.RemoveAt(currentSequenceElements.Count - 1);
+                        continue;
+                    }
+
+                    var stateAndWeight = stackItem as StateWeight;
+
+                    stateIndex = stateAndWeight.StateIndex;
+                    var state = this.builder[stateIndex];
+                    currentWeight = stateAndWeight.Weight;
+
+                    // Find a non-epsilon self-loop if there is one
+                    Transition? selfLoop = null;
+                    for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
+                    {
+                        var transition = iterator.Value;
+                        if (transition.DestinationStateIndex == stateIndex)
+                        {
+                            Debug.Assert(
+                                selfLoop == null,
+                                "Multiple self-loops should have been merged by MergeParallelTransitions()");
+                            selfLoop = transition;
+                        }
+                    }
+
+                    // Push the found self-loop to the end of the current sequence
+                    if (selfLoop != null)
+                    {
+                        currentSequenceElements.Add(new GeneralizedElement(
+                            selfLoop.Value.ElementDistribution, selfLoop.Value.Group, selfLoop.Value.Weight));
+                        stack.Push(new ElementItem(null));
+                    }
+
+                    // Can this state produce a sequence?
+                    if (state.CanEnd && generalizedTreeNodes[stateIndex])
+                    {
+                        var sequence = new GeneralizedSequence(currentSequenceElements);
+                        // TODO: use immutable data structure instead of copying sequences
+                        weightedSequences.Add(new WeightedSequence(sequence, Weight.Product(currentWeight, state.EndWeight)));
+                    }
+
+                    // Traverse the outgoing transitions
+                    for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
+                    {
+                        var transition = iterator.Value;
+                        // Skip self-loops & disallowed states
+                        if (transition.DestinationStateIndex == stateIndex ||
+                            !generalizedTreeNodes[transition.DestinationStateIndex])
+                        {
+                            continue;
+                        }
+
+                        if (!transition.IsEpsilon)
+                        {
+                            // Non-epsilon transitions contribute to the sequence
+                            stack.Push(new ElementItem(null));
+                        }
+
+                        stack.Push(
+                            new StateWeight(
+                                transition.DestinationStateIndex,
+                                Weight.Product(currentWeight, transition.Weight)));
+
+                        if (!transition.IsEpsilon)
+                        {
+                            stack.Push(
+                                new ElementItem(
+                                    new GeneralizedElement(transition.ElementDistribution, transition.Group, null)));
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Increases the value of this automaton on <paramref name="sequence"/> by <paramref name="weight"/>.
+            /// </summary>
+            /// <param name="firstAllowedStateIndex">The minimum index of an existing state that can be used for the sequence.</param>
+            /// <param name="sequence">The generalized sequence.</param>
+            /// <param name="weight">The weight of the sequence.</param>
+            /// <remarks>
+            /// This function attempts to add as few new states and transitions as possible.
+            /// Its implementation is conceptually similar to adding string to a trie.
+            /// </remarks>
+            private void AddGeneralizedSequence(int firstAllowedStateIndex, Simplification.GeneralizedSequence sequence, Weight weight)
+            {
+                // First, try to add at start state
+                var isFreshStartState = !this.builder.Start.HasTransitions && this.builder.Start.EndWeight.IsZero;
+                if (this.DoAddGeneralizedSequence(this.builder.Start.Index, isFreshStartState, false, firstAllowedStateIndex, 0, sequence, weight))
+                {
+                    return;
+                }
+
+                // Branch the start state
+                var builder = this.builder;
+                var oldStart = builder.Start;
+                var start = builder.AddState();
+                builder.StartStateIndex = start.Index;
+                var otherBranch = builder.AddState();
+                builder.Start.AddEpsilonTransition(Weight.One, oldStart.Index);
+                builder.Start.AddEpsilonTransition(Weight.One, otherBranch.Index);
+
+                // This should always work
+                var success = this.DoAddGeneralizedSequence(otherBranch.Index, true, false, firstAllowedStateIndex, 0, sequence, weight);
+                Debug.Assert(success, "This call must always succeed.");
+            }
+
+            /// <summary>
+            /// Recursively increases the value of this automaton on <paramref name="sequence"/> by <paramref name="weight"/>.
+            /// </summary>
+            /// <param name="stateIndex">Index of currently traversed state.</param>
+            /// <param name="isNewState">Indicates whether state <paramref name="stateIndex"/> was just created.</param>
+            /// <param name="selfLoopAlreadyMatched">Indicates whether self-loop on state <paramref name="stateIndex"/> was just matched.</param>
+            /// <param name="firstAllowedStateIndex">The minimum index of an existing state that can be used for the sequence.</param>
+            /// <param name="currentSequencePos">The current position in the generalized sequence.</param>
+            /// <param name="sequence">The generalized sequence.</param>
+            /// <param name="weight">The weight of the sequence.</param>
+            /// <returns>
+            /// <see langword="true"/> if the subsequence starting at <paramref name="currentSequencePos"/> has been successfully merged in,
+            /// <see langword="false"/> otherwise.
+            /// </returns>
+            /// <remarks>
+            /// This function attempts to add as few new states and transitions as possible.
+            /// Its implementation is conceptually similar to adding string to a trie.
+            /// </remarks>
+            private bool DoAddGeneralizedSequence(
+                int stateIndex,
+                bool isNewState,
+                bool selfLoopAlreadyMatched,
+                int firstAllowedStateIndex,
+                int currentSequencePos,
+                GeneralizedSequence sequence,
+                Weight weight)
+            {
+                bool success;
+                var builder = this.builder;
+                var state = builder[stateIndex];
+
+                if (currentSequencePos == sequence.Count)
+                {
+                    if (!selfLoopAlreadyMatched)
+                    {
+                        // We can't finish in a state with a self-loop
+                        for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
+                        {
+                            if (iterator.Value.DestinationStateIndex == state.Index)
+                            {
+                                return false;
+                            }
+                        }
+                    }
+
+                    state.SetEndWeight(Weight.Sum(state.EndWeight, weight));
+                    return true;
+                }
+
+                var element = sequence[currentSequencePos];
+
+                // Treat self-loops elements separately
+                if (element.LoopWeight.HasValue)
+                {
+                    if (selfLoopAlreadyMatched)
+                    {
+                        // Previous element was also a self-loop, we should try to find an espilon transition
+                        for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
+                        {
+                            var transition = iterator.Value;
+                            if (transition.DestinationStateIndex != state.Index &&
+                                transition.IsEpsilon &&
+                                transition.DestinationStateIndex >= firstAllowedStateIndex)
+                            {
+                                if (this.DoAddGeneralizedSequence(
+                                    transition.DestinationStateIndex,
+                                    false,
+                                    false,
+                                    firstAllowedStateIndex,
+                                    currentSequencePos,
+                                    sequence,
+                                    Weight.Product(weight, Weight.Inverse(transition.Weight))))
+                                {
+                                    return true;
+                                }
+                            }
+                        }
+
+                        // Epsilon transition not found, let's create a new one
+                        var destination = state.AddEpsilonTransition(Weight.One);
+                        success = this.DoAddGeneralizedSequence(
+                            destination.Index, true, false, firstAllowedStateIndex, currentSequencePos, sequence, weight);
+                        Debug.Assert(success, "This call must always succeed.");
+                        return true;
+                    }
+
+                    // Find a matching self-loop
+                    for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
+                    {
+                        var transition = iterator.Value;
+
+                        if (transition.IsEpsilon && transition.DestinationStateIndex != state.Index && transition.DestinationStateIndex >= firstAllowedStateIndex)
+                        {
+                            // Try this epsilon transition
+                            if (this.DoAddGeneralizedSequence(
+                                transition.DestinationStateIndex, false, false, firstAllowedStateIndex, currentSequencePos, sequence, weight))
+                            {
+                                return true;
+                            }
+                        }
+
+                        // Is it a self-loop?
+                        if (transition.DestinationStateIndex == state.Index)
+                        {
+                            // Do self-loops match?
+                            if ((transition.Weight == element.LoopWeight.Value) &&
+                                (element.Group == transition.Group) &&
+                                ((transition.IsEpsilon && element.IsEpsilonSelfLoop) || (!transition.IsEpsilon && !element.IsEpsilonSelfLoop && transition.ElementDistribution.Equals(element.ElementDistribution))))
+                            {
+                                // Skip the element in the sequence, remain in the same state
+                                success = this.DoAddGeneralizedSequence(
+                                    stateIndex, false, true, firstAllowedStateIndex, currentSequencePos + 1, sequence, weight);
+                                Debug.Assert(success, "This call must always succeed.");
+                                return true;
+                            }
+
+                            // StateIndex also has a self-loop, but the two doesn't match
+                            return false;
+                        }
+                    }
+
+                    if (!isNewState)
+                    {
+                        // Can't add self-loop to an existing state, it will change the language accepted by the state
+                        return false;
+                    }
+
+                    // Add a new self-loop
+                    state.AddTransition(element.ElementDistribution, element.LoopWeight.Value, stateIndex, element.Group);
+                    success = this.DoAddGeneralizedSequence(stateIndex, false, true, firstAllowedStateIndex, currentSequencePos + 1, sequence, weight);
                     Debug.Assert(success, "This call must always succeed.");
                     return true;
                 }
 
-                // Find a matching self-loop
-                for (int i = 0; i < state.TransitionCount; ++i)
+                // Try to find a transition for the element
+                for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
                 {
-                    Transition transition = state.GetTransition(i);
+                    var transition = iterator.Value;
 
                     if (transition.IsEpsilon && transition.DestinationStateIndex != state.Index && transition.DestinationStateIndex >= firstAllowedStateIndex)
                     {
                         // Try this epsilon transition
                         if (this.DoAddGeneralizedSequence(
-                            this.States[transition.DestinationStateIndex], false, false, firstAllowedStateIndex, currentSequencePos, sequence, weight))
+                            transition.DestinationStateIndex, false, false, firstAllowedStateIndex, currentSequencePos, sequence, weight))
                         {
                             return true;
                         }
@@ -837,278 +766,47 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     // Is it a self-loop?
                     if (transition.DestinationStateIndex == state.Index)
                     {
-                        // Do self-loops match?
-                        if ((transition.Weight == element.LoopWeight.Value) &&
-                            (element.Group == transition.Group) &&
-                            ((transition.IsEpsilon && element.IsEpsilonSelfLoop) || (!transition.IsEpsilon && !element.IsEpsilonSelfLoop && transition.ElementDistribution.Equals(element.ElementDistribution))))
+                        if (selfLoopAlreadyMatched)
                         {
-                            // Skip the element in the sequence, remain in the same state
-                            success = this.DoAddGeneralizedSequence(state, false, true, firstAllowedStateIndex, currentSequencePos + 1, sequence, weight);
-                            Debug.Assert(success, "This call must always succeed.");
-                            return true;
+                            // The self-loop was checked or added by the caller
+                            continue;
                         }
 
-                        // State also has a self-loop, but the two doesn't match
+                        // Can't go through an existing self-loop, it will allow undesired sequences to be accepted
                         return false;
                     }
-                }
 
-                if (!isNewState)
-                {
-                    // Can't add self-loop to an existing state, it will change the language accepted by the state
-                    return false;
-                }
+                    if (transition.DestinationStateIndex < firstAllowedStateIndex ||
+                        element.Group != transition.Group ||
+                        !element.ElementDistribution.Equals(transition.ElementDistribution))
+                    {
+                        continue;
+                    }
 
-                // Add a new self-loop
-                state.AddTransition(element.ElementDistribution, element.LoopWeight.Value, state, element.Group);
-                success = this.DoAddGeneralizedSequence(state, false, true, firstAllowedStateIndex, currentSequencePos + 1, sequence, weight);
-                Debug.Assert(success, "This call must always succeed.");
-                return true;
-            }
-
-            // Try to find a transition for the element
-            for (int i = 0; i < state.TransitionCount; ++i)
-            {
-                Transition transition = state.GetTransition(i);
-
-                if (transition.IsEpsilon && transition.DestinationStateIndex != state.Index && transition.DestinationStateIndex >= firstAllowedStateIndex)
-                {
-                    // Try this epsilon transition
+                    // Skip the element in the sequence, move to the destination state
+                    // Weight of the existing transition must be taken into account
+                    // This case can fail if the next element is a self-loop and the destination state already has a different one
                     if (this.DoAddGeneralizedSequence(
-                        this.States[transition.DestinationStateIndex], false, false, firstAllowedStateIndex, currentSequencePos, sequence, weight))
+                        transition.DestinationStateIndex,
+                        false,
+                        false,
+                        firstAllowedStateIndex,
+                        currentSequencePos + 1,
+                        sequence,
+                        Weight.Product(weight, Weight.Inverse(transition.Weight))))
                     {
                         return true;
                     }
                 }
 
-                // Is it a self-loop?
-                if (transition.DestinationStateIndex == state.Index)
-                {
-                    if (selfLoopAlreadyMatched)
-                    {
-                        // The self-loop was checked or added by the caller
-                        continue;
-                    }
-
-                    // Can't go through an existing self-loop, it will allow undesired sequences to be accepted
-                    return false;
-                }
-
-                if (transition.DestinationStateIndex < firstAllowedStateIndex ||
-                    element.Group != transition.Group ||
-                    !element.ElementDistribution.Equals(transition.ElementDistribution))
-                {
-                    continue;
-                }
-
-                // Skip the element in the sequence, move to the destination state
-                // Weight of the existing transition must be taken into account
-                // This case can fail if the next element is a self-loop and the destination state already has a different one
-                if (this.DoAddGeneralizedSequence(
-                    this.States[transition.DestinationStateIndex],
-                    false,
-                    false,
-                    firstAllowedStateIndex,
-                    currentSequencePos + 1,
-                    sequence,
-                    Weight.Product(weight, Weight.Inverse(transition.Weight))))
-                {
-                    return true;
-                }
+                // Add a new transition
+                var newChild = state.AddTransition(element.ElementDistribution, Weight.One, null, element.Group);
+                success = this.DoAddGeneralizedSequence(
+                    newChild.Index, true, false, firstAllowedStateIndex, currentSequencePos + 1, sequence, weight);
+                Debug.Assert(success, "This call must always succeed.");
+                return true;
             }
 
-            // Add a new transition
-            State newChild = state.AddTransition(element.ElementDistribution, Weight.One, default(State), element.Group);
-            success = this.DoAddGeneralizedSequence(newChild, true, false, firstAllowedStateIndex, currentSequencePos + 1, sequence, weight);
-            Debug.Assert(success, "This call must always succeed.");
-            return true;
-        }
-
-        /// <summary>
-        /// Groups together helper classes used for automata determinization.
-        /// </summary>
-        protected static class Determinization
-        {
-            /// <summary>
-            /// Represents a state of the resulting automaton in the power set construction.
-            /// It is essentially a set of (stateId, weight) pairs of the source automaton, where each state id is unique.
-            /// Supports a quick lookup of the weight by state id.
-            /// </summary>
-            public class WeightedStateSet : IEnumerable<KeyValuePair<int, Weight>>
-            {
-                /// <summary>
-                /// A mapping from state ids to weights.
-                /// </summary>
-                private readonly Dictionary<int, Weight> stateIdToWeight;
-
-                /// <summary>
-                /// Initializes a new instance of the <see cref="WeightedStateSet"/> class.
-                /// </summary>
-                public WeightedStateSet()
-                {
-                    this.stateIdToWeight = new Dictionary<int, Weight>();
-                }
-
-                /// <summary>
-                /// Initializes a new instance of the <see cref="WeightedStateSet"/> class.
-                /// </summary>
-                /// <param name="stateIdToWeight">A collection of (stateId, weight) pairs.
-                /// </param>
-                public WeightedStateSet(IEnumerable<KeyValuePair<int, Weight>> stateIdToWeight)
-                {
-                    this.stateIdToWeight = stateIdToWeight.ToDictionary(kv => kv.Key, kv => kv.Value);
-                }
-
-                /// <summary>
-                /// Gets or sets the weight for a given state id.
-                /// </summary>
-                /// <param name="stateId">The state id.</param>
-                /// <returns>The weight.</returns>
-                public Weight this[int stateId]
-                {
-                    get { return this.stateIdToWeight[stateId]; }
-                    set { this.stateIdToWeight[stateId] = value; }
-                }
-
-                /// <summary>
-                /// Adds a given state id and a weight to the set.
-                /// </summary>
-                /// <param name="stateId">The state id.</param>
-                /// <param name="weight">The weight.</param>
-                public void Add(int stateId, Weight weight)
-                {
-                    this.stateIdToWeight.Add(stateId, weight);
-                }
-
-                /// <summary>
-                /// Attempts to retrieve the weight corresponding to a given state id from the set.
-                /// </summary>
-                /// <param name="stateId">The state id.</param>
-                /// <param name="weight">When the method returns, contains the retrieved weight.</param>
-                /// <returns>
-                /// <see langword="true"/> if the given state id was present in the set,
-                /// <see langword="false"/> otherwise.
-                /// </returns>
-                public bool TryGetWeight(int stateId, out Weight weight)
-                {
-                    return this.stateIdToWeight.TryGetValue(stateId, out weight);
-                }
-
-                /// <summary>
-                /// Checks whether the state with a given id is present in the set.
-                /// </summary>
-                /// <param name="stateId">The state id,</param>
-                /// <returns>
-                /// <see langword="true"/> if the given state id was present in the set,
-                /// <see langword="false"/> otherwise.
-                /// </returns>
-                public bool ContainsState(int stateId)
-                {
-                    return this.stateIdToWeight.ContainsKey(stateId);
-                }
-
-                /// <summary>
-                /// Checks whether this object is equal to a given one.
-                /// </summary>
-                /// <param name="obj">The object to compare this object with.</param>
-                /// <returns>
-                /// <see langword="true"/> if the objects are equal,
-                /// <see langword="false"/> otherwise.
-                /// </returns>
-                public override bool Equals(object obj)
-                {
-                    if (obj == null || obj.GetType() != typeof(WeightedStateSet))
-                    {
-                        return false;
-                    }
-
-                    var other = (WeightedStateSet)obj;
-
-                    if (this.stateIdToWeight.Count != other.stateIdToWeight.Count)
-                    {
-                        return false;
-                    }
-
-                    foreach (KeyValuePair<int, Weight> pair in this.stateIdToWeight)
-                    {
-                        // TODO: Should we allow for some tolerance? But what about hashing then?
-                        if (!other.stateIdToWeight.TryGetValue(pair.Key, out Weight otherWeight) || otherWeight != pair.Value)
-                        {
-                            return false;
-                        }
-                    }
-
-                    return true;
-                }
-
-                /// <summary>
-                /// Computes the hash code of this instance.
-                /// </summary>
-                /// <returns>The computed hash code.</returns>
-                public override int GetHashCode()
-                {
-                    int result = 0;
-                    foreach (KeyValuePair<int, Weight> pair in this.stateIdToWeight)
-                    {
-                        int pairHash = Hash.Start;
-                        pairHash = Hash.Combine(pairHash, pair.Key.GetHashCode());
-                        pairHash = Hash.Combine(pairHash, pair.Value.GetHashCode());
-
-                        // Use commutative hashing combination because dictionaries are not ordered
-                        result ^= pairHash;
-                    }
-
-                    return result;
-                }
-
-                /// <summary>
-                /// Returns a string representation of the instance.
-                /// </summary>
-                /// <returns>A string representation of the instance.</returns>
-                public override string ToString()
-                {
-                    StringBuilder builder = new StringBuilder();
-                    foreach (var kvp in this.stateIdToWeight)
-                    {
-                        builder.AppendLine(kvp.ToString());
-                    }
-
-                    return builder.ToString();
-                }
-
-                #region IEnumerable implementation
-
-                /// <summary>
-                /// Gets the enumerator.
-                /// </summary>
-                /// <returns>
-                /// The enumerator.
-                /// </returns>
-                public IEnumerator<KeyValuePair<int, Weight>> GetEnumerator()
-                {
-                    return this.stateIdToWeight.GetEnumerator();
-                }
-
-                /// <summary>
-                /// Gets the enumerator.
-                /// </summary>
-                /// <returns>
-                /// The enumerator.
-                /// </returns>
-                IEnumerator IEnumerable.GetEnumerator()
-                {
-                    return this.GetEnumerator();
-                }
-
-                #endregion
-            }
-        }
-
-        /// <summary>
-        /// Groups together helper classes used for automata simplification.
-        /// </summary>
-        private static class Simplification
-        {
             /// <summary>
             /// Represents an element of a generalized sequence,
             /// i.e. a distribution over a single symbol or a weighted self-loop.
@@ -1162,14 +860,15 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 /// <returns>The string representation of the generalized element.</returns>
                 public override string ToString()
                 {
-                    string elementDistributionAsString = this.ElementDistribution.Value.IsPointMass ? this.ElementDistribution.Value.Point.ToString() : this.ElementDistribution.ToString();
-                    string groupString = this.Group == 0 ? string.Empty : $"#{this.Group}";
-                    if (this.LoopWeight.HasValue)
-                    {
-                        return $"{groupString}{elementDistributionAsString}*({this.LoopWeight.Value})";
-                    }
-
-                    return $"{groupString}{elementDistributionAsString}";
+                    var elementDistributionAsString =
+                        this.ElementDistribution.Value.IsPointMass
+                            ? this.ElementDistribution.Value.Point.ToString()
+                            : this.ElementDistribution.ToString();
+                    var groupString = this.Group == 0 ? string.Empty : $"#{this.Group}";
+                    return
+                        this.LoopWeight.HasValue
+                            ? $"{groupString}{elementDistributionAsString}*({this.LoopWeight.Value})"
+                            : $"{groupString}{elementDistributionAsString}";
                 }
             }
 
@@ -1195,20 +894,14 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 /// <summary>
                 /// Gets the number of elements in the sequence.
                 /// </summary>
-                public int Count
-                {
-                    get { return this.elements.Count; }
-                }
+                public int Count => this.elements.Count;
 
                 /// <summary>
                 /// Gets the sequence element with the specified index.
                 /// </summary>
                 /// <param name="index">The element index.</param>
                 /// <returns>The element at the given index.</returns>
-                public GeneralizedElement this[int index]
-                {
-                    get { return this.elements[index]; }
-                }
+                public GeneralizedElement this[int index] => this.elements[index];
 
                 /// <summary>
                 /// Gets the string representation of the sequence.
@@ -1217,7 +910,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 public override string ToString()
                 {
                     var stringBuilder = new StringBuilder();
-                    foreach (GeneralizedElement element in this.elements)
+                    foreach (var element in this.elements)
                     {
                         stringBuilder.Append(element);
                     }
@@ -1254,10 +947,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 /// Gets the string representation of this <see cref="WeightedSequence"/>.
                 /// </summary>
                 /// <returns>The string representation of the <see cref="WeightedSequence"/>.</returns>
-                public override string ToString()
-                {
-                    return $"[{this.Sequence},{this.Weight}]";
-                }
+                public override string ToString() => $"[{this.Sequence},{this.Weight}]";
 
                 /// <summary>
                 /// Checks if this object is equal to <paramref name="obj"/>.
@@ -1267,15 +957,10 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 /// <see langword="true"/> if this object is equal to <paramref name="obj"/>,
                 /// <see langword="false"/> otherwise.
                 /// </returns>
-                public override bool Equals(object obj)
-                {
-                    if (obj is WeightedSequence weightedSequence)
-                    {
-                        return object.Equals(this.Sequence, weightedSequence.Sequence) && object.Equals(this.Weight, weightedSequence.Weight);
-                    }
-
-                    return false;
-                }
+                public override bool Equals(object obj) =>
+                    obj is WeightedSequence weightedSequence &&
+                    object.Equals(this.Sequence, weightedSequence.Sequence) &&
+                    object.Equals(this.Weight, weightedSequence.Weight);
 
                 /// <summary>
                 /// Computes the hash code of this object.

--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -11,7 +11,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System.Linq;
     using System.Text;
 
-    using Microsoft.ML.Probabilistic.Core.Collections;
+    using Microsoft.ML.Probabilistic.Collections;
     using Microsoft.ML.Probabilistic.Utilities;
 
     /// <content>

--- a/src/Runtime/Distributions/Automata/Automaton.State.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.State.cs
@@ -8,68 +8,45 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Runtime.Serialization;
     using System.Text;
 
     using Microsoft.ML.Probabilistic.Collections;
-    using Microsoft.ML.Probabilistic.Distributions;
-    using Microsoft.ML.Probabilistic.Math;
-    using Microsoft.ML.Probabilistic.Serialization;
-    using Microsoft.ML.Probabilistic.Utilities;
+    using Microsoft.ML.Probabilistic.Core.Collections;
 
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
-        where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
-        where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
-        where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {
         /// <summary>
         /// Represents a reference to a state of automaton for exposure in public API.
         /// </summary>
         /// <remarks>
         /// Acts as a "fat reference" to state in automaton. In addition to reference to actual StateData it carries
-        /// 2 additional properties for convinience: <see cref="Owner"/> automaton and <see cref="Index"/> of the state.
-        /// We don't store them in <see cref="StateData"/> to save some memoty. C# compiler and .NET jitter are good
-        /// at optimizing wrapping where it is not needed.
+        /// 3 additional properties for convenience: <see cref="Owner"/> automaton, <see cref="Index"/> of the state
+        /// and full <see cref="transitions"/> table.
         /// </remarks>
         public struct State : IEquatable<State>
         {
-            internal readonly StateData Data;
+            private readonly ReadOnlyArray<StateData> states;
+
+            private readonly ReadOnlyArray<Transition> transitions;
 
             /// <summary>
             /// Initializes a new instance of <see cref="State"/> class. Used internally by automaton implementation
             /// to wrap StateData for use in public Automaton APIs.
             /// </summary>
-            internal State(Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> owner, int index, StateData data)
+            internal State(
+                Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> owner,
+                ReadOnlyArray<StateData> states,
+                ReadOnlyArray<Transition> transitions,
+                int index)
             {
                 this.Owner = owner;
+                this.states = states;
+                this.transitions = transitions;
                 this.Index = index;
-                this.Data = data;
             }
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="State"/> class. Created state does not belong
-            /// to any automaton and has to be added to some automaton explicitly via Automaton.AddStates.
-            /// </summary>
-            /// <param name="index">The index of the state.</param>
-            /// <param name="transitions">The outgoing transitions.</param>
-            /// <param name="endWeight">The ending weight of the state.</param>
-            [Construction("Index", "GetTransitions", "EndWeight")]
-            public State(int index, IEnumerable<Transition> transitions, Weight endWeight)
-                : this()
-            {
-                Argument.CheckIfInRange(index >= 0, "index", "State index must be non-negative.");
-                this.Index = index;
-                this.Data = new StateData(transitions, endWeight);
-            }
-
-            /// <summary>
-            /// Returns where this State represents some valid state in automaton.
-            /// </summary>
-            public bool IsNull => this.Data == null;
-
-            /// <summary>
-            /// Automaton to which this state belongs.
+            /// Gets automaton to which this state belongs.
             /// </summary>
             public Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> Owner { get; }
 
@@ -79,50 +56,28 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             public int Index { get; }
 
             /// <summary>
-            /// Gets or sets the ending weight of the state.
+            /// Gets the ending weight of the state.
             /// </summary>
-            /// <remarks>
-            /// C# compiler disallows to use property setter if it sees that <see cref="States"/> instance is a temporary.
-            /// It is not smart enough to understand that property setter actually changes something behind a reference.
-            /// To overcome this issue special <see cref="SetEndWeight"/> method is added calling which is equivalent
-            /// to calling property setter but is not rejected by compiler.
-            /// </remarks>
             public Weight EndWeight => this.Data.EndWeight;
-
-            /// <summary>
-            /// Sets the <see cref="EndWeight"/> property of State.
-            ///
-            /// Because <see cref="State"/> is a struct, trying to set <see cref="EndWeight"/> on it
-            /// (if property setter was provided) would result in compilation error. Compiler isn't
-            /// smart enough to see that setting property just updates the value in referenced <see cref="Data"/>.
-            /// Having a method call doesn't create this problem.
-            /// </summary>
-            /// <param name="weight">New end weight.</param>
-            public void SetEndWeight(Weight weight)
-            {
-                this.Data.EndWeight = weight;
-            }
-
+            
             /// <summary>
             /// Gets a value indicating whether the ending weight of this state is greater than zero.
             /// </summary>
             public bool CanEnd => this.Data.CanEnd;
 
-            /// <summary>
-            /// Gets the number of outgoing transitions.
-            /// </summary>
-            public int TransitionCount => this.Data.TransitionCount;
+            public ReadOnlyArraySegment<Transition> Transitions =>
+                new ReadOnlyArraySegment<Transition>(
+                    this.transitions,
+                    this.Data.FirstTransition,
+                    this.Data.LastTransition);
 
-            /// <summary>
-            /// Creates the copy of the array of outgoing transitions. Used by quoting.
-            /// </summary>
-            /// <returns>The copy of the array of outgoing transitions.</returns>
-            public Transition[] GetTransitions() => this.Data.GetTransitions();
+            internal StateData Data => this.states[this.Index];
 
             /// <summary>
             /// Compares 2 states for equality.
             /// </summary>
-            public static bool operator ==(State a, State b) => a.Data == b.Data;
+            public static bool operator ==(State a, State b) =>
+                ReferenceEquals(a.Owner, b.Owner) && a.Index == b.Index;
 
             /// <summary>
             /// Compares 2 states for inequality.
@@ -134,181 +89,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// </summary>
             public bool Equals(State that) => this == that;
 
-            /// <summary>
-            /// Compares 2 states for equality.
-            /// </summary>
+            /// <inheritdoc/>
             public override bool Equals(object obj) => obj is State that && this.Equals(that);
 
-            /// <summary>
-            /// Returns HashCode of this state.
-            /// </summary>
-            public override int GetHashCode() => this.Data?.GetHashCode() ?? 0;
-
-            /// <summary>
-            /// Adds a series of transitions labeled with the elements of a given sequence to the current state,
-            /// as well as the intermediate states. All the added transitions have unit weight.
-            /// </summary>
-            /// <param name="sequence">The sequence.</param>
-            /// <param name="destinationState">
-            /// The last state in the transition series.
-            /// If the value of this parameter is <see langword="null"/>, a new state will be created.
-            /// </param>
-            /// <param name="group">The group of the added transitions.</param>
-            /// <returns>The last state in the added transition series.</returns>
-            public State AddTransitionsForSequence(TSequence sequence, State destinationState = default(State), int group = 0)
-            {
-                var currentState = this;
-                using (var enumerator = sequence.GetEnumerator())
-                {
-                    var moveNext = enumerator.MoveNext();
-                    while (moveNext)
-                    {
-                        var element = enumerator.Current;
-                        moveNext = enumerator.MoveNext();
-                        currentState = currentState.AddTransition(
-                            element, Weight.One, moveNext ? default(State) : destinationState, group);
-                    }
-                }
-
-                return currentState;
-            }
-
-            /// <summary>
-            /// Adds a transition labeled with a given element to the current state.
-            /// </summary>
-            /// <param name="element">The element.</param>
-            /// <param name="weight">The transition weight.</param>
-            /// <param name="destinationState">
-            /// The destination state of the added transition.
-            /// If the value of this parameter is <see langword="null"/>, a new state will be created.</param>
-            /// <param name="group">The group of the added transition.</param>
-            /// <returns>The destination state of the added transition.</returns>
-            public State AddTransition(TElement element, Weight weight, State destinationState = default(State), int group = 0)
-            {
-                return this.AddTransition(new TElementDistribution { Point = element }, weight, destinationState, group);
-            }
-
-            /// <summary>
-            /// Adds an epsilon transition to the current state.
-            /// </summary>
-            /// <param name="weight">The transition weight.</param>
-            /// <param name="destinationState">
-            /// The destination state of the added transition.
-            /// If the value of this parameter is <see langword="null"/>, a new state will be created.</param>
-            /// <param name="group">The group of the added transition.</param>
-            /// <returns>The destination state of the added transition.</returns>
-            public State AddEpsilonTransition(Weight weight, State destinationState = default(State), int group = 0)
-            {
-                return this.AddTransition(Option.None, weight, destinationState, group);
-            }
-
-            /// <summary>
-            /// Adds a transition to the current state.
-            /// </summary>
-            /// <param name="elementDistribution">
-            /// The element distribution associated with the transition.
-            /// If the value of this parameter is <see langword="null"/>, an epsilon transition will be created.
-            /// </param>
-            /// <param name="weight">The transition weight.</param>
-            /// <param name="destinationState">
-            /// The destination state of the added transition.
-            /// If the value of this parameter is <see langword="null"/>, a new state will be created.</param>
-            /// <param name="group">The group of the added transition.</param>
-            /// <returns>The destination state of the added transition.</returns>
-            public State AddTransition(Option<TElementDistribution> elementDistribution, Weight weight, State destinationState = default(State), int group = 0)
-            {
-                if (destinationState.IsNull)
-                {
-                    destinationState = this.Owner.AddState();
-                }
-                else if (!ReferenceEquals(destinationState.Owner, this.Owner))
-                {
-                    throw new ArgumentException("The given state belongs to another automaton.");
-                }
-
-                this.AddTransition(new Transition(elementDistribution, weight, destinationState.Index, group));
-                return destinationState;
-            }
-
-            /// <summary>
-            /// Adds a transition to the current state.
-            /// </summary>
-            /// <param name="transition">The transition to add.</param>
-            /// <returns>The destination state of the added transition.</returns>
-            public State AddTransition(Transition transition)
-            {
-                Argument.CheckIfValid(this.Owner == null || transition.DestinationStateIndex < this.Owner.statesData.Count, "transition", "The destination state index is not valid.");
-                
-                this.Data.AddTransition(transition);
-                if (this.Owner.isEpsilonFree == true)
-                {
-                    this.Owner.isEpsilonFree = !transition.IsEpsilon;
-                }
-
-                return this.Owner.States[transition.DestinationStateIndex];
-            }
-
-            /// <summary>
-            /// Adds a self-transition labeled with a given element to the current state.
-            /// </summary>
-            /// <param name="element">The element.</param>
-            /// <param name="weight">The transition weight.</param>
-            /// <param name="group">The group of the added transition.</param>
-            /// <returns>The current state.</returns>
-            public State AddSelfTransition(TElement element, Weight weight, int group = 0)
-            {
-                return this.AddTransition(element, weight, this, group);
-            }
-
-            /// <summary>
-            /// Adds a self-transition to the current state.
-            /// </summary>
-            /// <param name="elementDistribution">
-            /// The element distribution associated with the transition.
-            /// If the value of this parameter is <see langword="null"/>, an epsilon transition will be created.
-            /// </param>
-            /// <param name="weight">The transition weight.</param>
-            /// <param name="group">The group of the added transition.</param>
-            /// <returns>The current state.</returns>
-            public State AddSelfTransition(Option<TElementDistribution> elementDistribution, Weight weight, byte group = 0)
-            {
-                return this.AddTransition(elementDistribution, weight, this, group);
-            }
-
-            /// <summary>
-            /// Gets the transition at a specified index.
-            /// </summary>
-            /// <param name="index">The index of the transition.</param>
-            /// <returns>The transition.</returns>
-            public Transition GetTransition(int index) => this.Data.GetTransition(index);
-
-            /// <summary>
-            /// Replaces the transition at a given index with a given transition.
-            /// </summary>
-            /// <param name="index">The index of the transition to replace.</param>
-            /// <param name="updatedTransition">The transition to replace with.</param>
-            public void SetTransition(int index, Transition updatedTransition)
-            {
-                Argument.CheckIfInRange(index >= 0 && index < this.TransitionCount, "index", "An invalid transition index given.");
-                Argument.CheckIfValid(updatedTransition.DestinationStateIndex < this.Owner.statesData.Count, "updatedTransition", "The destination state index is not valid.");
-
-                if (updatedTransition.IsEpsilon)
-                {
-                    this.Owner.isEpsilonFree = false;
-                }
-                else
-                {
-                    this.Owner.isEpsilonFree = null;
-                }
-
-                this.Data.SetTransition(index, updatedTransition);
-            }
-
-            /// <summary>
-            /// Removes the transition with a given index.
-            /// </summary>
-            /// <param name="index">The index of the transition to remove.</param>
-            public void RemoveTransition(int index) => this.Data.RemoveTransition(index);
+            /// <inheritdoc/>
+            public override int GetHashCode() => this.Data.GetHashCode();
 
             /// <summary>
             /// Returns a string that represents the state.
@@ -321,14 +106,14 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
                 var sb = new StringBuilder();
 
-                bool isStartState = this.Owner != null && this.Owner.Start == this;
+                var isStartState = this.Owner != null && this.Owner.Start == this;
                 if (isStartState)
                 {
                     sb.Append(StartStateMarker);
                 }
 
-                bool firstTransition = true;
-                foreach (Transition transition in this.GetTransitions())
+                var firstTransition = true;
+                foreach (var transition in this.Transitions)
                 {
                     if (firstTransition)
                     {
@@ -342,9 +127,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     sb.Append(transition.ToString());
                 }
 
-                if (CanEnd)
+                if (this.CanEnd)
                 {
-                    if (!firstTransition) sb.Append(TransitionSeparator);
+                    if (!firstTransition)
+                    {
+                        sb.Append(TransitionSeparator);
+                    }
+
                     sb.Append(this.EndWeight.Value + " -> END");
                 }
 
@@ -352,181 +141,10 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             }
 
             /// <summary>
-            /// Computes the logarithm of the value of the automaton
-            /// having this state as the start state on a given sequence.
-            /// </summary>
-            /// <param name="sequence">The sequence.</param>
-            /// <returns>The logarithm of the value on the sequence.</returns>
-            public double GetLogValue(TSequence sequence)
-            {
-                var valueCache = new Dictionary<(int, int), Weight>();
-                return this.DoGetValue(sequence, 0, valueCache).LogValue;
-            }
-
-            /// <summary>
-            /// Gets whether the automaton having this state as the start state is zero everywhere.
-            /// </summary>
-            /// <returns>A value indicating whether the automaton having this state as the start state is zero everywhere.</returns>
-            public bool IsZero()
-            {
-                var visitedStates = new BitArray(this.Owner.States.Count, false);
-                return this.DoIsZero(visitedStates);
-            }
-
-            /// <summary>
-            /// Gets whether the automaton having this state as the start state has non-trivial loops.
-            /// </summary>
-            /// <returns>A value indicating whether the automaton having this state as the start state is zero everywhere.</returns>
-            public bool HasNonTrivialLoops()
-            {
-                return this.DoHasNonTrivialLoops(new ArrayDictionary<bool>(this.Owner.States.Count));
-            }
-
-            /// <summary>
             /// Gets the epsilon closure of this state.
             /// </summary>
             /// <returns>The epsilon closure of this state.</returns>
-            public EpsilonClosure GetEpsilonClosure()
-            {
-                return new EpsilonClosure(this);
-            }
-
-            #region Helpers
-
-            /// <summary>
-            /// Recursively checks if the automaton has non-trivial loops
-            /// (i.e. loops consisting of more than one transition).
-            /// </summary>
-            /// <param name="stateInStack">
-            /// A dictionary, storing for each state whether it has already been visited, and,
-            /// if so, whether the state still is on the traversal stack.</param>
-            /// <returns>
-            /// <see langword="true"/> if a non-trivial loop has been found,
-            /// <see langword="false"/> otherwise.
-            /// </returns>
-            private bool DoHasNonTrivialLoops(ArrayDictionary<bool> stateInStack)
-            {
-                bool inStack;
-                if (stateInStack.TryGetValue(this.Index, out inStack))
-                {
-                    return inStack;
-                }
-
-                stateInStack.Add(this.Index, true);
-
-                for (int i = 0; i < this.TransitionCount; ++i)
-                {
-                    var transition = this.GetTransition(i);
-                    if (transition.DestinationStateIndex != this.Index)
-                    {
-                        var destState = this.Owner.States[transition.DestinationStateIndex];
-                        if (destState.DoHasNonTrivialLoops(stateInStack))
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                stateInStack[this.Index] = false;
-                return false;
-            }
-
-            /// <summary>
-            /// Recursively checks if the automaton is zero.
-            /// </summary>
-            /// <param name="visitedStates">For each state stores whether it has been already visited.</param>
-            /// <returns>
-            /// <see langword="false"/> if an accepting path has been found,
-            /// <see langword="true"/> otherwise.
-            /// </returns>
-            private bool DoIsZero(BitArray visitedStates)
-            {
-                if (visitedStates[this.Index])
-                {
-                    return true;
-                }
-
-                visitedStates[this.Index] = true;
-
-                var isZero = !this.CanEnd;
-                var transitionIndex = 0;
-                while (isZero && transitionIndex < this.TransitionCount)
-                {
-                    var transition = this.GetTransition(transitionIndex);
-                    if (!transition.Weight.IsZero)
-                    {
-                        var destState = this.Owner.States[transition.DestinationStateIndex];
-                        isZero = destState.DoIsZero(visitedStates);
-                    }
-
-                    ++transitionIndex;
-                }
-
-                return isZero;
-            }
-
-            /// <summary>
-            /// Recursively computes the value of the automaton on a given sequence.
-            /// </summary>
-            /// <param name="sequence">The sequence to compute the value on.</param>
-            /// <param name="sequencePosition">The current position in the sequence.</param>
-            /// <param name="valueCache">A lookup table for memoization.</param>
-            /// <returns>The value computed from the current state.</returns>
-            private Weight DoGetValue(
-                TSequence sequence, int sequencePosition, Dictionary<(int, int), Weight> valueCache)
-            {
-                var stateIndexPair = (this.Index, sequencePosition);
-                if (valueCache.TryGetValue(stateIndexPair, out var cachedValue))
-                {
-                    return cachedValue;
-                }
-
-                var closure = this.GetEpsilonClosure();
-
-                var value = Weight.Zero;
-                var count = SequenceManipulator.GetLength(sequence);
-                var isCurrent = sequencePosition < count;
-                if (isCurrent)
-                {
-                    var element = SequenceManipulator.GetElement(sequence, sequencePosition);
-                    for (var closureStateIndex = 0; closureStateIndex < closure.Size; ++closureStateIndex)
-                    {
-                        var closureState = closure.GetStateByIndex(closureStateIndex);
-                        var closureStateWeight = closure.GetStateWeightByIndex(closureStateIndex);
-
-                        for (int transitionIndex = 0; transitionIndex < closureState.TransitionCount; transitionIndex++)
-                        {
-                            var transition = closureState.GetTransition(transitionIndex);
-                            if (transition.IsEpsilon)
-                            {
-                                continue; // The destination is a part of the closure anyway
-                            }
-
-                            var destState = this.Owner.States[transition.DestinationStateIndex];
-                            var distWeight = Weight.FromLogValue(transition.ElementDistribution.Value.GetLogProb(element));
-                            if (!distWeight.IsZero && !transition.Weight.IsZero)
-                            {
-                                var destValue = destState.DoGetValue(sequence, sequencePosition + 1, valueCache);
-                                if (!destValue.IsZero)
-                                {
-                                    value = Weight.Sum(
-                                        value,
-                                        Weight.Product(closureStateWeight, transition.Weight, distWeight, destValue));
-                                }
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    value = closure.EndWeight;
-                }
-
-                valueCache.Add(stateIndexPair, value);
-                return value;
-            }
-
-            #endregion
+            public EpsilonClosure GetEpsilonClosure() => new EpsilonClosure(this);
 
             /// <summary>
             /// Whether there are incoming transitions to this state
@@ -535,45 +153,69 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             {
                 get
                 {
-                    var this_ = this;
-                    return this.Owner.States.Any(
-                        state => state.GetTransitions().Any(
-                            transition => transition.DestinationStateIndex == this_.Index));
+                    foreach (var state in this.Owner.States)
+                    {
+                        foreach (var transition in state.Transitions)
+                        {
+                            if (transition.DestinationStateIndex == this.Index)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+
+                    return false;
                 }
             }
 
+            #region Serialization
 
-            /// <summary>
-            /// Writes the automaton state.
-            /// </summary>
-            public void Write(Action<int> writeInt32, Action<double> writeDouble, Action<TElementDistribution> writeElementDistribution)
+            public void Write(Action<double> writeDouble, Action<int> writeInt32, Action<TElementDistribution> writeElementDistribution)
             {
                 this.EndWeight.Write(writeDouble);
                 writeInt32(this.Index);
-                writeInt32(this.TransitionCount);
-                for (var i = 0; i < TransitionCount; i++)
+                writeInt32(this.Transitions.Count);
+                foreach (var transition in this.Transitions)
                 {
-                    GetTransition(i).Write(writeInt32, writeDouble, writeElementDistribution);
+                    transition.Write(writeInt32, writeDouble, writeElementDistribution);
                 }
             }
 
             /// <summary>
-            /// Reads the automaton state.
+            /// Reads state and appends it into Automaton builder. Returns index in the serialized data.
+            /// If <paramref name="checkIndex"/> is true, will throw exception if serialized index
+            /// does not match index in deserialized states array. This check is bypassed only when
+            /// start state is serialized second time.
             /// </summary>
-            public static State Read(Func<int> readInt32, Func<double> readDouble, Func<TElementDistribution> readElementDistribution)
+            public static int ReadTo(
+                ref Builder builder,
+                Func<int> readInt32,
+                Func<double> readDouble,
+                Func<TElementDistribution> readElementDistribution,
+                bool checkIndex = false)
             {
                 var endWeight = Weight.Read(readDouble);
                 // Note: index is serialized for compatibility with old binary serializations
                 var index = readInt32();
-                var transitionCount = readInt32();
-                var transitions = new Transition[transitionCount];
-                for (var i = 0; i < transitionCount; i++)
+
+                if (checkIndex && index != builder.StatesCount)
                 {
-                    transitions[i] = Transition.Read(readInt32, readDouble, readElementDistribution);
+                    throw new Exception("Index in serialized data does not match index in deserialized array");
                 }
 
-                return new State(index, transitions, endWeight);
+                var state = builder.AddState();
+                state.SetEndWeight(endWeight);
+
+                var transitionCount = readInt32();
+                for (var i = 0; i < transitionCount; i++)
+                {
+                    state.AddTransition(Transition.Read(readInt32, readDouble, readElementDistribution));
+                }
+
+                return index;
             }
+
+            #endregion
         }
     }
 }

--- a/src/Runtime/Distributions/Automata/Automaton.State.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.State.cs
@@ -11,7 +11,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System.Text;
 
     using Microsoft.ML.Probabilistic.Collections;
-    using Microsoft.ML.Probabilistic.Core.Collections;
 
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
     {

--- a/src/Runtime/Distributions/Automata/Automaton.StateCollection.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.StateCollection.cs
@@ -4,71 +4,118 @@
 
 namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
 
-    using Microsoft.ML.Probabilistic.Distributions;
-    using Microsoft.ML.Probabilistic.Math;
+    using Microsoft.ML.Probabilistic.Core.Collections;
+    using Microsoft.ML.Probabilistic.Utilities;
 
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
-        where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
-        where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
-        where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {
         /// <summary>
         /// Represents a collection of automaton states for use in public APIs
         /// </summary>
         /// <remarks>
-        /// Is a thin wrapper around Automaton.stateData. Wraps each <see cref="StateData"/> into <see cref="State"/> on demand.
+        /// Is a thin wrapper around Automaton.data. Wraps each <see cref="StateData"/> into <see cref="State"/> on demand.
         /// </remarks>
         public struct StateCollection : IReadOnlyList<State>
         {
+            /// <summary>
+            /// Cached value of this.owner.Data.states. Cached for performance.
+            /// </summary>
+            internal readonly ReadOnlyArray<StateData> states;
+
+            /// <summary>
+            /// Cached value of this.owner.Data.states. Cached for performance.
+            /// </summary>
+            internal readonly ReadOnlyArray<Transition> transitions;
+
             /// <summary>
             /// Owner automaton of all states in collection.
             /// </summary>
             private readonly Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> owner;
 
             /// <summary>
-            /// Cached value of owner.statesData. Cached for performance reasons.
-            /// </summary>
-            private readonly List<StateData> statesData;
-
-            /// <summary>
             /// Initializes instance of <see cref="StateCollection"/>.
             /// </summary>
-            internal StateCollection(Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> owner)
+            internal StateCollection(
+                Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> owner)
             {
                 this.owner = owner;
-                this.statesData = owner.statesData;
+                this.states = owner.Data.States;
+                this.transitions = owner.Data.Transitions;
             }
 
-            /// <summary>
-            /// Gets state by its index.
-            /// </summary>
-            public State this[int index] => new State(this.owner, index, this.statesData[index]);
+            #region IReadOnlyList<State> methods
+
+            /// <inheritdoc/>
+            public State this[int index] => new State(this.owner, this.states, this.transitions, index);
+
+            /// <inheritdoc/>
+            public int Count => this.states.Count;
 
             /// <summary>
-            /// Gets number of states in collection.
+            /// Returns enumerator over all states.
             /// </summary>
-            public int Count => this.statesData.Count;
+            /// <remarks>
+            /// This is value-type non-virtual version of enumerator that is used by compiler in foreach loops.
+            /// </remarks>
+            public StateEnumerator GetEnumerator() => new StateEnumerator(this);
+
+            /// <inheritdoc/>
+            IEnumerator<State> IEnumerable<State>.GetEnumerator() => new StateEnumerator(this);
+
+            /// <inheritdoc/>
+            IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+            #endregion
 
             /// <summary>
-            /// Returns enumerator over all states in collection.
+            /// Enumerator over states in <see cref="StateCollection"/>.
             /// </summary>
-            public IEnumerator<State> GetEnumerator()
+            public struct StateEnumerator : IEnumerator<State>
             {
-                var owner = this.owner;
-                return this.statesData.Select((data, index) => new State(owner, index, data)).GetEnumerator();
-            }
+                /// <summary>
+                /// Collection being enumerated.
+                /// </summary>
+                private readonly StateCollection collection;
 
-            /// <summary>
-            /// Returns enumerator over all states in collection.
-            /// </summary>
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
+                /// <summary>
+                /// Index of current state.
+                /// </summary>
+                private int index;
+
+                public StateEnumerator(StateCollection collection)
+                {
+                    this.collection = collection;
+                    this.index = -1;
+                }
+
+                /// <inheritdoc/>
+                public void Dispose()
+                {
+                }
+
+                /// <inheritdoc/>
+                public bool MoveNext()
+                {
+                    ++this.index;
+                    return this.index < this.collection.Count;
+                }
+
+                /// <inheritdoc/>
+                public State Current => this.collection[this.index];
+
+                /// <inheritdoc/>
+                object IEnumerator.Current => this.Current;
+
+                /// <inheritdoc/>
+                void IEnumerator.Reset()
+                {
+                    this.index = -1;
+                }
             }
         }
     }

--- a/src/Runtime/Distributions/Automata/Automaton.StateCollection.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.StateCollection.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System.Collections.Generic;
     using System.Linq;
 
-    using Microsoft.ML.Probabilistic.Core.Collections;
+    using Microsoft.ML.Probabilistic.Collections;
     using Microsoft.ML.Probabilistic.Utilities;
 
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>

--- a/src/Runtime/Distributions/Automata/Automaton.StateData.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.StateData.cs
@@ -5,145 +5,66 @@
 namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
     using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Runtime.Serialization;
 
-    using Microsoft.ML.Probabilistic.Distributions;
-    using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Serialization;
-    using Microsoft.ML.Probabilistic.Utilities;
 
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
-        where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
-        where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
-        where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {
         /// <summary>
-        /// Represents a state of an automaton that is stored in the Automaton.statesData. This is an internal representation
+        /// Represents a state of an automaton that is stored in the Automaton.states. This is an internal representation
         /// of the state. <see cref="State"/> struct should be used in public APIs.
         /// </summary>
         [Serializable]
         [DataContract]
-        internal class StateData
+        public struct StateData
         {
             /// <summary>
-            /// The default capacity of the <see cref="transitions"/>.
-            /// </summary>
-            private const int DefaultTransitionArrayCapacity = 1;
-
-            /// <summary>
-            /// The array of outgoing transitions.
+            /// Gets or sets index of the first transition from this state in <see cref="DataContainer.Transitions"/>
+            /// array. All transitions for the same state are stored as a contiguous block.
             /// </summary>
             /// <remarks>
-            /// We don't use <see cref="List{T}"/> here for performance reasons.
+            /// During automaton construction <see cref="Automaton{TSequence,TElement,TElementDistribution,TSequenceManipulator,TThis}.Builder"/>
+            /// stores transitions as linked-list instead of contiguous block. So, during construction
+            /// this property contains index of the head of the linked-list of transitions.
             /// </remarks>
             [DataMember]
-            private Transition[] transitions = new Transition[DefaultTransitionArrayCapacity];
+            public int FirstTransition { get; internal set; }
 
             /// <summary>
-            /// The number of outgoing transitions from the state.
+            /// Gets or sets index of the first transition in <see cref="DataContainer.Transitions"/> after
+            /// <see cref="FirstTransition"/> which does not belong to this state. All transitions for
+            /// the same state are stored as a contiguous block.
+            /// </summary>
+            /// <remarks>
+            /// During automaton construction <see cref="Automaton{TSequence,TElement,TElementDistribution,TSequenceManipulator,TThis}.Builder"/>
+            /// stores transitions as linked-list instead of contiguous block. So, during construction
+            /// this property contains index of the tail of the linked-list of transitions.
+            /// </remarks>
+            [DataMember]
+            public int LastTransition { get; internal set; }
+
+            /// <summary>
+            /// Gets or sets ending weight of the state.
             /// </summary>
             [DataMember]
-            private int transitionCount;
+            public Weight EndWeight { get; internal set; }
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="StateData"/> class.
+            /// Initializes a new instance of the <see cref="StateData"/> struct.
             /// </summary>
-            public StateData() => this.EndWeight = Weight.Zero;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="StateData"/> class.
-            /// </summary>
-            /// <param name="transitions">The outgoing transitions.</param>
-            /// <param name="endWeight">The ending weight of the state.</param>
-            [Construction("GetTransitions", "EndWeight")]
-            public StateData(IEnumerable<Transition> transitions, Weight endWeight)
-                : this()
+            [Construction("FirstTransition", "LastTransition", "EndWeight")]
+            public StateData(int firstTransition, int lastTransition, Weight endWeight)
             {
-                Argument.CheckIfNotNull(transitions, nameof(transitions));
-
+                this.FirstTransition = firstTransition;
+                this.LastTransition = lastTransition;
                 this.EndWeight = endWeight;
-
-                foreach (var transition in transitions)
-                {
-                    this.AddTransition(transition);
-                }
             }
-
-            /// <summary>
-            /// Gets or sets the ending weight of the state.
-            /// </summary>
-            [DataMember]
-            public Weight EndWeight { get; set; }
 
             /// <summary>
             /// Gets a value indicating whether the ending weight of this state is greater than zero.
             /// </summary>
-            public bool CanEnd => !this.EndWeight.IsZero;
-
-            /// <summary>
-            /// Gets the number of outgoing transitions.
-            /// </summary>
-            public int TransitionCount => this.transitionCount;
-
-            /// <summary>
-            /// Creates the copy of the array of outgoing transitions. Used by quoting.
-            /// </summary>
-            /// <returns>The copy of the array of outgoing transitions.</returns>
-            public Transition[] GetTransitions()
-            {
-                var result = new Transition[this.transitionCount];
-                Array.Copy(this.transitions, result, this.transitionCount);
-                return result;
-            }
-
-            /// <summary>
-            /// Adds a transition to the current state.
-            /// </summary>
-            /// <param name="transition">The transition to add.</param>
-            /// <returns>The destination state of the added transition.</returns>
-            public void AddTransition(Transition transition)
-            {
-                if (this.transitionCount == this.transitions.Length)
-                {
-                    var newTransitions = new Transition[this.transitionCount * 2];
-                    Array.Copy(this.transitions, newTransitions, this.transitionCount);
-                    this.transitions = newTransitions;
-                }
-
-                this.transitions[this.transitionCount++] = transition;
-            }
-
-            /// <summary>
-            /// Gets the transition at a specified index.
-            /// </summary>
-            /// <param name="index">The index of the transition.</param>
-            /// <returns>The transition.</returns>
-            public Transition GetTransition(int index)
-            {
-                Debug.Assert(index >= 0 && index < this.transitionCount, nameof(index), "An invalid transition index given.");
-                return this.transitions[index];
-            }
-
-            /// <summary>
-            /// Replaces the transition at a given index with a given transition.
-            /// </summary>
-            /// <param name="index">The index of the transition to replace.</param>
-            /// <param name="updatedTransition">The transition to replace with.</param>
-            public void SetTransition(int index, Transition updatedTransition) =>
-                this.transitions[index] = updatedTransition;
-
-            /// <summary>
-            /// Removes the transition with a given index.
-            /// </summary>
-            /// <param name="index">The index of the transition to remove.</param>
-            public void RemoveTransition(int index)
-            {
-                Argument.CheckIfInRange(index >= 0 && index < this.transitionCount, nameof(index), "An invalid transition index given.");
-                this.transitions[index] = this.transitions[--this.transitionCount];
-            }
+            internal bool CanEnd => !this.EndWeight.IsZero;
         }
     }
 }

--- a/src/Runtime/Distributions/Automata/Automaton.StronglyConnectedComponent.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.StronglyConnectedComponent.cs
@@ -9,18 +9,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System.Diagnostics;
     using System.Linq;
 
-    using Microsoft.ML.Probabilistic.Distributions;
-    using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Utilities;
 
     /// <content>
     /// Contains the class used to represent the condensation of an automaton graph.
     /// </content>
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
-        where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
-        where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
-        where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {
         /// <summary>
         /// Represents a strongly connected component of an automaton graph.
@@ -112,12 +106,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <see langword="true"/> if <paramref name="state"/> belongs to the component,
             /// <see langword="false"/> otherwise.
             /// </returns>
-            public bool HasState(State state)
-            {
-                Argument.CheckIfValid(!state.IsNull, nameof(state));
-
-                return this.GetIndexByState(state) != -1;
-            }
+            public bool HasState(State state) => this.GetIndexByState(state) != -1;
 
             /// <summary>
             /// Attempts to retrieve the index of a given state in the component.
@@ -128,7 +117,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// </returns>
             public int GetIndexByState(State state)
             {
-                Argument.CheckIfValid(!state.IsNull, nameof(state));
                 Argument.CheckIfValid(ReferenceEquals(state.Owner, this.statesInComponent[0].Owner), "state", "The given state belongs to other automaton.");
 
                 if (this.statesInComponent.Count == 1)
@@ -173,9 +161,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         // Optimize for a common case
                         State state = this.statesInComponent[0];
                         this.singleStatePairwiseWeight = Weight.Zero;
-                        for (int i = 0; i < state.TransitionCount; ++i)
+                        foreach (var transition in state.Transitions)
                         {
-                            Transition transition = state.GetTransition(i);
                             if (this.transitionFilter(transition) && transition.DestinationStateIndex == state.Index)
                             {
                                 this.singleStatePairwiseWeight = Weight.Sum(
@@ -210,9 +197,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 for (int srcStateIndexInComponent = 0; srcStateIndexInComponent < this.Size; ++srcStateIndexInComponent)
                 {
                     State state = this.statesInComponent[srcStateIndexInComponent];
-                    for (int transitionIndex = 0; transitionIndex < state.TransitionCount; ++transitionIndex)
+                    foreach (var transition in state.Transitions)
                     {
-                        Transition transition = state.GetTransition(transitionIndex);
                         State destState = state.Owner.States[transition.DestinationStateIndex];
                         int destStateIndexInComponent;
                         if (this.transitionFilter(transition) && (destStateIndexInComponent = this.GetIndexByState(destState)) != -1)

--- a/src/Runtime/Distributions/Automata/Automaton.Transition.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Transition.cs
@@ -5,23 +5,17 @@
 namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
     using System;
-    using System.Collections.Generic;
     using System.Runtime.Serialization;
     using System.Text;
 
-    using Microsoft.ML.Probabilistic.Distributions;
-    using Microsoft.ML.Probabilistic.Math;
+    using Microsoft.ML.Probabilistic.Core.Collections;
     using Microsoft.ML.Probabilistic.Serialization;
     using Microsoft.ML.Probabilistic.Utilities;
 
     /// <content>
-    /// Contains the class used to represent a transition in an automaton.
+    /// Contains the class used to represent a transition in an automaton.#
     /// </content>
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
-        where TSequence : class, IEnumerable<TElement>
-        where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
-        where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
-        where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {
         /// <summary>
         /// Represents a transition in an automaton.
@@ -154,7 +148,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 }
 
                 sb.Append('[');
-                sb.Append(this.ElementDistribution.HasValue ? "eps" : this.ElementDistribution.ToString());
+                sb.Append(this.ElementDistribution.HasValue ? this.ElementDistribution.ToString() : "eps");
                 sb.Append(']');
                 sb.Append(" " + this.Weight.Value);
                 sb.Append(" -> " + this.DestinationStateIndex);

--- a/src/Runtime/Distributions/Automata/Automaton.Transition.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Transition.cs
@@ -8,7 +8,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System.Runtime.Serialization;
     using System.Text;
 
-    using Microsoft.ML.Probabilistic.Core.Collections;
+    using Microsoft.ML.Probabilistic.Collections;
     using Microsoft.ML.Probabilistic.Serialization;
     using Microsoft.ML.Probabilistic.Utilities;
 

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -16,7 +16,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
     using Microsoft.ML.Probabilistic.Factors.Attributes;
     using Microsoft.ML.Probabilistic.Collections;
-    using Microsoft.ML.Probabilistic.Core.Collections;
     using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Utilities;
     using Microsoft.ML.Probabilistic.Serialization;

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -1945,6 +1945,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             builder.StartStateIndex = BuildEpsilonClosure(automaton.Start);
 
             this.Data = builder.GetData();
+            this.LogValueOverride = automaton.LogValueOverride;
+            this.PruneTransitionsWithLogWeightLessThan = automaton.LogValueOverride;
 
             // Recursively builds an automaton representing the epsilon closure of a given automaton.
             // Returns the state index of state representing the closure
@@ -2175,7 +2177,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             {
                 if (!double.IsInfinity(logNormalizer))
                 {
-                    this.SwapWith(PushWeights());
+                    this.Data = PushWeights();
                 }
             }
 
@@ -2183,7 +2185,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
             // Re-distributes weights of the states and transitions so that the underlying automaton becomes stochastic
             // (i.e. sum of weights of all the outgoing transitions and the ending weight is 1 for every node).
-            TThis PushWeights()
+            DataContainer PushWeights()
             {
                 var builder = Builder.FromAutomaton(noEpsilonTransitions);
                 for (int i = 0; i < builder.StatesCount; ++i)
@@ -2209,7 +2211,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     state.SetEndWeight(Weight.Product(state.EndWeight, weightToEndInv));
                 }
 
-                return builder.GetAutomaton();
+                return builder.GetData();
             }
         }
 

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+
 namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
     using System;
@@ -14,6 +16,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
     using Microsoft.ML.Probabilistic.Factors.Attributes;
     using Microsoft.ML.Probabilistic.Collections;
+    using Microsoft.ML.Probabilistic.Core.Collections;
     using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Utilities;
     using Microsoft.ML.Probabilistic.Serialization;
@@ -51,14 +54,25 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     /// <typeparam name="TSequenceManipulator">The type providing ways to manipulate sequences.</typeparam>
     /// <typeparam name="TThis">The type of a concrete automaton class.</typeparam>
     [Quality(QualityBand.Experimental)]
+    [DataContract]
     [Serializable]
-    public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> : ISerializable
+    public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
         where TSequence : class, IEnumerable<TElement>
         where TElementDistribution : IDistribution<TElement>, SettableToProduct<TElementDistribution>, SettableToWeightedSumExact<TElementDistribution>, CanGetLogAverageOf<TElementDistribution>, SettableToPartialUniform<TElementDistribution>, new()
         where TSequenceManipulator : ISequenceManipulator<TSequence, TElement>, new()
         where TThis : Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>, new()
     {
         #region Fields & constants
+
+        /// <summary>
+        /// Cached states representation of states for zero automaton.
+        /// </summary>
+        private static readonly ReadOnlyArray<StateData> ZeroStates = new[] { new StateData(0, 0, Weight.Zero) };
+
+        /// <summary>
+        /// Cached states representation of transitions for zero automaton.
+        /// </summary>
+        private static readonly ReadOnlyArray<Transition> ZeroTransitions = new Transition[] { };
 
         /// <summary>
         /// The maximum number of states an automaton can have.
@@ -82,27 +96,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </summary>
         private static int maxDeadStateCount = 0;
 
-        //// When adding a new field, make sure to update the SwapWith() function implementation
-
-        /// <summary>
-        /// The collection of states.
-        /// </summary>
-        [DataMember]
-        private List<StateData> statesData = new List<StateData>();
-
-        /// <summary>
-        /// The start state.
-        /// </summary>
-        [DataMember]
-        private int startStateIndex;
-
-        /// <summary>
-        /// Whether the automaton is free of epsilon transition.
-        /// If the value of this field is null, it means that the presence of epsilon transitions is unknown.
-        /// </summary>
-        [DataMember]
-        private bool? isEpsilonFree; // TODO: Isn't it always known?
-
         #endregion
 
         #region Constructors
@@ -122,6 +115,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         #region Properties
 
         /// <summary>
+        /// Immutable container for automaton data - states and transitions.
+        /// </summary>
+        [DataMember]
+        public DataContainer Data { get; protected set; }
+
+        /// <summary>
         /// Gets the sequence manipulator.
         /// </summary>
         public static TSequenceManipulator SequenceManipulator { get; } =
@@ -135,12 +134,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// This should only be set non-null if this distribution is improper and there is 
         /// a need to override the actual automaton value. 
         /// </remarks>
-        [DataMember]
-        public double? LogValueOverride
-        {
-            get;
-            set;
-        }
+        public double? LogValueOverride { get; set; }
 
         /// <summary>
         /// Gets or sets a value for truncating small weights.
@@ -150,12 +144,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <remarks>
         /// TODO: We need to develop more elegant automaton approximation methods, this is a simple placeholder for those.
         /// </remarks>
-        [DataMember]
-        public double? PruneTransitionsWithLogWeightLessThan
-        {
-            get;
-            set;
-        }
+        public double? PruneTransitionsWithLogWeightLessThan { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of states an automaton can have.
@@ -207,22 +196,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public StateCollection States => new StateCollection(this);
 
         /// <summary>
-        /// Gets or sets the start state of the automaton.
+        /// Gets the start state of the automaton.
         /// </summary>
         /// <remarks>
         /// Only a state from <see cref="States"/> can be specified as the value of this property. 
         /// </remarks>
-        public State Start
-        {
-            get => new State(this, this.startStateIndex, this.statesData[this.startStateIndex]);
-
-            set
-            {
-                Argument.CheckIfValid(!value.IsNull, nameof(value));
-                Argument.CheckIfValid(ReferenceEquals(value.Owner, this), nameof(value), "The given state does not belong to this automaton.");
-                this.startStateIndex = value.Index;
-            }
-        }
+        public State Start => this.States[this.Data.StartStateIndex];
 
         #endregion
 
@@ -232,35 +211,26 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// Creates an automaton from a given array of states and a start state.
         /// Used by quoting to embed automata in the generated inference code.
         /// </summary>
-        /// <remarks>
-        /// Only the index of the <paramref name="startState"/> will be used to determine the start state,
-        /// not the object itself.
-        /// </remarks>
-        /// <param name="states">The array of states.</param>
-        /// <param name="startState">The start state.</param>
-        /// <returns>The created automaton.</returns>
-        [Construction("GetStates", "Start")]
-        public static TThis FromStates(IEnumerable<State> states, State startState)
+        /// <param name="data">Quoted automaton state.</param>
+        /// <returns>
+        /// The created automaton.
+        /// </returns>
+        [Construction("Data")]
+        public static TThis FromData(DataContainer data)
         {
-            Argument.CheckIfNotNull(states, nameof(states));
-            Argument.CheckIfValid(!startState.IsNull, nameof(startState));
+            if (!data.IsConsistent())
+            {
+                throw new ArgumentException("Quoted data is not consistent");
+            }
 
-            CheckStateConsistency(states, startState);
-
-            var result = new TThis();
-            result.SetStates(states.Select(state => state.Data), startState.Index);
-            return result;
+            return new TThis { Data = data };
         }
 
         /// <summary>
         /// Creates an automaton which maps every sequence to zero.
         /// </summary>
         /// <returns>The created automaton.</returns>
-        public static TThis Zero()
-        {
-            var result = new TThis();
-            return result;
-        }
+        public static TThis Zero() => new TThis();
 
         /// <summary>
         /// Creates an automaton which maps every sequence to a given value.
@@ -338,17 +308,17 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <returns>The created automaton.</returns>
         public static TThis ConstantOnElementLog(double logValue, TElementDistribution allowedElements)
         {
-            Argument.CheckIfNotNull(allowedElements, "allowedElements");
+            Argument.CheckIfNotNull(allowedElements, nameof(allowedElements));
 
-            TThis result = Zero();
+            var result = Builder.Zero();
             if (!double.IsNegativeInfinity(logValue))
             {
                 allowedElements = Distribution.CreatePartialUniform(allowedElements);
-                State finish = result.Start.AddTransition(allowedElements, Weight.FromLogValue(-allowedElements.GetLogAverageOf(allowedElements)));
+                var finish = result.Start.AddTransition(allowedElements, Weight.FromLogValue(-allowedElements.GetLogAverageOf(allowedElements)));
                 finish.SetEndWeight(Weight.FromLogValue(logValue));
             }
 
-            return result;
+            return result.GetAutomaton();
         }
 
         /// <summary>
@@ -359,7 +329,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <returns>The created automaton.</returns>
         public static TThis ConstantOnLog(double logValue, TSequence sequence)
         {
-            Argument.CheckIfNotNull(sequence, "sequence");
+            Argument.CheckIfNotNull(sequence, nameof(sequence));
             return ConstantOnLog(logValue, new[] { sequence });
         }
 
@@ -392,17 +362,17 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         {
             Argument.CheckIfNotNull(sequences, "sequences");
 
-            TThis result = Zero();
+            var result = Builder.Zero();
             if (!double.IsNegativeInfinity(logValue))
             {
-                foreach (TSequence sequence in sequences)
+                foreach (var sequence in sequences)
                 {
-                    State sequenceEndState = result.Start.AddTransitionsForSequence(sequence);
+                    var sequenceEndState = result.Start.AddTransitionsForSequence(sequence);
                     sequenceEndState.SetEndWeight(Weight.FromLogValue(logValue));
                 }
             }
 
-            return result;
+            return result.GetAutomaton();
         }
 
         /// <summary>
@@ -467,9 +437,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 throw new NotImplementedException("Negative values are not yet supported.");
             }
 
-            TThis result = Zero();
+            var result = Builder.Zero();
             result.Start.SetEndWeight(Weight.FromLogValue(Math.Log(value)));
-            return result;
+            return result.GetAutomaton();
         }
 
         /// <summary>
@@ -564,20 +534,20 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         {
             Argument.CheckIfNotNull(automata, "automata");
 
-            TThis result = Zero();
-            foreach (TThis automaton in automata)
+            var result = Builder.Zero();
+            foreach (var automaton in automata)
             {
                 if (automaton.IsCanonicZero())
                 {
                     continue;
                 }
 
-                int index = result.statesData.Count;
-                result.AddStates(automaton.statesData);
-                result.Start.AddEpsilonTransition(Weight.One, result.States[index + automaton.Start.Index]);
+                int index = result.StatesCount;
+                result.AddStates(automaton.States);
+                result.Start.AddEpsilonTransition(Weight.One, index + automaton.Start.Index);
             }
 
-            return result;
+            return result.GetAutomaton();
         }
 
         /// <summary>
@@ -661,23 +631,24 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             }
 
             int maxTimes = nonZeroRepetitionWeights[nonZeroRepetitionWeights.Count - 1].Index;
-            TThis result = ConstantOn(1.0, SequenceManipulator.ToSequence(new TElement[0]));
+            var result = Builder.ConstantOn(Weight.One, SequenceManipulator.ToSequence(new TElement[0]));
 
             // Build a list of all intermediate end states with their target ending weights while adding repetitions
-            var endStatesWithTargetWeights = new List<(State, Weight)>();
+            var endStatesWithTargetWeights = new List<(int, Weight)>();
             int prevStateCount = 0;
             for (int i = 0; i <= maxTimes; ++i)
             {
                 // Remember added ending states
                 if (repetitionNumberWeights[i] > 0)
                 {
-                    for (int j = prevStateCount; j < result.statesData.Count; ++j)
+                    for (int j = prevStateCount; j < result.StatesCount; ++j)
                     {
-                        if (result.statesData[j].CanEnd)
+                        var state = result[j];
+                        if (state.CanEnd)
                         {
                             endStatesWithTargetWeights.Add(ValueTuple.Create(
-                                result.States[j],
-                                Weight.Product(Weight.FromValue(repetitionNumberWeights[i]), result.statesData[j].EndWeight)));
+                                state.Index,
+                                Weight.Product(Weight.FromValue(repetitionNumberWeights[i]), state.EndWeight)));
                         }
                     }
                 }
@@ -685,19 +656,19 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 // Add one more repetition
                 if (i != maxTimes)
                 {
-                    prevStateCount = result.statesData.Count;
-                    result.AppendInPlaceNoOptimizations(automaton);
+                    prevStateCount = result.StatesCount;
+                    result.Append(automaton, avoidEpsilonTransitions: false);
                 }
             }
 
             // Set target ending weights
             for (int i = 0; i < endStatesWithTargetWeights.Count; ++i)
             {
-                var (state, weight) = endStatesWithTargetWeights[i];
-                state.SetEndWeight(weight);
+                var (stateIndex, weight) = endStatesWithTargetWeights[i];
+                result[stateIndex].SetEndWeight(weight);
             }
 
-            return result;
+            return result.GetAutomaton();
         }
 
         /// <summary>
@@ -733,24 +704,25 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
             TSequence emptySequence = SequenceManipulator.ToSequence(new TElement[0]);
 
-            TThis result = ConstantOn(1.0, emptySequence);
+            var result = Builder.ConstantOn(Weight.One, emptySequence);
             for (int i = 0; i < minTimes; ++i)
             {
-                result.AppendInPlace(automaton);
+                result.Append(automaton);
             }
 
-            TThis optionalPart = automaton.Clone();
-            for (int i = 0; i < optionalPart.statesData.Count; ++i)
+            var optionalPart = Builder.FromAutomaton(automaton);
+            for (var i = 0; i < optionalPart.StatesCount; ++i)
             {
-                if (optionalPart.statesData[i].CanEnd)
+                var state = optionalPart[i];
+                if (state.CanEnd)
                 {
-                    optionalPart.States[i].AddEpsilonTransition(optionalPart.States[i].EndWeight, optionalPart.Start);
+                    state.AddEpsilonTransition(state.EndWeight, optionalPart.StartStateIndex);
                 }
             }
 
-            result.AppendInPlace(Sum(optionalPart, ConstantOn(1.0, emptySequence)));
+            result.Append(Sum(optionalPart.GetAutomaton(), ConstantOn(1.0, emptySequence)));
 
-            return result;
+            return result.GetAutomaton();
         }
 
         #endregion
@@ -823,12 +795,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <returns>True if it the automaton has this group, false otherwise.</returns>
         public bool HasGroup(int group)
         {
-            for (int stateIndex = 0; stateIndex < this.statesData.Count; stateIndex++)
+            for (int stateIndex = 0; stateIndex < this.States.Count; stateIndex++)
             {
-                var state = this.statesData[stateIndex];
-                for (int transitionIndex = 0; transitionIndex < state.TransitionCount; transitionIndex++)
+                var state = this.States[stateIndex];
+                foreach (var transition in state.Transitions)
                 {
-                    Transition transition = state.GetTransition(transitionIndex);
                     if (transition.Group == group)
                     {
                         return true;
@@ -845,12 +816,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <returns>True if it the automaton has groups, false otherwise.</returns>
         public bool UsesGroups()
         {
-            for (int stateIndex = 0; stateIndex < this.statesData.Count; stateIndex++)
+            for (int stateIndex = 0; stateIndex < this.States.Count; stateIndex++)
             {
-                var state = this.statesData[stateIndex];
-                for (int transitionIndex = 0; transitionIndex < state.TransitionCount; transitionIndex++)
+                var state = this.States[stateIndex];
+                foreach (var transition in state.Transitions)
                 {
-                    Transition transition = state.GetTransition(transitionIndex);
                     if (transition.Group != 0)
                     {
                         return true;
@@ -877,16 +847,18 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="group">The specified group.</param>
         public void SetGroup(int group)
         {
-            for (int stateIndex = 0; stateIndex < this.statesData.Count; stateIndex++)
+            var builder = Builder.FromAutomaton(this);
+            for (var i = 0; i < builder.StatesCount; ++i)
             {
-                var state = this.statesData[stateIndex];
-                for (int transitionIndex = 0; transitionIndex < state.TransitionCount; transitionIndex++)
+                for (var iterator = builder[i].TransitionIterator; iterator.Ok; iterator.Next())
                 {
-                    Transition transition = state.GetTransition(transitionIndex);
+                    var transition = iterator.Value;
                     transition.Group = group;
-                    state.SetTransition(transitionIndex, transition);
+                    iterator.Value = transition;
                 }
             }
+
+            this.Data = builder.GetData();
         }
 
         #endregion
@@ -960,7 +932,39 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </remarks>
         public bool IsZero()
         {
-            return this.IsCanonicZero() || this.Start.IsZero();
+            if (this.IsCanonicZero())
+            {
+                return true;
+            }
+
+            var visitedStates = new BitArray(this.States.Count, false);
+            return DoIsZero(this.Start.Index);
+
+            bool DoIsZero(int stateIndex)
+            {
+                if (visitedStates[stateIndex])
+                {
+                    return true;
+                }
+
+                visitedStates[stateIndex] = true;
+
+                var state = this.States[stateIndex];
+                var isZero = !state.CanEnd;
+                var transitionIndex = 0;
+                while (isZero && transitionIndex < state.Transitions.Count)
+                {
+                    var transition = state.Transitions[transitionIndex];
+                    if (!transition.Weight.IsZero)
+                    {
+                        isZero = DoIsZero(transition.DestinationStateIndex);
+                    }
+
+                    ++transitionIndex;
+                }
+
+                return isZero;
+            }
         }
 
         /// <summary>
@@ -977,7 +981,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </remarks>
         public bool IsCanonicZero()
         {
-            return this.Start.TransitionCount == 0 && this.Start.EndWeight.IsZero;
+            return this.Start.Transitions.Count == 0 && this.Start.EndWeight.IsZero;
         }
 
         /// <summary>
@@ -993,25 +997,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </remarks>
         public bool IsCanonicConstant()
         {
-            if (this.statesData.Count != 1 || this.Start.TransitionCount != 1 || !this.Start.CanEnd)
+            if (this.States.Count != 1 || this.Start.Transitions.Count != 1 || !this.Start.CanEnd)
             {
                 return false;
             }
 
-            var transitionDistribution = this.Start.GetTransition(0).ElementDistribution;
+            var transitionDistribution = this.Start.Transitions[0].ElementDistribution;
             return transitionDistribution.HasValue && transitionDistribution.Value.IsUniform();
-        }
-
-        /// <summary>
-        /// Checks whether the automaton has non-trivial loops (i.e. loops consisting of more than one edge).
-        /// </summary>
-        /// <returns>
-        /// <see langword="true"/> if the automaton has non-trivial loops,
-        /// <see langword="false"/> otherwise.
-        /// </returns>
-        public bool HasNonTrivialLoops()
-        {
-            return this.Start.HasNonTrivialLoops();
         }
 
         /// <summary>
@@ -1048,25 +1040,26 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 return;
             }
 
-            TThis result = automaton.Clone();
-            if (!result.TryDeterminize())
+            var determinizedAutomaton = automaton.Clone();
+            if (!determinizedAutomaton.TryDeterminize())
             {
                 throw new NotImplementedException("Not yet supported for non-determinizable automata.");
             }
 
-            for (int stateId = 0; stateId < result.States.Count; ++stateId)
+            var result = Builder.FromAutomaton(determinizedAutomaton);
+
+            for (int stateId = 0; stateId < result.StatesCount; ++stateId)
             {
-                var state = result.States[stateId];
+                var state = result[stateId];
                 if (state.CanEnd)
                 {
                     // Make all accepting states contibute the desired value to the result
                     state.SetEndWeight(value);
                 }
 
-                for (int transitionIndex = 0; transitionIndex < state.TransitionCount; ++transitionIndex)
+                for (var transitionIterator = state.TransitionIterator; transitionIterator.Ok; transitionIterator.Next())
                 {
-                    // Make all non-zero transition weights unit
-                    var transition = state.GetTransition(transitionIndex);
+                    var transition = transitionIterator.Value;
                     if (!transition.Weight.IsZero)
                     {
                         if (transition.IsEpsilon)
@@ -1079,12 +1072,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                             transition.Weight = Weight.FromLogValue(-transition.ElementDistribution.Value.GetLogAverageOf(transition.ElementDistribution.Value));
                         }
 
-                        state.SetTransition(transitionIndex, transition);
+                        transitionIterator.Value = transition;
                     }
                 }
             }
 
-            this.SwapWith(result);
+            this.Data = result.GetData();
         }
 
         /// <summary>
@@ -1105,36 +1098,35 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <returns>The created automaton.</returns>
         public TThis Reverse()
         {
-            var result = Zero();
+            var result = Builder.Zero();
 
             // Result already has 1 state, we add the remaining Count-1 states
-            result.AddStates(this.statesData.Count - 1);
+            result.AddStates(this.States.Count - 1);
 
             // And the new start state
-            result.Start = result.AddState();
+            result.StartStateIndex = result.AddState().Index;
 
             // The start state in the original automaton is going to be the one and only end state in result
-            result.States[this.Start.Index].SetEndWeight(Weight.One);
+            result[this.Start.Index].SetEndWeight(Weight.One);
 
-            for (int i = 0; i < this.statesData.Count; ++i)
+            for (int i = 0; i < this.States.Count; ++i)
             {
-                var oldState = this.statesData[i];
-                for (int j = 0; j < this.statesData[i].TransitionCount; ++j)
+                var oldState = this.States[i];
+                foreach (var oldTransition in oldState.Transitions)
                 {
                     // Result has original transitions reversed
-                    var oldTransition = oldState.GetTransition(j);
-                    result.States[oldTransition.DestinationStateIndex].AddTransition(
-                        oldTransition.ElementDistribution, oldTransition.Weight, result.States[i]);
+                    result[oldTransition.DestinationStateIndex].AddTransition(
+                        oldTransition.ElementDistribution, oldTransition.Weight, i);
                 }
 
                 // End states of the original automaton are the new start states
                 if (oldState.CanEnd)
                 {
-                    result.Start.AddEpsilonTransition(oldState.EndWeight, result.States[i]);
+                    result.Start.AddEpsilonTransition(oldState.EndWeight, i);
                 }
             }
 
-            return result;
+            return result.GetAutomaton();
         }
 
         /// <summary>
@@ -1197,58 +1189,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 return;
             }
 
-            if (ReferenceEquals(automaton, this))
-            {
-                automaton = automaton.Clone();
-            }
-
-            // Append the states of the second automaton
-            var endStates = this.States.Where(nd => nd.CanEnd).ToList();
-            int stateCount = this.statesData.Count;
-
-            this.AddStates(automaton.statesData, group);
-            var secondStartState = this.States[stateCount + automaton.Start.Index];
-
-            // todo: make efficient
-            bool startIncoming = automaton.Start.HasIncomingTransitions;
-            if (!startIncoming || endStates.All(endState => (endState.TransitionCount == 0)))
-            {
-                foreach (var endState in endStates)
-                {
-                    for (int transitionIndex = 0; transitionIndex < secondStartState.TransitionCount; transitionIndex++)
-                    {
-                        var transition = secondStartState.GetTransition(transitionIndex);
-
-                        if (group != 0)
-                        {
-                            transition.Group = group;
-                        }
-
-                        if (transition.DestinationStateIndex == secondStartState.Index)
-                        {
-                            transition.DestinationStateIndex = endState.Index;
-                        }
-                        else
-                        {
-                            transition.Weight = Weight.Product(transition.Weight, endState.EndWeight);
-                        }
-
-                        endState.Data.AddTransition(transition);
-                    }
-
-                    endState.SetEndWeight(Weight.Product(endState.EndWeight, secondStartState.EndWeight));
-                }
-
-                this.RemoveState(secondStartState.Index);
-                return;
-            }
-
-            for (int i = 0; i < endStates.Count; i++)
-            {
-                State state = endStates[i];
-                state.AddEpsilonTransition(state.EndWeight, secondStartState, group);
-                state.SetEndWeight(Weight.Zero);
-            }
+            var builder = Builder.FromAutomaton(this);
+            builder.Append(automaton, group);
+            this.Data = builder.GetData();
         }
 
         /// <summary>
@@ -1287,45 +1230,106 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             Argument.CheckIfNotNull(automaton1, "automaton1");
             Argument.CheckIfNotNull(automaton2, "automaton2");
 
-            TThis result = Zero();
-            if (!automaton1.IsCanonicZero() && !automaton2.IsCanonicZero())
+            if (automaton1.IsCanonicZero() || automaton2.IsCanonicZero())
             {
-                if (automaton1.UsesGroups())
+                this.SetToZero();
+                return;
+            }
+
+            if (automaton1.UsesGroups())
+            {
+                // We cannot swap automaton 1 and automaton 2 as groups from first are used.
+                if (!automaton2.IsEpsilonFree)
                 {
-                    // We cannot swap automaton 1 and automaton 2 as groups from first are used.
-                    if (!automaton2.IsEpsilonFree)
-                    {
-                        automaton2.MakeEpsilonFree();
-                    }
+                    automaton2.MakeEpsilonFree();
                 }
-                else
+            }
+            else
+            {
+                // The second argument of BuildProduct must be epsilon-free
+                if (!automaton1.IsEpsilonFree && !automaton2.IsEpsilonFree)
                 {
-                    // The second argument of BuildProduct must be epsilon-free
-                    if (!automaton1.IsEpsilonFree && !automaton2.IsEpsilonFree)
-                    {
-                        automaton2.MakeEpsilonFree();
-                    }
-                    else if (automaton1.IsEpsilonFree && !automaton2.IsEpsilonFree)
-                    {
-                        Util.Swap(ref automaton1, ref automaton2);
-                    }
+                    automaton2.MakeEpsilonFree();
                 }
-
-                var stateCache = new Dictionary<(int, int), State>(automaton1.States.Count + automaton2.States.Count);
-                result.Start = result.BuildProduct(automaton1.Start, automaton2.Start, stateCache);
-
-                result.RemoveDeadStates(); // Product can potentially create dead states
-                result.PruneTransitionsWithLogWeightLessThan = this.MergePruningWeights(automaton1, automaton2);
-                result.SimplifyIfNeeded();
-                result.LogValueOverride = this.MergeLogValueOverrides(automaton1, automaton2);
-
-                if (this is StringAutomaton && tryDeterminize)
+                else if (automaton1.IsEpsilonFree && !automaton2.IsEpsilonFree)
                 {
-                    result.TryDeterminize();
+                    Util.Swap(ref automaton1, ref automaton2);
                 }
             }
 
-            this.SwapWith(result);
+            var builder = new Builder();
+            var productStateCache = new Dictionary<(int, int), int>(automaton1.States.Count + automaton2.States.Count);
+            builder.StartStateIndex = BuildProduct(automaton1.Start, automaton2.Start);
+
+            var simplification = new Simplification(builder, this.PruneTransitionsWithLogWeightLessThan);
+            simplification.RemoveDeadStates(); // Product can potentially create dead states
+            simplification.SimplifyIfNeeded();
+
+            this.Data = builder.GetData();
+            if (this is StringAutomaton && tryDeterminize)
+            {
+                this.TryDeterminize();
+            }
+
+            // Recursively builds an automaton representing the product of two given automata.
+            // Returns start state of product automaton.
+            int BuildProduct(State state1, State state2)
+            {
+                Debug.Assert(state1 != null && state2 != null, "Valid states must be provided.");
+                Debug.Assert(
+                    state2.Owner.IsEpsilonFree,
+                    "The second argument of the product operation must be epsilon-free.");
+
+                // State already exists, return its index
+                var statePair = (state1.Index, state2.Index);
+                if (productStateCache.TryGetValue(statePair, out var productStateIndex))
+                {
+                    return productStateIndex;
+                }
+
+                // Create a new state
+                var productState = builder.AddState();
+                productStateCache.Add(statePair, productState.Index);
+
+                // Iterate over transitions in state1
+                foreach (var transition1 in state1.Transitions)
+                {
+                    var destState1 = state1.Owner.States[transition1.DestinationStateIndex];
+
+                    if (transition1.IsEpsilon)
+                    {
+                        // Epsilon transition case
+                        var destProductStateIndex = BuildProduct(destState1, state2);
+                        productState.AddEpsilonTransition(transition1.Weight, destProductStateIndex, transition1.Group);
+                        continue;
+                    }
+
+                    // Iterate over transitions in state2
+                    foreach (var transition2 in state2.Transitions)
+                    {
+                        Debug.Assert(
+                            !transition2.IsEpsilon,
+                            "The second argument of the product operation must be epsilon-free.");
+                        var destState2 = state2.Owner.States[transition2.DestinationStateIndex];
+                        var productLogNormalizer = Distribution<TElement>.GetLogAverageOf(
+                            transition1.ElementDistribution.Value, transition2.ElementDistribution.Value, out var product);
+                        if (double.IsNegativeInfinity(productLogNormalizer))
+                        {
+                            continue;
+                        }
+
+                        var productWeight = Weight.Product(
+                            transition1.Weight,
+                            transition2.Weight,
+                            Weight.FromLogValue(productLogNormalizer));
+                        var destProductStateIndex = BuildProduct(destState1, destState2);
+                        productState.AddTransition(product, productWeight, destProductStateIndex, transition1.Group);
+                    }
+                }
+
+                productState.SetEndWeight(Weight.Product(state1.EndWeight, state2.EndWeight));
+                return productState.Index;
+            }
         }
 
         /// <summary>
@@ -1430,7 +1434,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 !double.IsPositiveInfinity(logWeight1) && !double.IsPositiveInfinity(logWeight2),
                 "Weights must not be infinite.");
 
-            TThis result = Zero();
+            var result = Builder.Zero();
 
             bool hasFirstTerm = !automaton1.IsCanonicZero() && !double.IsNegativeInfinity(logWeight1);
             bool hasSecondTerm = !automaton2.IsCanonicZero() && !double.IsNegativeInfinity(logWeight2);
@@ -1438,20 +1442,22 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             {
                 if (hasFirstTerm)
                 {
-                    result.AddStates(automaton1.statesData);
-                    result.Start.AddEpsilonTransition(Weight.FromLogValue(logWeight1), result.States[1 + automaton1.Start.Index]);
+                    result.AddStates(automaton1.States);
+                    result.Start.AddEpsilonTransition(Weight.FromLogValue(logWeight1), 1 + automaton1.Start.Index);
                 }
 
                 if (hasSecondTerm)
                 {
-                    int cnt = result.statesData.Count;
-                    result.AddStates(automaton2.statesData);
-                    result.Start.AddEpsilonTransition(Weight.FromLogValue(logWeight2), result.States[cnt + automaton2.Start.Index]);
+                    int cnt = result.StatesCount;
+                    result.AddStates(automaton2.States);
+                    result.Start.AddEpsilonTransition(Weight.FromLogValue(logWeight2), cnt + automaton2.Start.Index);
                 }
             }
 
-            result.SimplifyIfNeeded();
-            this.SwapWith(result);
+            var simplification = new Simplification(result, this.PruneTransitionsWithLogWeightLessThan);
+            simplification.SimplifyIfNeeded();
+
+            this.Data = result.GetData();
         }
 
         /// <summary>
@@ -1512,9 +1518,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </summary>
         public void SetToZero()
         {
-            this.statesData.Clear();
-            this.startStateIndex = this.AddState().Index;
-            this.isEpsilonFree = true;
+            this.Data = new DataContainer(0, true, ZeroStates, ZeroTransitions);
         }
 
         /// <summary>
@@ -1564,12 +1568,14 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             Argument.CheckIfNotNull(allowedElements, "allowedElements");
 
             allowedElements = Distribution.CreatePartialUniform(allowedElements);
-            this.SetToZero();
+            var builder = Builder.Zero();
             if (!double.IsNegativeInfinity(logValue))
             {
-                this.Start.SetEndWeight(Weight.FromLogValue(logValue));
-                this.Start.AddTransition(allowedElements, Weight.FromLogValue(-allowedElements.GetLogAverageOf(allowedElements)), this.Start);
+                builder.Start.SetEndWeight(Weight.FromLogValue(logValue));
+                builder.Start.AddTransition(allowedElements, Weight.FromLogValue(-allowedElements.GetLogAverageOf(allowedElements)), builder.StartStateIndex);
             }
+
+            this.Data = builder.GetData();
         }
 
         /// <summary>
@@ -1580,13 +1586,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         {
             Argument.CheckIfNotNull(automaton, "automaton");
 
-            if (!ReferenceEquals(this, automaton))
-            {
-                this.SetStates(automaton.statesData, automaton.Start.Index);
-                this.isEpsilonFree = automaton.isEpsilonFree;
-                this.LogValueOverride = automaton.LogValueOverride;
-                this.PruneTransitionsWithLogWeightLessThan = automaton.PruneTransitionsWithLogWeightLessThan;
-            }
+            this.Data = automaton.Data;
+            this.LogValueOverride = automaton.LogValueOverride;
+            this.PruneTransitionsWithLogWeightLessThan = automaton.PruneTransitionsWithLogWeightLessThan;
         }
 
         /// <summary>
@@ -1602,7 +1604,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="transitionTransform">The transition transformation.</param>
         public void SetToFunction<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton>(
             Automaton<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton> sourceAutomaton,
-            Func<Option<TSrcElementDistribution>, Weight, int, Tuple<Option<TElementDistribution>, Weight>> transitionTransform)
+            Func<Option<TSrcElementDistribution>, Weight, int, ValueTuple<Option<TElementDistribution>, Weight>> transitionTransform)
             where TSrcElementDistribution : IDistribution<TSrcElement>, CanGetLogAverageOf<TSrcElementDistribution>, SettableToProduct<TSrcElementDistribution>, SettableToWeightedSumExact<TSrcElementDistribution>, SettableToPartialUniform<TSrcElementDistribution>, new()
             where TSrcSequence : class, IEnumerable<TSrcElement>
             where TSrcSequenceManipulator : ISequenceManipulator<TSrcSequence, TSrcElement>, new()
@@ -1611,33 +1613,35 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             Argument.CheckIfNotNull(sourceAutomaton, "sourceAutomaton");
             Argument.CheckIfNotNull(transitionTransform, "transitionTransform");
 
+            var builder = Builder.Zero();
+
             // Add states
-            this.SetToZero();
-            this.AddStates(sourceAutomaton.statesData.Count - 1);
+            builder.AddStates(sourceAutomaton.States.Count - 1);
 
             // Copy state parameters and transitions
-            for (int stateIndex = 0; stateIndex < sourceAutomaton.statesData.Count; stateIndex++)
+            for (int stateIndex = 0; stateIndex < sourceAutomaton.States.Count; stateIndex++)
             {
-                var thisState = this.States[stateIndex];
+                var thisState = builder[stateIndex];
                 var otherState = sourceAutomaton.States[stateIndex];
 
                 thisState.SetEndWeight(otherState.EndWeight);
                 if (otherState == sourceAutomaton.Start)
                 {
-                    this.Start = thisState;
+                    builder.StartStateIndex = thisState.Index;
                 }
 
-                for (int transitionIndex = 0; transitionIndex < otherState.TransitionCount; transitionIndex++)
+                foreach (var otherTransition in otherState.Transitions)
                 {
-                    var otherTransition = otherState.GetTransition(transitionIndex);
                     var transformedTransition = transitionTransform(otherTransition.ElementDistribution, otherTransition.Weight, otherTransition.Group);
-                    this.States[stateIndex].AddTransition(
+                    builder[stateIndex].AddTransition(
                         transformedTransition.Item1,
                         transformedTransition.Item2,
-                        this.States[otherTransition.DestinationStateIndex],
+                        otherTransition.DestinationStateIndex,
                         otherTransition.Group);
                 }
             }
+
+            this.Data = builder.GetData();
         }
 
         /// <summary>
@@ -1648,13 +1652,66 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public double GetLogValue(TSequence sequence)
         {
             Argument.CheckIfNotNull(sequence, "sequence");
-            var value = this.Start.GetLogValue(sequence);
-            if (!double.IsNegativeInfinity(value) && this.LogValueOverride.HasValue)
-            {
-                return this.LogValueOverride.Value;
-            }
+            var valueCache = new Dictionary<(int, int), Weight>();
+            var logValue = DoGetValue(this.Start.Index, 0).LogValue;
 
-            return value;
+            return
+                !double.IsNegativeInfinity(logValue) && this.LogValueOverride.HasValue
+                    ? this.LogValueOverride.Value
+                    : logValue;
+
+            Weight DoGetValue(int stateIndex, int sequencePosition)
+            {
+                var state = this.States[stateIndex];
+                var stateIndexPair = (stateIndex, sequencePosition);
+                if (valueCache.TryGetValue(stateIndexPair, out var cachedValue))
+                {
+                    return cachedValue;
+                }
+
+                var closure = state.GetEpsilonClosure();
+
+                var value = Weight.Zero;
+                var count = SequenceManipulator.GetLength(sequence);
+                var isCurrent = sequencePosition < count;
+                if (isCurrent)
+                {
+                    var element = SequenceManipulator.GetElement(sequence, sequencePosition);
+                    for (var closureStateIndex = 0; closureStateIndex < closure.Size; ++closureStateIndex)
+                    {
+                        var closureState = closure.GetStateByIndex(closureStateIndex);
+                        var closureStateWeight = closure.GetStateWeightByIndex(closureStateIndex);
+
+                        foreach (var transition in closureState.Transitions)
+                        {
+                            if (transition.IsEpsilon)
+                            {
+                                continue; // The destination is a part of the closure anyway
+                            }
+
+                            var destState = this.States[transition.DestinationStateIndex];
+                            var distWeight = Weight.FromLogValue(transition.ElementDistribution.Value.GetLogProb(element));
+                            if (!distWeight.IsZero && !transition.Weight.IsZero)
+                            {
+                                var destValue = DoGetValue(destState.Index, sequencePosition + 1);
+                                if (!destValue.IsZero)
+                                {
+                                    value = Weight.Sum(
+                                        value,
+                                        Weight.Product(closureStateWeight, transition.Weight, distWeight, destValue));
+                                }
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    value = closure.EndWeight;
+                }
+
+                valueCache.Add(stateIndexPair, value);
+                return value;
+            }
         }
 
         /// <summary>
@@ -1684,7 +1741,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
             var point = new List<TElement>();
             int? pointLength = null;
-            var stateDepth = new ArrayDictionary<int>(this.statesData.Count);
+            var stateDepth = new ArrayDictionary<int>(this.States.Count);
             bool isPoint = this.TryComputePointDfs(this.Start, 0, stateDepth, endNodeReachability, point, ref pointLength);
             return isPoint && pointLength.HasValue ? SequenceManipulator.ToSequence(point) : null;
         }
@@ -1799,79 +1856,59 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         #region Manipulating structure
 
         /// <summary>
-        /// Creates a deep copy of the state collection. Used by quoting.
-        /// </summary>
-        /// <returns>The created state collection copy.</returns>
-        public State[] GetStates()
-        {
-            // FIXME: discuss what it is supposed to do
-            // if needed - implement real full automaton deep-copy
-            return this.States.ToArray();
-        }
-
-        /// <summary>
-        /// Adds a new state to the automaton.
-        /// </summary>
-        /// <returns>The added state.</returns>
-        /// <remarks>Indices of the added states are guaranteed to be increasing consecutive.</remarks>
-        public State AddState()
-        {
-            if (this.statesData.Count >= maxStateCount)
-            {
-                throw new AutomatonTooLargeException(MaxStateCount);
-            }
-
-            var index = this.statesData.Count;
-            var stateImpl = new StateData();
-            this.statesData.Add(stateImpl);
-
-            return new State(this, index, stateImpl);
-        }
-
-        /// <summary>
-        /// Adds a given number of states to the automaton.
-        /// </summary>
-        /// <param name="stateCount">The number of states to add.</param>
-        public void AddStates(int stateCount)
-        {
-            Argument.CheckIfInRange(stateCount >= 0, "stateCount", "The number of states to add must not be negative.");
-
-            for (int i = 0; i < stateCount; i++)
-            {
-                this.AddState();
-            }
-        }
-
-        /// <summary>
         /// Gets a value indicating whether this automaton is epsilon-free.
         /// </summary>
-        public bool IsEpsilonFree
-        {
-            get
-            {
-                if (this.isEpsilonFree == null)
-                {
-                    this.isEpsilonFree = true;
-                    foreach (var state in this.statesData)
-                    {
-                        for (int i = 0; i < state.TransitionCount; i++)
-                        {
-                            if (state.GetTransition(i).IsEpsilon)
-                            {
-                                this.isEpsilonFree = false;
-                                break;
-                            }
-                        }
+        public bool IsEpsilonFree => this.Data.IsEpsilonFree;
 
-                        if (this.isEpsilonFree == false)
+        /// <summary>
+        /// Tests whether the automaton is deterministic,
+        /// i.e. it's epsilon free and for every state and every element there is at most one transition that allows for that element.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if the automaton is deterministic,
+        /// <see langword="false"/> otherwise.
+        /// </returns>
+        public bool IsDeterministic()
+        {
+            //// We can't track whether the automaton is deterministic while adding/updating transitions
+            //// because element distributions are not immutable.
+            
+            if (!this.IsEpsilonFree)
+            {
+                return false;
+            }
+            
+            for (int stateId = 0; stateId < this.States.Count; ++stateId)
+            {
+                var state = this.States[stateId];
+
+                // There should be no epsilon transitions
+                foreach (var transition in state.Transitions)
+                {
+                    if (transition.IsEpsilon)
+                    {
+                        return false;
+                    }
+                }
+                
+                // Element distributions should not intersect
+                var transitions = state.Transitions;
+                for (int transitionIndex1 = 0; transitionIndex1 < transitions.Count; ++transitionIndex1)
+                {
+                    var transition1 = transitions[transitionIndex1];
+                    for (int transitionIndex2 = transitionIndex1 + 1; transitionIndex2 < transitions.Count; ++transitionIndex2)
+                    {
+                        var transition2 = transitions[transitionIndex2];
+                        double logProductNormalizer = transition1.ElementDistribution.Value.GetLogAverageOf(transition2.ElementDistribution.Value);
+                        if (!double.IsNegativeInfinity(logProductNormalizer))
                         {
-                            break;
+                            return false;
                         }
                     }
                 }
-
-                return this.isEpsilonFree.Value;
             }
+
+            return true;
         }
 
         /// <summary>
@@ -1904,12 +1941,49 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 return;
             }
 
-            TThis result = Zero();
-            result.Start = result.BuildEpsilonClosure(automaton.Start, new ArrayDictionary<State>(automaton.States.Count));
-            result.LogValueOverride = automaton.LogValueOverride;
-            result.PruneTransitionsWithLogWeightLessThan = automaton.PruneTransitionsWithLogWeightLessThan;
-            result.isEpsilonFree = true;
-            this.SwapWith(result);
+            var builder = Builder.Zero();
+            var oldToNewState = new ArrayDictionary<int>(automaton.States.Count);
+            builder.StartStateIndex = BuildEpsilonClosure(automaton.Start);
+
+            this.Data = builder.GetData();
+
+            // Recursively builds an automaton representing the epsilon closure of a given automaton.
+            // Returns the state index of state representing the closure
+            int BuildEpsilonClosure(State state)
+            {
+                if (oldToNewState.TryGetValue(state.Index, out var resultStateIndex))
+                {
+                    return resultStateIndex;
+                }
+
+                var resultState = builder.AddState();
+                oldToNewState.Add(state.Index, resultState.Index);
+
+                var closure = state.GetEpsilonClosure();
+                resultState.SetEndWeight(closure.EndWeight);
+                for (var stateIndex = 0; stateIndex < closure.Size; ++stateIndex)
+                {
+                    var closureState = closure.GetStateByIndex(stateIndex);
+                    var closureStateWeight = closure.GetStateWeightByIndex(stateIndex);
+                    foreach (var transition in closureState.Transitions)
+                    {
+                        if (transition.IsEpsilon)
+                        {
+                            continue;
+                        }
+
+                        var destState = state.Owner.States[transition.DestinationStateIndex];
+                        var closureDestStateIndex = BuildEpsilonClosure(destState);
+                        resultState.AddTransition(
+                            transition.ElementDistribution,
+                            Weight.Product(transition.Weight, closureStateWeight),
+                            closureDestStateIndex,
+                            transition.Group);
+                    }
+                }
+
+                return resultState.Index;
+            }
         }
 
         #endregion
@@ -1975,13 +2049,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             {
                 TThis automaton = automata[automatonIndex];
 
-                for (int stateIndex = 0; stateIndex < automaton.statesData.Count; ++stateIndex)
+                for (int stateIndex = 0; stateIndex < automaton.States.Count; ++stateIndex)
                 {
                     State state = automaton.States[stateIndex];
                     Weight transitionWeightSum = Weight.Zero;
-                    for (int transitionIndex = 0; transitionIndex < state.TransitionCount; ++transitionIndex)
+                    foreach (var transition in state.Transitions)
                     {
-                        Transition transition = state.GetTransition(transitionIndex);
                         transitionWeightSum = Weight.Sum(transitionWeightSum, transition.Weight);
                     }
 
@@ -1998,7 +2071,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             // An automaton, product with which will make every self-loop converging
             var uniformDist = new TElementDistribution();
             uniformDist.SetToUniform();
-            TThis theConverger = Zero();
+            var theConverger = Builder.Zero();
             Weight transitionWeight = Weight.Product(
                 Weight.FromLogValue(-uniformDist.GetLogAverageOf(uniformDist)),
                 Weight.FromLogValue(-maxLogTransitionWeightSum),
@@ -2006,92 +2079,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             theConverger.Start.AddSelfTransition(uniformDist, transitionWeight);
             theConverger.Start.SetEndWeight(Weight.One);
 
-            return theConverger;
-        }
-
-        /// <summary>
-        /// Checks if indices assigned to given states and their transitions are consistent with each other.
-        /// </summary>
-        /// <param name="states">The collection of states to check.</param>
-        /// <param name="startState">The start state to check.</param>
-        private static void CheckStateConsistency(IEnumerable<State> states, State startState)
-        {
-            State[] stateArray = states.ToArray();
-            for (int stateIndex = 0; stateIndex < stateArray.Length; ++stateIndex)
-            {
-                var state = stateArray[stateIndex];
-                if (state.Index != stateIndex)
-                {
-                    throw new ArgumentException("State indices must be consequent zero-based.");
-                }
-
-                for (int transitionIndex = 0; transitionIndex < stateArray[stateIndex].TransitionCount; ++transitionIndex)
-                {
-                    var transition = state.GetTransition(transitionIndex);
-                    if (transition.DestinationStateIndex < 0 || transition.DestinationStateIndex >= stateArray.Length)
-                    {
-                        throw new ArgumentException("Transition destination indices must point to a valid state.");
-                    }
-                }
-            }
-
-            if (startState.Index >= stateArray.Length)
-            {
-                throw new ArgumentException("Start state has an invalid index.");
-            }
-        }
-
-        /// <summary>
-        /// Performs depth-first traversal of a given graph.
-        /// </summary>
-        /// <param name="currentVertex">The index of the currently traversed vertex.</param>
-        /// <param name="visitedVertices">An array to keep track of the visited vertices.</param>
-        /// <param name="edgeDestinationIndices">An array containing destination indices of the graph edges.</param>
-        /// <param name="edgeArrayStarts">An array</param>
-        private static void LabelReachableNodesDfs(
-            int currentVertex, bool[] visitedVertices, int[] edgeDestinationIndices, int[] edgeArrayStarts)
-        {
-            Debug.Assert(!visitedVertices[currentVertex], "Visited vertices must not be revisited.");
-            visitedVertices[currentVertex] = true;
-
-            for (int edgeIndex = edgeArrayStarts[currentVertex]; edgeIndex < edgeArrayStarts[currentVertex + 1]; ++edgeIndex)
-            {
-                int destVertexIndex = edgeDestinationIndices[edgeIndex];
-                if (!visitedVertices[destVertexIndex])
-                {
-                    LabelReachableNodesDfs(destVertexIndex, visitedVertices, edgeDestinationIndices, edgeArrayStarts);
-                }
-            }
-        }
-
-        /// <summary>
-        /// A version of <see cref="AppendInPlace(TThis, int)"/> that is guaranteed to preserve
-        /// the states of both the original automaton and the automaton being appended in the result.
-        /// </summary>
-        /// <param name="automaton">The automaton to append.</param>
-        /// <remarks>
-        /// Useful for implementing functions like <see cref="Repeat(TThis, Vector)"/>,
-        /// where on-the-fly result optimization creates unnecessary complications.
-        /// </remarks>
-        private void AppendInPlaceNoOptimizations(TThis automaton)
-        {
-            if (ReferenceEquals(automaton, this))
-            {
-                automaton = automaton.Clone();
-            }
-
-            int stateCount = this.statesData.Count;
-            var endStates = this.States.Where(nd => nd.CanEnd).ToList();
-
-            this.AddStates(automaton.statesData);
-            var secondStartState = this.States[stateCount + automaton.Start.Index];
-
-            for (int i = 0; i < endStates.Count; i++)
-            {
-                var state = endStates[i];
-                state.AddEpsilonTransition(state.EndWeight, secondStartState);
-                state.SetEndWeight(Weight.Zero);
-            }
+            return theConverger.GetAutomaton();
         }
 
         /// <summary>
@@ -2102,13 +2090,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         {
             //// First, build a reversed graph
 
-            int[] edgePlacementIndices = new int[this.statesData.Count + 1];
-            for (int i = 0; i < this.statesData.Count; ++i)
+            int[] edgePlacementIndices = new int[this.States.Count + 1];
+            for (int i = 0; i < this.States.Count; ++i)
             {
-                var state = this.statesData[i];
-                for (int j = 0; j < state.TransitionCount; ++j)
+                var state = this.States[i];
+                foreach (var transition in state.Transitions)
                 {
-                    var transition = state.GetTransition(j);
                     if (!transition.Weight.IsZero)
                     {
                         ++edgePlacementIndices[transition.DestinationStateIndex + 1];
@@ -2125,14 +2112,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             }
 
             int[] edgeArrayStarts = (int[])edgePlacementIndices.Clone();
-            int totalEdgeCount = edgePlacementIndices[this.statesData.Count];
+            int totalEdgeCount = edgePlacementIndices[this.States.Count];
             int[] edgeDestinationIndices = new int[totalEdgeCount];
-            for (int i = 0; i < this.statesData.Count; ++i)
+            for (int i = 0; i < this.States.Count; ++i)
             {
-                var state = this.statesData[i];
-                for (int j = 0; j < state.TransitionCount; ++j)
+                var state = this.States[i];
+                foreach (var transition in state.Transitions)
                 {
-                    var transition = state.GetTransition(j);
                     if (!transition.Weight.IsZero)
                     {
                         // The unique index for this edge
@@ -2145,73 +2131,31 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             }
 
             //// Now run a depth-first search to label all reachable nodes
-
-            bool[] visitedNodes = new bool[this.statesData.Count];
-            for (int i = 0; i < this.statesData.Count; ++i)
+            bool[] visitedNodes = new bool[this.States.Count];
+            for (int i = 0; i < this.States.Count; ++i)
             {
-                if (!visitedNodes[i] && this.statesData[i].CanEnd)
+                if (!visitedNodes[i] && this.States[i].CanEnd)
                 {
-                    LabelReachableNodesDfs(i, visitedNodes, edgeDestinationIndices, edgeArrayStarts);
+                    LabelReachableNodesDfs(i);
                 }
             }
 
             return visitedNodes;
-        }
 
-        /// <summary>
-        /// For each state computes whether it can be reached from the start state.
-        /// </summary>
-        /// <returns>An array mapping state indices to start state reachability.</returns>
-        private bool[] ComputeStartStateReachability()
-        {
-            //// First, build a reversed graph
-
-            int[] edgePlacementIndices = new int[this.statesData.Count + 1];
-            for (int i = 0; i < this.statesData.Count; ++i)
+            void LabelReachableNodesDfs(int currentVertex)
             {
-                var state = this.statesData[i];
-                for (int j = 0; j < state.TransitionCount; ++j)
+                Debug.Assert(!visitedNodes[currentVertex], "Visited vertices must not be revisited.");
+                visitedNodes[currentVertex] = true;
+
+                for (int edgeIndex = edgeArrayStarts[currentVertex]; edgeIndex < edgeArrayStarts[currentVertex + 1]; ++edgeIndex)
                 {
-                    var transition = state.GetTransition(j);
-                    if (!transition.Weight.IsZero)
+                    int destVertexIndex = edgeDestinationIndices[edgeIndex];
+                    if (!visitedNodes[destVertexIndex])
                     {
-                        ++edgePlacementIndices[i + 1];
+                        LabelReachableNodesDfs(destVertexIndex);
                     }
                 }
             }
-
-            // The element of edgePlacementIndices at index i+1 contains a count of the number of edges 
-            // going out of the i'th state (the outdegree of the state).
-            // Convert this into a cumulative count (which will be used to give a unique index to each edge).
-            for (int i = 1; i < edgePlacementIndices.Length; ++i)
-            {
-                edgePlacementIndices[i] += edgePlacementIndices[i - 1];
-            }
-
-            int[] edgeArrayStarts = (int[])edgePlacementIndices.Clone();
-            int totalEdgeCount = edgePlacementIndices[this.statesData.Count];
-            int[] edgeDestinationIndices = new int[totalEdgeCount];
-            for (int i = 0; i < this.statesData.Count; ++i)
-            {
-                var state = this.statesData[i];
-                for (int j = 0; j < state.TransitionCount; ++j)
-                {
-                    var transition = state.GetTransition(j);
-                    if (!transition.Weight.IsZero)
-                    {
-                        // The unique index for this edge
-                        int edgePlacementIndex = edgePlacementIndices[i]++;
-
-                        // The destination index for the edge 
-                        edgeDestinationIndices[edgePlacementIndex] = transition.DestinationStateIndex;
-                    }
-                }
-            }
-
-            //// Now run a depth-first search to label all reachable nodes
-            bool[] visitedNodes = new bool[this.statesData.Count];
-            LabelReachableNodesDfs(this.Start.Index, visitedNodes, edgeDestinationIndices, edgeArrayStarts);
-            return visitedNodes;
         }
 
         /// <summary>
@@ -2227,47 +2171,46 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             noEpsilonTransitions.SetToEpsilonClosureOf((TThis)this); // To get rid of infinite weight closures
 
             Condensation condensation = noEpsilonTransitions.ComputeCondensation(noEpsilonTransitions.Start, tr => true, false);
-            double logNormalizer = condensation.GetWeightToEnd(noEpsilonTransitions.Start).LogValue;
+            double logNormalizer = condensation.GetWeightToEnd(noEpsilonTransitions.Start.Index).LogValue;
             if (normalize)
             {
                 if (!double.IsInfinity(logNormalizer))
                 {
-                    noEpsilonTransitions.PushWeights(condensation);
-                    this.SwapWith(noEpsilonTransitions);
+                    this.SwapWith(PushWeights());
                 }
             }
 
             return logNormalizer;
-        }
 
-        /// <summary>
-        /// Re-distributes weights of the states and transitions so that the underlying automaton becomes stochastic
-        /// (i.e. sum of weights of all the outgoing transitions and the ending weight is 1 for every node).
-        /// </summary>
-        /// <param name="condensation">A condensation of the automaton.</param>
-        private void PushWeights(Condensation condensation)
-        {
-            for (int i = 0; i < this.statesData.Count; ++i)
+            // Re-distributes weights of the states and transitions so that the underlying automaton becomes stochastic
+            // (i.e. sum of weights of all the outgoing transitions and the ending weight is 1 for every node).
+            TThis PushWeights()
             {
-                var state = this.States[i];
-                Weight weightToEnd = condensation.GetWeightToEnd(state);
-                if (weightToEnd.IsZero)
+                var builder = Builder.FromAutomaton(noEpsilonTransitions);
+                for (int i = 0; i < builder.StatesCount; ++i)
                 {
-                    continue; // End states cannot be reached from this state, no point in normalization
+                    var state = builder[i];
+                    var weightToEnd = condensation.GetWeightToEnd(i);
+                    if (weightToEnd.IsZero)
+                    {
+                        continue; // End states cannot be reached from this state, no point in normalization
+                    }
+
+                    var weightToEndInv = Weight.Inverse(weightToEnd);
+                    for (var transitionIterator = state.TransitionIterator; transitionIterator.Ok; transitionIterator.Next())
+                    {
+                        var transition = transitionIterator.Value;
+                        transition.Weight = Weight.Product(
+                            transition.Weight,
+                            condensation.GetWeightToEnd(transition.DestinationStateIndex),
+                            weightToEndInv);
+                        transitionIterator.Value = transition;
+                    }
+
+                    state.SetEndWeight(Weight.Product(state.EndWeight, weightToEndInv));
                 }
 
-                Weight weightToEndInv = Weight.Inverse(weightToEnd);
-                for (int j = 0; j < state.TransitionCount; ++j)
-                {
-                    Transition transition = state.GetTransition(j);
-                    transition.Weight = Weight.Product(
-                        transition.Weight,
-                        condensation.GetWeightToEnd(this.States[transition.DestinationStateIndex]),
-                        weightToEndInv);
-                    state.SetTransition(j, transition);
-                }
-
-                state.SetEndWeight(Weight.Product(state.EndWeight, weightToEndInv));
+                return builder.GetAutomaton();
             }
         }
 
@@ -2321,10 +2264,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 }
             }
 
-            for (int i = 0; i < currentState.TransitionCount; ++i)
+            foreach (var transition in currentState.Transitions)
             {
-                Transition transition = currentState.GetTransition(i);
-
                 State destState = this.States[transition.DestinationStateIndex];
                 if (!isEndNodeReachable[destState.Index])
                 {
@@ -2369,124 +2310,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         }
 
         /// <summary>
-        /// Recursively builds an automaton representing the product of two given automata.
-        /// The second automaton must be epsilon-free.
-        /// </summary>
-        /// <param name="state1">The currently traversed state of the first automaton.</param>
-        /// <param name="state2">The currently traversed state of the second automaton.</param>
-        /// <param name="productStateCache">
-        /// The mapping from a pair of argument state indices to an index of the corresponding product state.
-        /// </param>
-        /// <returns>The index of the product state corresponding to the given pair of state.</returns>
-        private State BuildProduct(
-            State state1,
-            State state2,
-            Dictionary<(int, int), State> productStateCache)
-        {
-            Debug.Assert(state1 != null && state2 != null, "Valid states must be provided.");
-            Debug.Assert(!ReferenceEquals(state1.Owner, this) && !ReferenceEquals(state2.Owner, this), "Cannot build product in place.");
-            Debug.Assert(state2.Owner.IsEpsilonFree, "The second argument of the product operation must be epsilon-free.");
-
-            // State already exists, return its index
-            var statePair = (state1.Index, state2.Index);
-            State productState;
-            if (productStateCache.TryGetValue(statePair, out productState))
-            {
-                return productState;
-            }
-
-            // Create a new state
-            productState = this.AddState();
-            productStateCache.Add(statePair, productState);
-
-            // Iterate over transitions in state1
-            for (int transition1Index = 0; transition1Index < state1.TransitionCount; transition1Index++)
-            {
-                Transition transition1 = state1.GetTransition(transition1Index);
-                State destState1 = state1.Owner.States[transition1.DestinationStateIndex];
-
-                if (transition1.IsEpsilon)
-                {
-                    // Epsilon transition case
-                    State destProductState = this.BuildProduct(destState1, state2, productStateCache);
-                    productState.AddEpsilonTransition(transition1.Weight, destProductState, transition1.Group);
-                    continue;
-                }
-
-                // Iterate over transitions in state2
-                for (int transition2Index = 0; transition2Index < state2.TransitionCount; transition2Index++)
-                {
-                    Transition transition2 = state2.GetTransition(transition2Index);
-                    Debug.Assert(!transition2.IsEpsilon, "The second argument of the product operation must be epsilon-free.");
-                    State destState2 = state2.Owner.States[transition2.DestinationStateIndex];
-
-                    TElementDistribution product;
-                    double productLogNormalizer = Distribution<TElement>.GetLogAverageOf(
-                        transition1.ElementDistribution.Value, transition2.ElementDistribution.Value, out product);
-                    ////if (product is StringDistribution)
-                    ////{
-                    ////    Console.WriteLine(transition1.ElementDistribution+" x "+transition2.ElementDistribution+" = "+product+" "+productLogNormalizer+" "+transition1.ElementDistribution.Equals(transition1.ElementDistribution)+" "+transition1.ElementDistribution.Equals(transition2.ElementDistribution));
-                    ////}
-                    if (double.IsNegativeInfinity(productLogNormalizer))
-                    {
-                        continue;
-                    }
-
-                    Weight productWeight = Weight.Product(transition1.Weight, transition2.Weight, Weight.FromLogValue(productLogNormalizer));
-                    State destProductState = this.BuildProduct(destState1, destState2, productStateCache);
-                    productState.AddTransition(product, productWeight, destProductState, transition1.Group);
-                }
-            }
-
-            productState.SetEndWeight(Weight.Product(state1.EndWeight, state2.EndWeight));
-            return productState;
-        }
-
-        /// <summary>
-        /// Recursively builds an automaton representing the epsilon closure of a given automaton.
-        /// </summary>
-        /// <param name="state">The currently traversed state of the source automaton.</param>
-        /// <param name="oldToNewState">
-        /// The mapping from the indices of the states of the source automaton to the states of the closure.
-        /// </param>
-        /// <returns>The state representing the closure of <paramref name="state"/>.</returns>
-        private State BuildEpsilonClosure(State state, ArrayDictionary<State> oldToNewState)
-        {
-            Debug.Assert(state != null, "A valid state must be provided.");
-            Debug.Assert(!ReferenceEquals(state.Owner, this), "In-place epsilon closure building is not supported.");
-
-            State resultState;
-            if (oldToNewState.TryGetValue(state.Index, out resultState))
-            {
-                return resultState;
-            }
-
-            resultState = this.AddState();
-            oldToNewState.Add(state.Index, resultState);
-
-            EpsilonClosure closure = state.GetEpsilonClosure();
-            resultState.SetEndWeight(closure.EndWeight);
-            for (int stateIndex = 0; stateIndex < closure.Size; ++stateIndex)
-            {
-                State closureState = closure.GetStateByIndex(stateIndex);
-                Weight closureStateWeight = closure.GetStateWeightByIndex(stateIndex);
-                for (int transitionIndex = 0; transitionIndex < closureState.TransitionCount; ++transitionIndex)
-                {
-                    Transition transition = closureState.GetTransition(transitionIndex);
-                    if (!transition.IsEpsilon)
-                    {
-                        State destState = state.Owner.States[transition.DestinationStateIndex];
-                        State closureDestState = this.BuildEpsilonClosure(destState, oldToNewState);
-                        resultState.AddTransition(
-                            transition.ElementDistribution, Weight.Product(transition.Weight, closureStateWeight), closureDestState, transition.Group);
-                    }
-                }
-            }
-
-            return resultState;
-        }
-
-        /// <summary>
         /// Swaps the current automaton with a given one.
         /// </summary>
         /// <param name="automaton">The automaton to swap the current one with.</param>
@@ -2495,118 +2318,17 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             Debug.Assert(automaton != null, "A valid automaton must be provided.");
 
             // Swap contents
-            Util.Swap(ref this.statesData, ref automaton.statesData);
-            Util.Swap(ref this.startStateIndex, ref automaton.startStateIndex);
-            Util.Swap(ref this.isEpsilonFree, ref automaton.isEpsilonFree);
+            var dummyData = this.Data;
+            this.Data = automaton.Data;
+            automaton.Data = this.Data;
+
             var dummy = this.LogValueOverride;
             this.LogValueOverride = automaton.LogValueOverride;
             automaton.LogValueOverride = dummy;
+
             dummy = this.PruneTransitionsWithLogWeightLessThan;
             this.PruneTransitionsWithLogWeightLessThan = automaton.PruneTransitionsWithLogWeightLessThan;
             automaton.PruneTransitionsWithLogWeightLessThan = dummy;
-        }
-
-        /// <summary>
-        /// Replaces the states of this automaton with a given collection of states.
-        /// </summary>
-        /// <param name="newStates">The states to replace the existing states with.</param>
-        /// <param name="newStartStateIndex">The index of the new start state.</param>
-        private void SetStates(IEnumerable<StateData> newStates, int newStartStateIndex)
-        {
-            this.statesData.Clear();
-            this.AddStates(newStates);
-            this.Start = this.States[newStartStateIndex];
-        }
-
-        /// <summary>
-        /// Adds the states in a given collection to the automaton together with their transitions,
-        /// but without attaching any of them to any of the existing states.
-        /// </summary>
-        /// <param name="statesToAdd">The states to add.</param>
-        /// <param name="group">The group for the transitions of the states being added.</param>
-        private void AddStates(IEnumerable<StateData> statesToAdd, int group = 0)
-        {
-            Debug.Assert(statesToAdd != null, "A valid state collection must be provided.");
-
-            int startIndex = this.statesData.Count;
-            var statesToAddList = statesToAdd as IList<StateData> ?? statesToAdd.ToList();
-
-            // Add states
-            for (int i = 0; i < statesToAddList.Count; ++i)
-            {
-                State newState = this.AddState();
-                newState.SetEndWeight(statesToAddList[i].EndWeight);
-
-                Debug.Assert(newState.Index == i + startIndex, "State indices must always be consequent.");
-            }
-
-            // Add transitions
-            for (int i = 0; i < statesToAddList.Count; ++i)
-            {
-                var stateToAdd = statesToAddList[i];
-                for (int transitionIndex = 0; transitionIndex < stateToAdd.TransitionCount; transitionIndex++)
-                {
-                    Transition transitionToAdd = stateToAdd.GetTransition(transitionIndex);
-                    Debug.Assert(transitionToAdd.DestinationStateIndex < statesToAddList.Count, "Self-inconsistent collection of states provided.");
-                    this.States[i + startIndex].AddTransition(
-                        transitionToAdd.ElementDistribution,
-                        transitionToAdd.Weight,
-                        this.States[transitionToAdd.DestinationStateIndex + startIndex],
-                        group != 0 ? group : transitionToAdd.Group);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Removes the state with a given index from the automaton.
-        /// </summary>
-        /// <param name="index">The index of the state to remove.</param>
-        /// <param name="replaceIndex">
-        /// If specified, all the transitions to the state being removed
-        /// will be redirected to the state with this index.
-        /// </param>
-        /// <remarks>
-        /// The automaton representation we currently use does not allow for fast state removal.
-        /// Ideally we should get rid of this function completely.
-        /// </remarks>
-        private void RemoveState(int index, int? replaceIndex = null)
-        {
-            //// TODO: see remarks
-
-            Debug.Assert(index >= 0 && index < this.statesData.Count, "An invalid state index provided.");
-            Debug.Assert(index != this.Start.Index, "Cannot remove the start state.");
-            Debug.Assert(
-                !replaceIndex.HasValue || (replaceIndex.Value >= 0 && replaceIndex.Value < this.statesData.Count),
-                "An invalid replace index provided.");
-            Debug.Assert(!replaceIndex.HasValue || replaceIndex.Value != index, "Replace index must point to a different state.");
-
-            this.statesData.RemoveAt(index);
-            int stateCount = this.statesData.Count;
-            for (int i = 0; i < stateCount; i++)
-            {
-                StateData state = this.statesData[i];
-                for (int j = state.TransitionCount - 1; j >= 0; j--)
-                {
-                    Transition transition = state.GetTransition(j);
-                    if (transition.DestinationStateIndex == index)
-                    {
-                        if (!replaceIndex.HasValue)
-                        {
-                            state.RemoveTransition(j);
-                            continue;
-                        }
-
-                        transition.DestinationStateIndex = replaceIndex.Value;
-                    }
-
-                    if (transition.DestinationStateIndex > index)
-                    {
-                        transition.DestinationStateIndex = transition.DestinationStateIndex - 1;
-                    }
-
-                    state.SetTransition(j, transition);
-                }
-            }
         }
 
         /// <summary>
@@ -2627,7 +2349,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             visitedStates.Add(stateIndex);
 
             var currentState = this.States[stateIndex];
-            var transitions = currentState.GetTransitions().Where(t => !t.Weight.IsZero);
+            var transitions = currentState.Transitions.Where(t => !t.Weight.IsZero);
             var selfTransitions = transitions.Where(t => t.DestinationStateIndex == stateIndex);
             int selfTransitionCount = selfTransitions.Count();
             var nonSelfTransitions = transitions.Where(t => t.DestinationStateIndex != stateIndex);
@@ -2728,10 +2450,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             }
 
             visitedStates[stateIndex] = true;
-            for (int i = 0; i < currentState.TransitionCount; ++i)
+            foreach (var transition in currentState.Transitions)
             {
-                var transition = currentState.GetTransition(i);
-
                 if (transition.Weight.IsZero)
                 {
                     continue;
@@ -2795,10 +2515,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             }
 
             visitedStates[stateIndex] = true;
-            for (int i = 0; i < currentState.TransitionCount; ++i)
+            foreach (var transition in currentState.Transitions)
             {
-                var transition = currentState.GetTransition(i);
-
                 if (transition.Weight.IsZero)
                 {
                     continue;
@@ -2862,40 +2580,24 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         }
         #endregion
 
-        #region Serialization
-
-        /// <summary>
-        /// Constructor used during deserialization by Newtonsoft.Json and BinaryFormatter .
-        /// </summary>
-        /// <remarks>
-        /// To be (de)serializable, classes inherited from Automaton must constructor with the same signature.
-        /// </remarks>
-        protected Automaton(SerializationInfo info, StreamingContext context)
-        {
-            this.statesData = (List<StateData>)info.GetValue(nameof(this.statesData), typeof(List<StateData>));
-            this.startStateIndex = (int)info.GetValue(nameof(this.startStateIndex), typeof(int));
-            this.isEpsilonFree = (bool?)info.GetValue(nameof(this.isEpsilonFree), typeof(bool?));
-        }
-
-        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            info.AddValue(nameof(this.statesData), this.statesData);
-            info.AddValue(nameof(this.startStateIndex), this.startStateIndex);
-            info.AddValue(nameof(this.isEpsilonFree), this.isEpsilonFree);
-        }
+        #region Serialization}
 
         /// <summary>
         /// Writes the current automaton.
         /// </summary>
+        /// <remarks>
+        /// Serialization format is a bit unnatural, but we do it for compatibility with old serialized data.
+        /// So we don't have to maintain 2 versions of deserialization.
+        /// </remarks>
         public void Write(Action<double> writeDouble, Action<int> writeInt32, Action<TElementDistribution> writeElementDistribution)
         {
             var propertyMask = new BitVector32();
             var idx = 0;
-            propertyMask[1 << idx++] = this.isEpsilonFree.HasValue;
-            propertyMask[1 << idx++] = this.isEpsilonFree.HasValue && this.isEpsilonFree.Value;
+            propertyMask[1 << idx++] = true; // isEpsilonFree is alway known
+            propertyMask[1 << idx++] = this.Data.IsEpsilonFree;
             propertyMask[1 << idx++] = this.LogValueOverride.HasValue;
             propertyMask[1 << idx++] = this.PruneTransitionsWithLogWeightLessThan.HasValue;
-            propertyMask[1 << idx++] = !this.Start.IsNull;
+            propertyMask[1 << idx++] = true; // start state is alway serialized
 
             writeInt32(propertyMask.Data);
 
@@ -2909,33 +2611,34 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 writeDouble(this.PruneTransitionsWithLogWeightLessThan.Value);
             }
 
-            if (!this.Start.IsNull)
-            {
-                this.Start.Write(writeInt32, writeDouble, writeElementDistribution);
-            }
-
-            writeInt32(this.statesData.Count);
+            // This state is serialized only for its index.
+            this.Start.Write(writeDouble, writeInt32, writeElementDistribution);
+            
+            writeInt32(this.States.Count);
             foreach (var state in this.States)
             {
-                state.Write(writeInt32, writeDouble, writeElementDistribution);
+                state.Write(writeDouble, writeInt32, writeElementDistribution);
             }
         }
 
         /// <summary>
         /// Reads an automaton from.
         /// </summary>
+        /// <remarks>
+        /// Serializtion format is a bit unnatural, but we do it for compatiblity with old serialized data.
+        /// So we don't have to maintain 2 versions of derserialization
+        /// </remarks>
         public static TThis Read(Func<double> readDouble, Func<int> readInt32, Func<TElementDistribution> readElementDistribution)
         {
             var propertyMask = new BitVector32(readInt32());
             var res = new TThis();
             var idx = 0;
-            var hasEpsilonFree = propertyMask[1 << idx++];
-            var isEpsilonFree = propertyMask[1 << idx++];
+            // we do not trust serialized "isEpsilonFree". Will take it from builder anyway
+            var hasEpsilonFreeIgnored = propertyMask[1 << idx++];
+            var isEpsilonFreeIgnored = propertyMask[1 << idx++];
             var hasLogValueOverride = propertyMask[1 << idx++];
             var hasPruneTransitions = propertyMask[1 << idx++];
             var hasStartState = propertyMask[1 << idx++];
-
-            res.isEpsilonFree = hasEpsilonFree ? (bool?)isEpsilonFree : null;
 
             if (hasLogValueOverride)
             {
@@ -2947,25 +2650,25 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 res.PruneTransitionsWithLogWeightLessThan = readDouble();
             }
 
-            var startState =
-                hasStartState
-                    ? State.Read(readInt32, readDouble, readElementDistribution)
-                    : default(State);
-
-            var numStates = readInt32();
-            res.statesData.Clear();
-            res.AddStates(numStates);
-            for (var i = 0; i < numStates; i++)
-            {
-                res.statesData[i] = State.Read(readInt32, readDouble, readElementDistribution).Data;
-            }
+            var builder = new Builder();
 
             if (hasStartState)
             {
-                res.startStateIndex = startState.Index;
+                // Start state is also present in the list of all states, so read it into temp builder where
+                // it will get index 0. But keep real deserialized start state index to be used in real builder
+                var tempBuilder = new Builder();
+                builder.StartStateIndex =
+                    State.ReadTo(ref tempBuilder, readInt32, readDouble, readElementDistribution, checkIndex: false);
             }
 
-            return res;
+            var numStates = readInt32();
+            
+            for (var i = 0; i < numStates; i++)
+            {
+                State.ReadTo(ref builder, readInt32, readDouble, readElementDistribution);
+            }
+
+            return builder.GetAutomaton();
         }
         #endregion
     }

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -309,7 +309,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         {
             Argument.CheckIfNotNull(allowedElements, nameof(allowedElements));
 
-            var result = Builder.Zero();
+            var result = new Builder();
             if (!double.IsNegativeInfinity(logValue))
             {
                 allowedElements = Distribution.CreatePartialUniform(allowedElements);
@@ -361,7 +361,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         {
             Argument.CheckIfNotNull(sequences, "sequences");
 
-            var result = Builder.Zero();
+            var result = new Builder();
             if (!double.IsNegativeInfinity(logValue))
             {
                 foreach (var sequence in sequences)
@@ -436,7 +436,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 throw new NotImplementedException("Negative values are not yet supported.");
             }
 
-            var result = Builder.Zero();
+            var result = new Builder();
             result.Start.SetEndWeight(Weight.FromLogValue(Math.Log(value)));
             return result.GetAutomaton();
         }
@@ -533,7 +533,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         {
             Argument.CheckIfNotNull(automata, "automata");
 
-            var result = Builder.Zero();
+            var result = new Builder();
             foreach (var automaton in automata)
             {
                 if (automaton.IsCanonicZero())
@@ -1097,7 +1097,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <returns>The created automaton.</returns>
         public TThis Reverse()
         {
-            var result = Builder.Zero();
+            var result = new Builder();
 
             // Result already has 1 state, we add the remaining Count-1 states
             result.AddStates(this.States.Count - 1);
@@ -1256,7 +1256,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 }
             }
 
-            var builder = new Builder();
+            var builder = new Builder(0);
             var productStateCache = new Dictionary<(int, int), int>(automaton1.States.Count + automaton2.States.Count);
             builder.StartStateIndex = BuildProduct(automaton1.Start, automaton2.Start);
 
@@ -1433,7 +1433,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 !double.IsPositiveInfinity(logWeight1) && !double.IsPositiveInfinity(logWeight2),
                 "Weights must not be infinite.");
 
-            var result = Builder.Zero();
+            var result = new Builder();
 
             bool hasFirstTerm = !automaton1.IsCanonicZero() && !double.IsNegativeInfinity(logWeight1);
             bool hasSecondTerm = !automaton2.IsCanonicZero() && !double.IsNegativeInfinity(logWeight2);
@@ -1567,7 +1567,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             Argument.CheckIfNotNull(allowedElements, "allowedElements");
 
             allowedElements = Distribution.CreatePartialUniform(allowedElements);
-            var builder = Builder.Zero();
+            var builder = new Builder();
             if (!double.IsNegativeInfinity(logValue))
             {
                 builder.Start.SetEndWeight(Weight.FromLogValue(logValue));
@@ -1612,7 +1612,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             Argument.CheckIfNotNull(sourceAutomaton, "sourceAutomaton");
             Argument.CheckIfNotNull(transitionTransform, "transitionTransform");
 
-            var builder = Builder.Zero();
+            var builder = new Builder();
 
             // Add states
             builder.AddStates(sourceAutomaton.States.Count - 1);
@@ -1940,7 +1940,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 return;
             }
 
-            var builder = Builder.Zero();
+            var builder = new Builder();
             var oldToNewState = new ArrayDictionary<int>(automaton.States.Count);
             builder.StartStateIndex = BuildEpsilonClosure(automaton.Start);
 
@@ -2070,7 +2070,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             // An automaton, product with which will make every self-loop converging
             var uniformDist = new TElementDistribution();
             uniformDist.SetToUniform();
-            var theConverger = Builder.Zero();
+            var theConverger = new Builder();
             Weight transitionWeight = Weight.Product(
                 Weight.FromLogValue(-uniformDist.GetLogAverageOf(uniformDist)),
                 Weight.FromLogValue(-maxLogTransitionWeightSum),
@@ -2649,13 +2649,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 res.PruneTransitionsWithLogWeightLessThan = readDouble();
             }
 
-            var builder = new Builder();
+            var builder = new Builder(0);
 
             if (hasStartState)
             {
                 // Start state is also present in the list of all states, so read it into temp builder where
                 // it will get index 0. But keep real deserialized start state index to be used in real builder
-                var tempBuilder = new Builder();
+                var tempBuilder = new Builder(0);
                 builder.StartStateIndex =
                     State.ReadTo(ref tempBuilder, readInt32, readDouble, readElementDistribution, checkIndex: false);
             }

--- a/src/Runtime/Distributions/Automata/GraphVizAutomatonFormat.cs
+++ b/src/Runtime/Distributions/Automata/GraphVizAutomatonFormat.cs
@@ -48,10 +48,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             // Specify transitions
             foreach (var state in automaton.States)
             {
-                for (int i = 0; i < state.TransitionCount; ++i)
+                foreach (var transition in state.Transitions)
                 {
-                    var transition = state.GetTransition(i);
-                    
                     string transitionLabel;
                     if (transition.IsEpsilon)
                     {

--- a/src/Runtime/Distributions/Automata/ListAutomaton.cs
+++ b/src/Runtime/Distributions/Automata/ListAutomaton.cs
@@ -26,14 +26,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         protected ListAutomaton()
         {
         }
-
-        /// <summary>
-        /// Constructor used during deserialization by Newtonsoft.Json and BinaryFormatter .
-        /// </summary>
-        protected ListAutomaton(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
     }
 
     /// <summary>
@@ -52,14 +44,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         }
 
         /// <summary>
-        /// Constructor used during deserialization by Newtonsoft.Json and BinaryFormatter .
-        /// </summary>
-        protected ListAutomaton(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
-
-        /// <summary>
         /// Computes a set of outgoing transitions from a given state of the determinization result.
         /// </summary>
         /// <param name="sourceState">The source state of the determinized automaton represented as 
@@ -69,7 +53,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// The first two elements of a tuple define the element distribution and the weight of a transition.
         /// The third element defines the outgoing state.
         /// </returns>
-        protected override IEnumerable<Tuple<TElementDistribution, Weight, Determinization.WeightedStateSet>> GetOutgoingTransitionsForDeterminization(
+        protected override List<(TElementDistribution, Weight, Determinization.WeightedStateSet)> GetOutgoingTransitionsForDeterminization(
             Determinization.WeightedStateSet sourceState)
         {
             throw new NotImplementedException("Determinization is not yet supported for this type of automata.");
@@ -91,14 +75,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         }
 
         /// <summary>
-        /// Constructor used during deserialization by Newtonsoft.Json and BinaryFormatter .
-        /// </summary>
-        protected ListAutomaton(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
-
-        /// <summary>
         /// Computes a set of outgoing transitions from a given state of the determinization result.
         /// </summary>
         /// <param name="sourceState">The source state of the determinized automaton represented as 
@@ -108,7 +84,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// The first two elements of a tuple define the element distribution and the weight of a transition.
         /// The third element defines the outgoing state.
         /// </returns>
-        protected override IEnumerable<Tuple<TElementDistribution, Weight, Determinization.WeightedStateSet>> GetOutgoingTransitionsForDeterminization(
+        protected override List<(TElementDistribution, Weight, Determinization.WeightedStateSet)> GetOutgoingTransitionsForDeterminization(
             Determinization.WeightedStateSet sourceState)
         {
             throw new NotImplementedException();

--- a/src/Runtime/Distributions/Automata/PairDistribution.cs
+++ b/src/Runtime/Distributions/Automata/PairDistribution.cs
@@ -6,6 +6,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
     using System.Diagnostics;
     using Microsoft.ML.Probabilistic.Collections;
+    using Microsoft.ML.Probabilistic.Core.Collections;
     using Microsoft.ML.Probabilistic.Distributions;
     using Microsoft.ML.Probabilistic.Factors.Attributes;
     using Microsoft.ML.Probabilistic.Math;

--- a/src/Runtime/Distributions/Automata/PairDistribution.cs
+++ b/src/Runtime/Distributions/Automata/PairDistribution.cs
@@ -6,7 +6,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
     using System.Diagnostics;
     using Microsoft.ML.Probabilistic.Collections;
-    using Microsoft.ML.Probabilistic.Core.Collections;
     using Microsoft.ML.Probabilistic.Distributions;
     using Microsoft.ML.Probabilistic.Factors.Attributes;
     using Microsoft.ML.Probabilistic.Math;

--- a/src/Runtime/Distributions/Automata/PairDistributionBase.cs
+++ b/src/Runtime/Distributions/Automata/PairDistributionBase.cs
@@ -6,6 +6,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
     using System;
     using Microsoft.ML.Probabilistic.Collections;
+    using Microsoft.ML.Probabilistic.Core.Collections;
     using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Utilities;
 

--- a/src/Runtime/Distributions/Automata/PairDistributionBase.cs
+++ b/src/Runtime/Distributions/Automata/PairDistributionBase.cs
@@ -6,7 +6,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
     using System;
     using Microsoft.ML.Probabilistic.Collections;
-    using Microsoft.ML.Probabilistic.Core.Collections;
     using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Utilities;
 

--- a/src/Runtime/Distributions/Automata/RegexpTreeBuilder.cs
+++ b/src/Runtime/Distributions/Automata/RegexpTreeBuilder.cs
@@ -96,9 +96,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 {
                     var state = currentComponent.GetStateByIndex(stateIndex);
                     RegexpTreeNode<TElement> stateDownwardRegexp = state.CanEnd ? RegexpTreeNode<TElement>.Empty() : RegexpTreeNode<TElement>.Nothing();
-                    for (int transitionIndex = 0; transitionIndex < state.TransitionCount; ++transitionIndex)
+
+                    foreach (var transition in state.Transitions)
                     {
-                        var transition = state.GetTransition(transitionIndex);
                         var destState = automaton.States[transition.DestinationStateIndex];
                         if (!transition.Weight.IsZero && !currentComponent.HasState(destState))
                         {
@@ -180,9 +180,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                                 return true;
                             }
 
-                            for (int tidx = 0; tidx < s.TransitionCount; ++tidx)
+                            foreach (var t in s.Transitions)
                             {
-                                var t = s.GetTransition(tidx);
                                 var dest = automaton.States[t.DestinationStateIndex];
                                 if ((!t.Weight.IsZero) && (!currentComponent.HasState(dest)))
                                 {
@@ -207,10 +206,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                                     continue;
                                 }
 
-                                var trans = s1.GetTransitions();
-                                for (int tIdx = 0; tIdx < trans.Length; tIdx++)
+                                foreach (var t in s1.Transitions)
                                 {
-                                    var t = trans[tIdx];
                                     if (t.DestinationStateIndex == sIdx && !t.Weight.IsZero)
                                     {
                                         return true;
@@ -238,9 +235,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     }
 
                     var outgoingRegexes = new Dictionary<int, RegexpTreeNode<TElement>>();
-                    for (int transitionIndex = 0; transitionIndex < state.TransitionCount; ++transitionIndex)
+                    foreach (var transition in state.Transitions)
                     {
-                        var transition = state.GetTransition(transitionIndex);
                         var destState = automaton.States[transition.DestinationStateIndex];
                         if ((!transition.Weight.IsZero) && (!currentComponent.HasState(destState)))
                         {
@@ -377,9 +373,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 var state = component.GetStateByIndex(stateIndex);
                 regexps[stateIndex, stateIndex] = RegexpTreeNode<TElement>.Empty();
 
-                for (int transitionIndex = 0; transitionIndex < state.TransitionCount; ++transitionIndex)
+                foreach (var transition in state.Transitions)
                 {
-                    var transition = state.GetTransition(transitionIndex);
                     if (transition.Weight.IsZero)
                     {
                         continue;

--- a/src/Runtime/Distributions/Automata/RegexpTreeNode.cs
+++ b/src/Runtime/Distributions/Automata/RegexpTreeNode.cs
@@ -12,7 +12,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System.Text;
 
     using Microsoft.ML.Probabilistic.Collections;
-    using Microsoft.ML.Probabilistic.Core.Collections;
     using Microsoft.ML.Probabilistic.Utilities;
 
     /// <summary>

--- a/src/Runtime/Distributions/Automata/RegexpTreeNode.cs
+++ b/src/Runtime/Distributions/Automata/RegexpTreeNode.cs
@@ -12,6 +12,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System.Text;
 
     using Microsoft.ML.Probabilistic.Collections;
+    using Microsoft.ML.Probabilistic.Core.Collections;
     using Microsoft.ML.Probabilistic.Utilities;
 
     /// <summary>
@@ -306,14 +307,14 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="discreteChar">The Discrete distribution over characters.</param>
         private static void AppendRangesForDiscreteChar(StringBuilder resultBuilder, DiscreteChar discreteChar)
         {
-            var ranges = discreteChar.GetRanges();
-            if (ranges.Length > 1)
+            var ranges = discreteChar.Ranges;
+            if (ranges.Count > 1)
             {
                 resultBuilder.Append('[');
                 ranges.ForEach(range => AppendCharacterRange(resultBuilder, range));
                 resultBuilder.Append(']');
             }
-            else if (ranges.Length == 1)
+            else if (ranges.Count == 1)
             {
                 AppendCharacterRange(resultBuilder, ranges.Single());
             }

--- a/src/Runtime/Distributions/Automata/Transducer.cs
+++ b/src/Runtime/Distributions/Automata/Transducer.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System;
     using System.Collections.Generic;
 
-    using Microsoft.ML.Probabilistic.Core.Collections;
+    using Microsoft.ML.Probabilistic.Collections;
     using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Utilities;
 

--- a/src/Runtime/Distributions/Automata/TransducerBase.cs
+++ b/src/Runtime/Distributions/Automata/TransducerBase.cs
@@ -9,7 +9,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System.Diagnostics;
     using System.Linq;
     using Microsoft.ML.Probabilistic.Collections;
-    using Microsoft.ML.Probabilistic.Core.Collections;
     using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Utilities;
 

--- a/src/Runtime/Distributions/Automata/TransducerBase.cs
+++ b/src/Runtime/Distributions/Automata/TransducerBase.cs
@@ -9,6 +9,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System.Diagnostics;
     using System.Linq;
     using Microsoft.ML.Probabilistic.Collections;
+    using Microsoft.ML.Probabilistic.Core.Collections;
     using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Utilities;
 
@@ -71,7 +72,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             var result = new TThis();
             result.sequencePairToWeight.SetToFunction(
                 srcAutomaton,
-                (dist, weight, group) => Tuple.Create(
+                (dist, weight, group) => ValueTuple.Create(
                     dist.HasValue
                         ? Option.Some(PairDistributionBase<TSrcElement, TSrcElementDistribution, TDestElement, TDestElementDistribution, TPairDistribution>.FromFirst(dist))
                         : Option.None,
@@ -112,7 +113,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             var result = new TThis();
             result.sequencePairToWeight.SetToFunction(
                 destAutomaton,
-                (dist, weight, group) => Tuple.Create(
+                (dist, weight, group) => ValueTuple.Create(
                     dist.HasValue
                         ? Option.Some(PairDistributionBase<TSrcElement, TSrcElementDistribution, TDestElement, TDestElementDistribution, TPairDistribution>.FromSecond(dist))
                         : Option.None,
@@ -322,21 +323,84 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         {
             Argument.CheckIfNotNull(srcAutomaton, "srcAutomaton");
 
-            var result = new TDestAutomaton();
-            result.SetToZero();
+            var result = Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.Builder.Zero();
 
-            if (!srcAutomaton.IsCanonicZero() && !this.sequencePairToWeight.IsCanonicZero())
+            if (srcAutomaton.IsCanonicZero() || this.sequencePairToWeight.IsCanonicZero())
             {
-                // The projected automaton must be epsilon-free
-                srcAutomaton.MakeEpsilonFree();
-
-                var destStateCache = new Dictionary<(int, int), Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.State>();
-                result.Start = this.BuildProjectionOfAutomaton(result, this.sequencePairToWeight.Start, srcAutomaton.Start, destStateCache);
-                result.RemoveDeadStates();
-                result.SimplifyIfNeeded();
+                return result.GetAutomaton();
             }
 
-            return result;
+            // The projected automaton must be epsilon-free
+            srcAutomaton.MakeEpsilonFree();
+
+            var destStateCache = new Dictionary<(int, int), int>();
+            result.StartStateIndex = BuildProjectionOfAutomaton(this.sequencePairToWeight.Start, srcAutomaton.Start);
+
+            var simplification = new Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.Simplification(result, null);
+            simplification.RemoveDeadStates();
+            simplification.SimplifyIfNeeded();
+
+            return result.GetAutomaton();
+            
+            // Recursively builds the projection of a given automaton onto this transducer.
+            // The projected automaton must be epsilon-free.
+            int BuildProjectionOfAutomaton(
+                PairListAutomaton.State mappingState,
+                Automaton<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton>.State srcState)
+            {
+                //// The code of this method has a lot in common with the code of Automaton<>.BuildProduct.
+                //// Unfortunately, it's not clear how to avoid the duplication in the current design.
+
+                // State already exists, return its index
+                var statePair = (mappingState.Index, srcState.Index);
+                if (destStateCache.TryGetValue(statePair, out var destStateIndex))
+                {
+                    return destStateIndex;
+                }
+
+                var destState = result.AddState();
+                destStateCache.Add(statePair, destState.Index);
+
+                // Iterate over transitions from mappingState
+                foreach (var mappingTransition in mappingState.Transitions)
+                {
+                    var childMappingState = mappingState.Owner.States[mappingTransition.DestinationStateIndex];
+
+                    // Epsilon transition case
+                    if (IsSrcEpsilon(mappingTransition))
+                    {
+                        var destElementDistribution =
+                            mappingTransition.ElementDistribution.HasValue
+                                ? mappingTransition.ElementDistribution.Value.Second
+                                : Option.None;
+                        var childDestStateIndex = BuildProjectionOfAutomaton(childMappingState, srcState);
+                        destState.AddTransition(destElementDistribution, mappingTransition.Weight, childDestStateIndex, mappingTransition.Group);
+                        continue;
+                    }
+
+                    // Iterate over states and transitions in the closure of srcState
+                    foreach (var srcTransition in srcState.Transitions)
+                    {
+                        Debug.Assert(!srcTransition.IsEpsilon, "The automaton being projected must be epsilon-free.");
+                        
+                        var srcChildState = srcState.Owner.States[srcTransition.DestinationStateIndex];
+
+                        var projectionLogScale = mappingTransition.ElementDistribution.Value.ProjectFirst(
+                            srcTransition.ElementDistribution.Value, out var destElementDistribution);
+                        if (double.IsNegativeInfinity(projectionLogScale))
+                        {
+                            continue;
+                        }
+
+                        var destWeight = Weight.Product(mappingTransition.Weight, srcTransition.Weight, Weight.FromLogValue(projectionLogScale));
+                        var childDestStateIndex = BuildProjectionOfAutomaton(childMappingState, srcChildState);
+                        destState.AddTransition(destElementDistribution, destWeight, childDestStateIndex, mappingTransition.Group);
+                    }
+                }
+
+                destState.SetEndWeight(Weight.Product(mappingState.EndWeight, srcState.EndWeight));
+                return destState.Index;
+            }
         }
 
         /// <summary>
@@ -352,18 +416,80 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         {
             Argument.CheckIfNotNull(srcSequence, "srcSequence");
 
-            var result = new TDestAutomaton();
-            result.SetToZero();
+            var result = Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.Builder.Zero();
 
-            if (!this.sequencePairToWeight.IsCanonicZero())
+            if (this.sequencePairToWeight.IsCanonicZero())
             {
-                var destStateCache = new Dictionary<(int, int), Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.State>();
-                result.Start = this.BuildProjectionOfSequence(result, this.sequencePairToWeight.Start, srcSequence, 0, destStateCache);
-                result.RemoveDeadStates();
-                result.SimplifyIfNeeded();
+                return result.GetAutomaton();
             }
 
-            return result;
+            var destStateCache = new Dictionary<(int, int), int>();
+            result.StartStateIndex = BuildProjectionOfSequence(this.sequencePairToWeight.Start, 0);
+
+            var simplification = new Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.Simplification(result, null);
+            simplification.RemoveDeadStates();
+            simplification.SimplifyIfNeeded();
+
+            return result.GetAutomaton();
+
+            // Recursively builds the projection of a given sequence onto this transducer.
+            int BuildProjectionOfSequence(PairListAutomaton.State mappingState, int srcSequenceIndex)
+            {
+                //// The code of this method has a lot in common with the code of Automaton<>.BuildProduct.
+                //// Unfortunately, it's not clear how to avoid the duplication in the current design.
+
+                var sourceSequenceManipulator =
+                    Automaton<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton>.SequenceManipulator;
+
+                var statePair = (mappingState.Index, srcSequenceIndex);
+                if (destStateCache.TryGetValue(statePair, out var destStateIndex))
+                {
+                    return destStateIndex;
+                }
+
+                var destState = result.AddState();
+                destStateCache.Add(statePair, destState.Index);
+
+                var srcSequenceLength = sourceSequenceManipulator.GetLength(srcSequence);
+
+                // Enumerate transitions from the current mapping state
+                foreach (var mappingTransition in mappingState.Transitions)
+                {
+                    var destMappingState = mappingState.Owner.States[mappingTransition.DestinationStateIndex];
+
+                    // Epsilon transition case
+                    if (IsSrcEpsilon(mappingTransition))
+                    {
+                        var destElementWeights =
+                            mappingTransition.ElementDistribution.HasValue
+                                ? mappingTransition.ElementDistribution.Value.Second
+                                : Option.None;
+                        var childDestStateIndex = BuildProjectionOfSequence(destMappingState, srcSequenceIndex);
+                        destState.AddTransition(destElementWeights, mappingTransition.Weight, childDestStateIndex, mappingTransition.Group);
+                        continue;
+                    }
+
+                    // Normal transition case - Find epsilon-reachable states
+                    if (srcSequenceIndex < srcSequenceLength)
+                    {
+                        var srcSequenceElement = sourceSequenceManipulator.GetElement(srcSequence, srcSequenceIndex);
+
+                        var projectionLogScale = mappingTransition.ElementDistribution.Value.ProjectFirst(
+                            srcSequenceElement, out var destElementDistribution);
+                        if (double.IsNegativeInfinity(projectionLogScale))
+                        {
+                            continue;
+                        }
+
+                        var weight = Weight.Product(mappingTransition.Weight, Weight.FromLogValue(projectionLogScale));
+                        var childDestState = BuildProjectionOfSequence(destMappingState,srcSequenceIndex + 1);
+                        destState.AddTransition(destElementDistribution, weight, childDestState, mappingTransition.Group);
+                    }
+                }
+
+                destState.SetEndWeight(srcSequenceIndex == srcSequenceLength ? mappingState.EndWeight : Weight.Zero);
+                return destState.Index;
+            }
         }
 
         /// <summary>
@@ -400,157 +526,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         private static bool IsSrcEpsilon(PairListAutomaton.Transition transition) =>
             !transition.ElementDistribution.HasValue || !transition.ElementDistribution.Value.First.HasValue;
 
-        /// <summary>
-        /// Recursively builds the projection of a given sequence onto this transducer.
-        /// </summary>
-        /// <param name="destAutomaton">The projection being built.</param>
-        /// <param name="mappingState">The currently traversed state of the transducer.</param>
-        /// <param name="srcSequence">The sequence being projected.</param>
-        /// <param name="srcSequenceIndex">The current index in the sequence being projected.</param>
-        /// <param name="destStateCache">The cache of the created projection states.</param>
-        /// <returns>The state of the projection corresponding to the given mapping state and the position in the projected sequence.</returns>
-        private Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.State BuildProjectionOfSequence(
-            TDestAutomaton destAutomaton,
-            PairListAutomaton.State mappingState,
-            TSrcSequence srcSequence,
-            int srcSequenceIndex,
-            Dictionary<(int, int), Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.State> destStateCache)
-        {
-            //// The code of this method has a lot in common with the code of Automaton<>.BuildProduct.
-            //// Unfortunately, it's not clear how to avoid the duplication in the current design.
-
-            var sourceSequenceManipulator =
-                Automaton<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton>.SequenceManipulator;
-
-            var statePair = (mappingState.Index, srcSequenceIndex);
-            Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.State destState;
-            if (destStateCache.TryGetValue(statePair, out destState))
-            {
-                return destState;
-            }
-
-            destState = destAutomaton.AddState();
-            destStateCache.Add(statePair, destState);
-
-            int srcSequenceLength = sourceSequenceManipulator.GetLength(srcSequence);
-
-            // Enumerate transitions from the current mapping state
-            for (int i = 0; i < mappingState.TransitionCount; i++)
-            {
-                var mappingTransition = mappingState.GetTransition(i);
-                var destMappingState = mappingState.Owner.States[mappingTransition.DestinationStateIndex];
-
-                // Epsilon transition case
-                if (IsSrcEpsilon(mappingTransition))
-                {
-                    var destElementWeights =
-                        mappingTransition.ElementDistribution.HasValue
-                            ? mappingTransition.ElementDistribution.Value.Second
-                            : Option.None;
-                    var childDestState = this.BuildProjectionOfSequence(
-                        destAutomaton, destMappingState, srcSequence, srcSequenceIndex, destStateCache);
-                    destState.AddTransition(destElementWeights, mappingTransition.Weight, childDestState, mappingTransition.Group);
-                    continue;
-                }
-
-                // Normal transition case - Find epsilon-reachable states
-                if (srcSequenceIndex < srcSequenceLength)
-                {
-                    var srcSequenceElement = sourceSequenceManipulator.GetElement(srcSequence, srcSequenceIndex);
-
-                    double projectionLogScale = mappingTransition.ElementDistribution.Value.ProjectFirst(
-                        srcSequenceElement, out var destElementDistribution);
-                    if (double.IsNegativeInfinity(projectionLogScale))
-                    {
-                        continue;
-                    }
-
-                    Weight weight = Weight.Product(mappingTransition.Weight, Weight.FromLogValue(projectionLogScale));
-                    var childDestState = this.BuildProjectionOfSequence(
-                        destAutomaton, destMappingState, srcSequence, srcSequenceIndex + 1, destStateCache);
-                    destState.AddTransition(destElementDistribution, weight, childDestState, mappingTransition.Group);
-                }
-            }
-
-            destState.SetEndWeight(srcSequenceIndex == srcSequenceLength ? mappingState.EndWeight : Weight.Zero);
-            return destState;
-        }
-
-        /// <summary>
-        /// Recursively builds the projection of a given automaton onto this transducer.
-        /// The projected automaton must be epsilon-free.
-        /// </summary>
-        /// <param name="destAutomaton">The projection being built.</param>
-        /// <param name="mappingState">The currently traversed state of the transducer.</param>
-        /// <param name="srcState">The currently traversed state of the automaton being projected.</param>
-        /// <param name="destStateCache">The cache of the created projection states.</param>
-        /// <returns>The state of the projection corresponding to the given mapping state and the position in the projected sequence.</returns>
-        private Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.State BuildProjectionOfAutomaton(
-            TDestAutomaton destAutomaton,
-            PairListAutomaton.State mappingState,
-            Automaton<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton>.State srcState,
-            Dictionary<(int, int), Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.State> destStateCache)
-        {
-            Debug.Assert(!mappingState.IsNull && srcState != null, "Valid states must be provided.");
-            Debug.Assert(!ReferenceEquals(srcState.Owner, destAutomaton), "Cannot build a projection in place.");
-            
-            //// The code of this method has a lot in common with the code of Automaton<>.BuildProduct.
-            //// Unfortunately, it's not clear how to avoid the duplication in the current design.
-
-            // State already exists, return its index
-            var statePair = (mappingState.Index, srcState.Index);
-            Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.State destState;
-            if (destStateCache.TryGetValue(statePair, out destState))
-            {
-                return destState;
-            }
-
-            destState = destAutomaton.AddState();
-            destStateCache.Add(statePair, destState);
-
-            // Iterate over transitions from mappingState
-            for (int mappingTransitionIndex = 0; mappingTransitionIndex < mappingState.TransitionCount; mappingTransitionIndex++)
-            {
-                var mappingTransition = mappingState.GetTransition(mappingTransitionIndex);
-                var childMappingState = mappingState.Owner.States[mappingTransition.DestinationStateIndex];
-
-                // Epsilon transition case
-                if (IsSrcEpsilon(mappingTransition))
-                {
-                    var destElementDistribution =
-                        mappingTransition.ElementDistribution.HasValue
-                            ? mappingTransition.ElementDistribution.Value.Second
-                            : Option.None;
-                    var childDestState = this.BuildProjectionOfAutomaton(destAutomaton, childMappingState, srcState, destStateCache);
-                    destState.AddTransition(destElementDistribution, mappingTransition.Weight, childDestState, mappingTransition.Group);
-                    continue;
-                }
-
-                // Iterate over states and transitions in the closure of srcState
-                for (int srcTransitionIndex = 0; srcTransitionIndex < srcState.TransitionCount; srcTransitionIndex++)
-                {
-                    var srcTransition = srcState.GetTransition(srcTransitionIndex);
-                    Debug.Assert(!srcTransition.IsEpsilon, "The automaton being projected must be epsilon-free.");
-                    
-                    var srcChildState = srcState.Owner.States[srcTransition.DestinationStateIndex];
-
-                    double projectionLogScale = mappingTransition.ElementDistribution.Value.ProjectFirst(
-                        srcTransition.ElementDistribution.Value, out var destElementDistribution);
-                    if (double.IsNegativeInfinity(projectionLogScale))
-                    {
-                        continue;
-                    }
-
-                    Weight destWeight = Weight.Product(mappingTransition.Weight, srcTransition.Weight, Weight.FromLogValue(projectionLogScale));
-                    var childDestState = this.BuildProjectionOfAutomaton(destAutomaton, childMappingState, srcChildState, destStateCache);
-                    destState.AddTransition(destElementDistribution, destWeight, childDestState, mappingTransition.Group);
-                }
-            }
-
-            destState.SetEndWeight(Weight.Product(mappingState.EndWeight, srcState.EndWeight));
-            return destState;
-        }
-
         #endregion
 
         #region Nested classes
@@ -571,7 +546,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// The first two elements of a tuple define the element distribution and the weight of a transition.
             /// The third element defines the outgoing state.
             /// </returns>
-            protected override IEnumerable<Tuple<TPairDistribution, Weight, Determinization.WeightedStateSet>> GetOutgoingTransitionsForDeterminization(
+            protected override List<(TPairDistribution, Weight, Determinization.WeightedStateSet)> GetOutgoingTransitionsForDeterminization(
                 Determinization.WeightedStateSet sourceState)
             {
                 throw new NotImplementedException("Determinization is not yet supported for this type of automata.");

--- a/src/Runtime/Distributions/Automata/TransducerBase.cs
+++ b/src/Runtime/Distributions/Automata/TransducerBase.cs
@@ -322,7 +322,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         {
             Argument.CheckIfNotNull(srcAutomaton, "srcAutomaton");
 
-            var result = Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.Builder.Zero();
+            var result = new Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.Builder();
 
             if (srcAutomaton.IsCanonicZero() || this.sequencePairToWeight.IsCanonicZero())
             {
@@ -415,7 +415,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         {
             Argument.CheckIfNotNull(srcSequence, "srcSequence");
 
-            var result = Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.Builder.Zero();
+            var result = new Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.Builder();
 
             if (this.sequencePairToWeight.IsCanonicZero())
             {

--- a/src/Runtime/Distributions/DiscreteChar.cs
+++ b/src/Runtime/Distributions/DiscreteChar.cs
@@ -20,8 +20,6 @@ namespace Microsoft.ML.Probabilistic.Distributions
     using Utilities;
     using Factors.Attributes;
 
-    using Microsoft.ML.Probabilistic.Core.Collections;
-
     using Serialization;
 
     /// <summary>

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -224,7 +224,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </remarks>
         public static TThis SingleElement(TElementDistribution elementDistribution)
         {
-            var func = Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>.Builder.Zero();
+            var func = new Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>.Builder();
             var end = func.Start.AddTransition(elementDistribution, Weight.One);
             end.SetEndWeight(Weight.One);
             return FromWorkspace(func.GetAutomaton());
@@ -424,7 +424,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 ? Weight.One
                 : Weight.FromLogValue(distLogNormalizer);
 
-            var func = Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>.Builder.Zero();
+            var func = new Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>.Builder();
             var state = func.Start;
 
             int iterationBound = maxTimes.HasValue ? maxTimes.Value : minTimes;

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices.ComTypes;
+
 namespace Microsoft.ML.Probabilistic.Distributions
 {
     using System;
@@ -239,6 +241,24 @@ namespace Microsoft.ML.Probabilistic.Distributions
         {
             var sequence = SequenceManipulator.ToSequence(new List<TElement> { element });
             return PointMass(sequence);
+        }
+
+        /// <summary>
+        /// Creates a distribution over sequences induced by a given list of distributions over sequence elements.
+        /// </summary>
+        /// <param name="sequence">Enumerable of distributions over sequence elements.</param>
+        /// <returns>The created distribution.</returns>
+        public static TThis Consecutive(IEnumerable<TElementDistribution> sequence)
+        {
+            var result = new Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>.Builder();
+            var last = result.Start;
+            foreach (var elem in sequence)
+            {
+                last = last.AddTransition(elem, Weight.One);
+            }
+            
+            last.SetEndWeight(Weight.One);
+            return FromWorkspace(result.GetAutomaton());
         }
 
         /// <summary>

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -248,7 +248,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </summary>
         /// <param name="sequence">Enumerable of distributions over sequence elements.</param>
         /// <returns>The created distribution.</returns>
-        public static TThis Consecutive(IEnumerable<TElementDistribution> sequence)
+        public static TThis Concatenate(IEnumerable<TElementDistribution> sequence)
         {
             var result = new Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>.Builder();
             var last = result.Start;

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -224,10 +224,10 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </remarks>
         public static TThis SingleElement(TElementDistribution elementDistribution)
         {
-            var func = Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>.Zero();
+            var func = Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>.Builder.Zero();
             var end = func.Start.AddTransition(elementDistribution, Weight.One);
             end.SetEndWeight(Weight.One);
-            return FromWorkspace(func);
+            return FromWorkspace(func.GetAutomaton());
         }
 
         /// <summary>
@@ -423,7 +423,8 @@ namespace Microsoft.ML.Probabilistic.Distributions
             var weight = uniformity == DistributionKind.UniformOverLengthThenValue
                 ? Weight.One
                 : Weight.FromLogValue(distLogNormalizer);
-            var func = Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>.Zero();
+
+            var func = Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TWeightFunction>.Builder.Zero();
             var state = func.Start;
 
             int iterationBound = maxTimes.HasValue ? maxTimes.Value : minTimes;
@@ -443,7 +444,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 state.AddSelfTransition(allowedElements, weight);
             }
 
-            return FromWorkspace(func);
+            return FromWorkspace(func.GetAutomaton());
         }
 
         /// <summary>
@@ -1444,10 +1445,8 @@ namespace Microsoft.ML.Probabilistic.Distributions
             {
                 double logSample = Math.Log(Rand.Double());
                 Weight probSum = Weight.Zero;
-                for (int i = 0; i < currentState.TransitionCount; ++i)
+                foreach (var transition in currentState.Transitions)
                 {
-                    var transition = currentState.GetTransition(i);
-
                     probSum = Weight.Sum(probSum, transition.Weight);
                     if (logSample < probSum.LogValue)
                     {

--- a/src/Runtime/Distributions/StringDistribution.cs
+++ b/src/Runtime/Distributions/StringDistribution.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <returns>The created distribution.</returns>
         public static StringDistribution CaseInvariant(string template)
         {
-            var result = StringAutomaton.Builder.Zero();
+            var result = new StringAutomaton.Builder();
             var last = result.Start;
             foreach (var ch in template)
             {

--- a/src/Runtime/Distributions/StringDistribution.cs
+++ b/src/Runtime/Distributions/StringDistribution.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
+
 namespace Microsoft.ML.Probabilistic.Distributions
 {
     using System;
@@ -69,30 +71,24 @@ namespace Microsoft.ML.Probabilistic.Distributions
         {
             return StringDistribution.SingleElement(characterDist);
         }
-        
+
         /// <summary>
         /// Creates a uniform distribution over all strings that are case-invariant matches of the specified string.
         /// </summary>
         /// <param name="template">The string to match.</param>
         /// <returns>The created distribution.</returns>
-        public static StringDistribution CaseInvariant(string template)
-        {
-            var result = new StringAutomaton.Builder();
-            var last = result.Start;
-            foreach (var ch in template)
-            {
-                var upper = char.ToUpperInvariant(ch);
-                var lower = char.ToLowerInvariant(ch);
-                var elem =
-                    upper == lower
-                        ? DiscreteChar.PointMass(lower)
-                        : DiscreteChar.OneOf(lower, upper);
-                last = last.AddTransition(elem, Weight.One);
-            }
-            
-            last.SetEndWeight(Weight.One);
-            return StringDistribution.FromWorkspace(result.GetAutomaton());
-        }
+        public static StringDistribution CaseInvariant(string template) =>
+            StringDistribution.Consecutive(
+                template.Select(
+                    ch =>
+                    {
+                        var upper = char.ToUpperInvariant(ch);
+                        var lower = char.ToLowerInvariant(ch);
+                        return
+                            upper == lower
+                                ? DiscreteChar.PointMass(lower)
+                                : DiscreteChar.OneOf(lower, upper);
+                    }));
 
         /// <summary>
         /// Creates a uniform distribution over strings of lowercase letters, with length within the given bounds.

--- a/src/Runtime/Distributions/StringDistribution.cs
+++ b/src/Runtime/Distributions/StringDistribution.cs
@@ -78,7 +78,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <param name="template">The string to match.</param>
         /// <returns>The created distribution.</returns>
         public static StringDistribution CaseInvariant(string template) =>
-            StringDistribution.Consecutive(
+            StringDistribution.Concatenate(
                 template.Select(
                     ch =>
                     {

--- a/src/Runtime/Distributions/StringDistribution.cs
+++ b/src/Runtime/Distributions/StringDistribution.cs
@@ -77,22 +77,21 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <returns>The created distribution.</returns>
         public static StringDistribution CaseInvariant(string template)
         {
-            StringDistribution result = StringDistribution.Empty();
+            var result = StringAutomaton.Builder.Zero();
+            var last = result.Start;
             foreach (var ch in template)
             {
                 var upper = char.ToUpperInvariant(ch);
                 var lower = char.ToLowerInvariant(ch);
-                if (upper == lower)
-                {
-                    result.AppendInPlace(ch);
-                }
-                else
-                {
-                    result.AppendInPlace(DiscreteChar.OneOf(lower, upper));
-                }
+                var elem =
+                    upper == lower
+                        ? DiscreteChar.PointMass(lower)
+                        : DiscreteChar.OneOf(lower, upper);
+                last = last.AddTransition(elem, Weight.One);
             }
             
-            return result;
+            last.SetEndWeight(Weight.One);
+            return StringDistribution.FromWorkspace(result.GetAutomaton());
         }
 
         /// <summary>

--- a/src/Runtime/Factors/SingleOp.cs
+++ b/src/Runtime/Factors/SingleOp.cs
@@ -46,9 +46,8 @@ namespace Microsoft.ML.Probabilistic.Factors
             {
                 StringAutomaton.State state = startEpsilonClosure.GetStateByIndex(stateIndex);
                 Weight stateLogWeight = startEpsilonClosure.GetStateWeightByIndex(stateIndex);
-                for (int transitionIndex = 0; transitionIndex < state.TransitionCount; ++transitionIndex)
+                foreach (var transition in state.Transitions)
                 {
-                    StringAutomaton.Transition transition = state.GetTransition(transitionIndex);
                     if (!transition.IsEpsilon)
                     {
                         StringAutomaton.State destState = probFunc.States[transition.DestinationStateIndex];

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Clone()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.One).SetEndWeight(Weight.One);
 
             var automaton = builder.GetAutomaton();
@@ -88,14 +88,14 @@ namespace Microsoft.ML.Probabilistic.Tests
             Assert.True(zero7.IsCanonicZero());
             StringInferenceTestUtilities.TestValue(zero7, 0.0, "abc", "ab", "a", string.Empty);
 
-            var zero8Builder = StringAutomaton.Builder.Zero();
+            var zero8Builder = new StringAutomaton.Builder();
             zero8Builder.Start.AddTransition('a', Weight.One);
             var zero8 = zero8Builder.GetAutomaton();
             Assert.True(zero8.IsZero());
             Assert.False(zero8.IsCanonicZero());
             StringInferenceTestUtilities.TestValue(zero8, 0.0, "abc", "ab", "a", string.Empty);
 
-            var zero9Builder = StringAutomaton.Builder.Zero();
+            var zero9Builder = new StringAutomaton.Builder();
             zero9Builder.Start.AddTransition('a', Weight.One);
             zero9Builder.Start.AddTransition('b', Weight.One, zero9Builder.StartStateIndex);
             zero9Builder.Start.AddTransitionsForSequence("abc");
@@ -390,7 +390,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ProductNoDeadBranches()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.One).AddTransition('b', Weight.One).SetEndWeight(Weight.One);
             builder.Start.AddTransition('a', Weight.One).AddTransition('c', Weight.One).SetEndWeight(Weight.One);
             var automaton = builder.GetAutomaton();
@@ -462,7 +462,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Reverse2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             var otherState = builder.Start.AddSelfTransition('a', Weight.FromValue(0.5)).AddTransition('b', Weight.FromValue(0.7));
             builder.Start.SetEndWeight(Weight.FromValue(0.3));
             otherState.SetEndWeight(Weight.FromValue(0.8));
@@ -617,7 +617,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NormalizeValuesDeadBranch()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransitionsForSequence("abc");
             builder.Start.AddTransitionsForSequence("def").SetEndWeight(Weight.FromValue(4.0));
             var automaton = builder.GetAutomaton();
@@ -640,7 +640,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             const double TransitionProbability = 0.7;
             const double EndWeight = 10.0;
 
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddSelfTransition('a', Weight.FromValue(TransitionProbability));
             builder.Start.SetEndWeight(Weight.FromValue(EndWeight));
             var automaton = builder.GetAutomaton();
@@ -677,7 +677,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             TestNonNormalizable(StringAutomaton.ConstantLog(Math.Log(0.87)), false);
             TestNonNormalizable(StringAutomaton.ConstantLog(Math.Log(0.01), DiscreteChar.PointMass('a')), false);
 
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddSelfTransition('a', Weight.FromValue(1.01));
             builder.Start.SetEndWeight(Weight.One);
             TestNonNormalizable(builder.GetAutomaton(), false);
@@ -719,7 +719,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void EpsilonClosure2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             var state = builder.Start;
             const int ChainLength = 16;
             for (int i = 0; i < ChainLength; ++i)
@@ -772,7 +772,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             int stateCount = Environment.Is64BitProcess  ? 600 : 1500; // Stack frames are larger on 64bit
             Debug.Assert(stateCount <= StringAutomaton.MaxStateCount, "MaxStateCount must be adjusted first.");
 
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             var state = builder.Start;
             
             for (int i = 1; i < stateCount; ++i)
@@ -866,7 +866,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToString1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.One).AddSelfTransition('b', Weight.One).AddTransition('c', Weight.One).SetEndWeight(Weight.One);
             var automaton = builder.GetAutomaton();
             Assert.Equal("ab*c", automaton.ToString(AutomatonFormats.Friendly));
@@ -881,7 +881,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToString2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             var middleState = builder.Start.AddTransition('b', Weight.One).AddTransition('c', Weight.One);
             builder.Start.AddTransition('a', Weight.One, middleState.Index);
             middleState.AddTransition('d', Weight.One).SetEndWeight(Weight.One);
@@ -897,7 +897,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToString3()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransitionsForSequence("hello").SetEndWeight(Weight.One);
             var automaton = builder.GetAutomaton();
             Assert.Equal("hello", automaton.ToString(AutomatonFormats.Friendly));
@@ -911,7 +911,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToString4()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransitionsForSequence("hello").SetEndWeight(Weight.Zero);
             var automaton = builder.GetAutomaton();
             Assert.Equal("Ø", automaton.ToString(AutomatonFormats.Friendly));
@@ -925,7 +925,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToString5()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransitionsForSequence("hello").SetEndWeight(Weight.One);
             builder.Start.AddEpsilonTransition(Weight.One).AddTransitionsForSequence("hi").SetEndWeight(Weight.One);
             builder.Start.AddEpsilonTransition(Weight.One).AddTransitionsForSequence("hey").SetEndWeight(Weight.One);
@@ -1029,7 +1029,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void RegexForAutomatonWithNonTrivialComponent()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.AddStates(7);
 
             builder[0].AddTransition('a', Weight.FromValue(1), 1);
@@ -1074,7 +1074,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void RegexForAutomatonWithNonTrivialComponent2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.AddStates(7);
 
             builder[0].AddTransition('a', Weight.FromValue(1), 1);
@@ -1177,7 +1177,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Equality3()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.SetEndWeight(Weight.One);
             builder.Start.AddSelfTransition(DiscreteChar.Lower(), Weight.FromLogValue(26 + 1e-3));
             var automaton = builder.GetAutomaton();
@@ -1193,7 +1193,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Equality4()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.SetEndWeight(Weight.One);
             builder.Start.AddSelfTransition('a', Weight.FromLogValue(1.0 - 1e-3));
             var automaton = builder.GetAutomaton();
@@ -1212,7 +1212,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             AssertEquals(StringAutomaton.Zero(), StringAutomaton.Zero());
             AssertNotEquals(StringAutomaton.Zero(), StringAutomaton.Constant(1.0));
 
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.One);
             var automaton = builder.GetAutomaton();
 
@@ -1228,7 +1228,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             StringAutomaton func1 = StringAutomaton.Constant(1.0, DiscreteChar.OneOf('a', 'b'));
 
-            var func2Builder = StringAutomaton.Builder.Zero();
+            var func2Builder = new StringAutomaton.Builder();
             func2Builder.Start.AddSelfTransition('a', Weight.One).AddSelfTransition('b', Weight.One).SetEndWeight(Weight.One);
             var func2 = func2Builder.GetAutomaton();
 
@@ -1242,11 +1242,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Equality7()
         {
-            var func1Builder = StringAutomaton.Builder.Zero();
+            var func1Builder = new StringAutomaton.Builder();
             func1Builder.Start.AddSelfTransition(DiscreteChar.PointMass('a'), Weight.One).SetEndWeight(Weight.One);
             var func1 = func1Builder.GetAutomaton();
 
-            var func2Builder = StringAutomaton.Builder.Zero();
+            var func2Builder = new StringAutomaton.Builder();
             func2Builder.Start
                 .AddEpsilonTransition(Weight.One)
                 .AddTransition(DiscreteChar.PointMass('a'), Weight.One, func2Builder.StartStateIndex)
@@ -1267,7 +1267,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.One).AddTransition('b', Weight.One).SetEndWeight(
                 Weight.FromValue(2.0));
             builder.Start.AddTransition('a', Weight.One).AddSelfTransition('d', Weight.One).AddTransition('c', Weight.One).SetEndWeight(
@@ -1291,7 +1291,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.One).AddSelfTransition('d', Weight.One).AddTransition('c', Weight.One).SetEndWeight(
                 Weight.FromValue(3.0));
             builder.Start.AddTransition('a', Weight.One).AddTransition('b', Weight.One).SetEndWeight(
@@ -1315,7 +1315,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify3()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.One).AddTransition('d', Weight.One).AddTransition('c', Weight.One).SetEndWeight(
                 Weight.FromValue(2.0));
             builder.Start.AddTransition('a', Weight.One).AddSelfTransition('d', Weight.One).AddTransition('c', Weight.One).SetEndWeight(
@@ -1338,7 +1338,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify4()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddEpsilonTransition(Weight.One).AddSelfTransition('a', Weight.One)
                            .AddEpsilonTransition(Weight.One).AddSelfTransition('b', Weight.One).SetEndWeight(Weight.FromValue(2.0));
             builder.Start.AddEpsilonTransition(Weight.One).AddSelfTransition('a', Weight.One)
@@ -1365,7 +1365,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify5()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             const string AcceptedSequence = "aaaaaaaaaa";
             var state = builder.Start;
             for (int i = 0; i < AcceptedSequence.Length; ++i)
@@ -1400,7 +1400,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify6()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.AddStates(5);
             builder[0].AddTransition('a', Weight.FromValue(1.0), 1);
             builder[0].AddTransition('a', Weight.FromValue(4.0), 4);
@@ -1433,7 +1433,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             DiscreteChar lowerEnglish = DiscreteChar.UniformInRange('a', 'z');
             DiscreteChar upperEnglish = DiscreteChar.UniformInRange('A', 'Z');
 
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             var branch1 = builder.Start.AddEpsilonTransition(Weight.FromValue(0.5)).AddTransition('a', Weight.FromValue(1.0 / 3.0)).AddTransition('B', Weight.FromValue(1.0 / 4.0));
             branch1.SetEndWeight(Weight.FromValue(3.0));
             branch1.AddTransition('X', Weight.FromValue(1.0 / 6.0)).SetEndWeight(Weight.FromValue(5.0));
@@ -1463,7 +1463,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify8()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.AddStates(10);
 
             builder[0].AddTransition('a', Weight.One, 0);
@@ -1538,7 +1538,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.FromValue(2)).AddTransition('b', Weight.FromValue(3)).SetEndWeight(Weight.FromValue(4));
             builder.Start.AddTransition('a', Weight.FromValue(5)).AddTransition('c', Weight.FromValue(6)).SetEndWeight(Weight.FromValue(7));
             builder.Start.SetEndWeight(Weight.FromValue(17));
@@ -1568,7 +1568,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition(DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(2)).AddTransition('b', Weight.FromValue(3)).SetEndWeight(Weight.FromValue(4));
             builder.Start.AddTransition(DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(5)).AddTransition('c', Weight.FromValue(6)).SetEndWeight(Weight.FromValue(7));
             builder.Start.SetEndWeight(Weight.FromValue(17));
@@ -1598,7 +1598,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize3()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition(DiscreteChar.Uniform(), Weight.FromValue(2)).AddTransition('b', Weight.FromValue(3)).SetEndWeight(Weight.FromValue(4));
             builder.Start.AddTransition(DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(5)).AddTransition('c', Weight.FromValue(6)).SetEndWeight(Weight.FromValue(7));
             builder.Start.AddTransition(DiscreteChar.UniformInRange('x', 'z'), Weight.FromValue(8)).AddTransition('d', Weight.FromValue(9)).SetEndWeight(Weight.FromValue(10));
@@ -1633,7 +1633,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize4()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.FromValue(2)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(3.0)).SetEndWeight(Weight.FromValue(4));
             builder.Start.AddTransition('a', Weight.FromValue(5)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('d', Weight.FromValue(6.0)).SetEndWeight(Weight.FromValue(7));
 
@@ -1665,7 +1665,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize5()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.FromValue(2)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(3.0)).SetEndWeight(Weight.FromValue(4));
             builder.Start.AddTransition('a', Weight.FromValue(5)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(6.0)).SetEndWeight(Weight.FromValue(7));
 
@@ -1694,7 +1694,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize6()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition(DiscreteChar.UniformInRange('a', 'c'), Weight.FromValue(2)).SetEndWeight(Weight.FromValue(3.0));
             builder.Start.AddTransition(DiscreteChar.UniformInRange('b', 'c'), Weight.FromValue(4)).SetEndWeight(Weight.FromValue(5.0));
             builder.Start.AddTransition(DiscreteChar.UniformInRange('b', 'd'), Weight.FromValue(6)).SetEndWeight(Weight.FromValue(7.0));
@@ -1728,7 +1728,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize7()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.AddStates(4);
 
             builder[0].AddTransition('a', Weight.FromValue(3), 1);
@@ -1771,7 +1771,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize8()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             var state = builder.Start;
 
             const int AcceptedSequenceLength = 20;
@@ -1809,7 +1809,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize9()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
 
             const int TransitionsPerCharacter = 3;
             for (int i = 0; i < TransitionsPerCharacter; ++i)
@@ -1845,7 +1845,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize10()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.AddStates(4);
 
             builder[0].AddTransition('a', Weight.FromValue(3), 1);
@@ -1886,7 +1886,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NonDeterminizable1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.FromValue(2)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(3.0)).SetEndWeight(Weight.FromValue(4));
             builder.Start.AddTransition('a', Weight.FromValue(5)).AddSelfTransition('b', Weight.FromValue(0.1)).AddTransition('c', Weight.FromValue(6.0)).SetEndWeight(Weight.FromValue(7));
 
@@ -1925,7 +1925,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         internal void DeterminizeList()
         {
-            var builder = ListAutomaton<string, StringDistribution>.Builder.Zero();
+            var builder = new Automaton<List<string>, string, StringDistribution, ListManipulator<List<string>, string>, ListAutomaton<string, StringDistribution>>.Builder();
 
             const int TransitionsPerCharacter = 3;
             for (int i = 0; i < TransitionsPerCharacter; ++i)
@@ -1961,7 +1961,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         internal void DeterminizeList2()
         {
-            var builder = ListAutomaton<string, StringDistribution>.Builder.Zero();
+            var builder = new Automaton<List<string>, string, StringDistribution, ListManipulator<List<string>, string>, ListAutomaton<string, StringDistribution>>.Builder();
             var unif = StringDistribution.Uniform();
             var scaledUniform = StringDistribution.FromWorkspace(unif.GetWorkspaceOrPoint().Scale(1.0 / 1000));
    
@@ -2001,7 +2001,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void EnumerateSupport()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.AddStates(6);
 
             builder[0].AddTransition(DiscreteChar.UniformOver('a', 'b'), Weight.FromValue(1), 1);
@@ -2038,7 +2038,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Fact]
         public void TryEnumerateSupportPerfTest()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.AddStates(6);
 
             builder[0].AddTransition(DiscreteChar.UniformOver('a', 'b'), Weight.FromValue(1), 1);

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Probabilistic.Collections;
+
 namespace Microsoft.ML.Probabilistic.Tests
 {
     using System;
@@ -9,8 +11,6 @@ namespace Microsoft.ML.Probabilistic.Tests
     using System.Diagnostics;
     using System.Linq;
     using System.Text.RegularExpressions;
-
-    using Microsoft.ML.Probabilistic.Core.Collections;
 
     using Xunit;
     using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -10,6 +10,8 @@ namespace Microsoft.ML.Probabilistic.Tests
     using System.Linq;
     using System.Text.RegularExpressions;
 
+    using Microsoft.ML.Probabilistic.Core.Collections;
+
     using Xunit;
     using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;
 
@@ -30,22 +32,13 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Clone()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.One).SetEndWeight(Weight.One);
-            StringAutomaton clone = automaton.Clone();
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.One).SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
+            var clone = automaton.Clone();
 
             Assert.Equal(automaton, clone);
-
-            // since DiscreteChar is a struct, the only possible way for updating it on some
-            // transition is copying stuff out, changing, and the copying in
-            var transition = automaton.Start.GetTransition(0);
-            var dist = transition.ElementDistribution.Value;
-            dist.SetTo(DiscreteChar.OneOf('a', 'b'));
-            transition.ElementDistribution = dist;
-            automaton.Start.SetTransition(0, transition);
-
-            // 'clone' must have its own copy of the element distribution
-            Assert.NotEqual(automaton, clone);
         }
 
         /// <summary>
@@ -95,16 +88,18 @@ namespace Microsoft.ML.Probabilistic.Tests
             Assert.True(zero7.IsCanonicZero());
             StringInferenceTestUtilities.TestValue(zero7, 0.0, "abc", "ab", "a", string.Empty);
 
-            StringAutomaton zero8 = StringAutomaton.Zero();
-            zero8.Start.AddTransition('a', Weight.One);
+            var zero8Builder = StringAutomaton.Builder.Zero();
+            zero8Builder.Start.AddTransition('a', Weight.One);
+            var zero8 = zero8Builder.GetAutomaton();
             Assert.True(zero8.IsZero());
             Assert.False(zero8.IsCanonicZero());
             StringInferenceTestUtilities.TestValue(zero8, 0.0, "abc", "ab", "a", string.Empty);
 
-            StringAutomaton zero9 = StringAutomaton.Zero();
-            zero9.Start.AddTransition('a', Weight.One);
-            zero9.Start.AddTransition('b', Weight.One, zero9.Start);
-            zero9.Start.AddTransitionsForSequence("abc");
+            var zero9Builder = StringAutomaton.Builder.Zero();
+            zero9Builder.Start.AddTransition('a', Weight.One);
+            zero9Builder.Start.AddTransition('b', Weight.One, zero9Builder.StartStateIndex);
+            zero9Builder.Start.AddTransitionsForSequence("abc");
+            var zero9 = zero9Builder.GetAutomaton();
             Assert.True(zero9.IsZero());
             Assert.False(zero9.IsCanonicZero());
             StringInferenceTestUtilities.TestValue(zero9, 0.0, "abc", "ab", "a", string.Empty);
@@ -395,9 +390,10 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ProductNoDeadBranches()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.One).AddTransition('b', Weight.One).SetEndWeight(Weight.One);
-            automaton.Start.AddTransition('a', Weight.One).AddTransition('c', Weight.One).SetEndWeight(Weight.One);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.One).AddTransition('b', Weight.One).SetEndWeight(Weight.One);
+            builder.Start.AddTransition('a', Weight.One).AddTransition('c', Weight.One).SetEndWeight(Weight.One);
+            var automaton = builder.GetAutomaton();
             StringAutomaton automatonSqr = automaton.Product(automaton);
             Assert.Equal(4, automatonSqr.States.Count);
         }
@@ -466,10 +462,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Reverse2()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            var otherState = automaton.Start.AddSelfTransition('a', Weight.FromValue(0.5)).AddTransition('b', Weight.FromValue(0.7));
-            automaton.Start.SetEndWeight(Weight.FromValue(0.3));
+            var builder = StringAutomaton.Builder.Zero();
+            var otherState = builder.Start.AddSelfTransition('a', Weight.FromValue(0.5)).AddTransition('b', Weight.FromValue(0.7));
+            builder.Start.SetEndWeight(Weight.FromValue(0.3));
             otherState.SetEndWeight(Weight.FromValue(0.8));
+            var automaton = builder.GetAutomaton();
 
             StringAutomaton reverse = automaton.Reverse();
             StringInferenceTestUtilities.TestValue(reverse, 0.7 * 0.8, "b");
@@ -620,9 +617,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NormalizeValuesDeadBranch()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransitionsForSequence("abc");
-            automaton.Start.AddTransitionsForSequence("def").SetEndWeight(Weight.FromValue(4.0));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransitionsForSequence("abc");
+            builder.Start.AddTransitionsForSequence("def").SetEndWeight(Weight.FromValue(4.0));
+            var automaton = builder.GetAutomaton();
+
             double logNormalizer;
             Assert.Equal(Math.Log(4.0), automaton.GetLogNormalizer(), 1e-8);
             Assert.True(automaton.TryNormalizeValues(out logNormalizer));
@@ -641,9 +640,11 @@ namespace Microsoft.ML.Probabilistic.Tests
             const double TransitionProbability = 0.7;
             const double EndWeight = 10.0;
 
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.FromValue(TransitionProbability), automaton.Start);
-            automaton.Start.SetEndWeight(Weight.FromValue(EndWeight));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddSelfTransition('a', Weight.FromValue(TransitionProbability));
+            builder.Start.SetEndWeight(Weight.FromValue(EndWeight));
+            var automaton = builder.GetAutomaton();
+
             double logNormalizer = automaton.GetLogNormalizer();
             Assert.Equal(Math.Log(EndWeight / (1 - TransitionProbability)), logNormalizer, 1e-8);
             Assert.Equal(logNormalizer, automaton.NormalizeValues());
@@ -676,10 +677,10 @@ namespace Microsoft.ML.Probabilistic.Tests
             TestNonNormalizable(StringAutomaton.ConstantLog(Math.Log(0.87)), false);
             TestNonNormalizable(StringAutomaton.ConstantLog(Math.Log(0.01), DiscreteChar.PointMass('a')), false);
 
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.FromValue(1.01), automaton.Start);
-            automaton.Start.SetEndWeight(Weight.One);
-            TestNonNormalizable(automaton, false);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddSelfTransition('a', Weight.FromValue(1.01));
+            builder.Start.SetEndWeight(Weight.One);
+            TestNonNormalizable(builder.GetAutomaton(), false);
         }
 
         /// <summary>
@@ -696,7 +697,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 .Scale(0.5);
 
             // Make sure it contains epsilon transitions
-            Assert.Contains(automaton.States, s => s.GetTransitions().Any(t => t.IsEpsilon));
+            Assert.Contains(automaton.States, s => s.Transitions.Any(t => t.IsEpsilon));
 
             // Test the original automaton, its epsilon closure and the closure of the closure
             for (int i = 0; i < 3; ++i)
@@ -707,7 +708,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 automaton.MakeEpsilonFree();
 
                 // Make sure it doesn't contain epsilon transitions
-                Assert.True(automaton.States.All(s => s.GetTransitions().All(t => !t.IsEpsilon)));
+                Assert.True(automaton.States.All(s => s.Transitions.All(t => !t.IsEpsilon)));
         }
         }
 
@@ -718,18 +719,19 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void EpsilonClosure2()
         {
-            var automaton = StringAutomaton.Zero();
-            var state = automaton.Start;
+            var builder = StringAutomaton.Builder.Zero();
+            var state = builder.Start;
             const int ChainLength = 16;
             for (int i = 0; i < ChainLength; ++i)
             {
                 var nextState = state.AddEpsilonTransition(Weight.One);
-                state.AddEpsilonTransition(Weight.One, nextState);
+                state.AddEpsilonTransition(Weight.One, nextState.Index);
                 state = nextState;
             }
 
             state.SetEndWeight(Weight.One);
 
+            var automaton = builder.GetAutomaton();
             var closure = automaton.Start.GetEpsilonClosure();
             
             Assert.Equal(ChainLength + 1, closure.Size);
@@ -770,8 +772,8 @@ namespace Microsoft.ML.Probabilistic.Tests
             int stateCount = Environment.Is64BitProcess  ? 600 : 1500; // Stack frames are larger on 64bit
             Debug.Assert(stateCount <= StringAutomaton.MaxStateCount, "MaxStateCount must be adjusted first.");
 
-            StringAutomaton automaton = StringAutomaton.Zero();
-            StringAutomaton.State state = automaton.Start;
+            var builder = StringAutomaton.Builder.Zero();
+            var state = builder.Start;
             
             for (int i = 1; i < stateCount; ++i)
             {
@@ -780,6 +782,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
             state.SetEndWeight(Weight.One);
 
+            var automaton = builder.GetAutomaton();
             string point = new string('a', stateCount - 1);
             
             Assert.True(automaton.TryComputePoint() == point);
@@ -794,80 +797,64 @@ namespace Microsoft.ML.Probabilistic.Tests
         public void QuotingTest()
         {
             // Should work 1
-            var states = new[]
-            {
-                new StringAutomaton.State(0, new[] { new StringAutomaton.Transition(DiscreteChar.PointMass('a'), Weight.One, 1) }, Weight.One),
-                new StringAutomaton.State(1, new StringAutomaton.Transition[0], Weight.One)
-            };
-            var automaton1 = StringAutomaton.FromStates(states, states[0]);
+            var automaton1 = StringAutomaton.FromData(
+                new StringAutomaton.DataContainer(
+                    0,
+                    true,
+                    new[]
+                        {
+                            new StringAutomaton.StateData(0, 1, Weight.One),
+                            new StringAutomaton.StateData(1, 1, Weight.One),
+                        },
+                    new[] { new StringAutomaton.Transition(DiscreteChar.PointMass('a'), Weight.One, 1) }));
+
             StringInferenceTestUtilities.TestValue(automaton1, 1.0, string.Empty, "a");
             StringInferenceTestUtilities.TestValue(automaton1, 0.0, "b");
 
             // Should work 2
-            var theOnlyState = new StringAutomaton.State(0, new StringAutomaton.Transition[0], Weight.Zero);
-            var automaton2 = StringAutomaton.FromStates(new[] { theOnlyState }, theOnlyState);
+            var automaton2 = StringAutomaton.FromData(
+                new StringAutomaton.DataContainer(
+                    0,
+                    true,
+                    new[] { new StringAutomaton.StateData(0, 0, Weight.Zero) },
+                    Array.Empty<StringAutomaton.Transition>()));
             Assert.True(automaton2.IsZero());
 
-            // Null states collection
-            Assert.Throws<ArgumentNullException>(() => StringAutomaton.FromStates(null, default(StringAutomaton.State)));
-
-            // Null start state
-            Assert.Throws<ArgumentException>(() => StringAutomaton.FromStates(new[] { theOnlyState }, default(StringAutomaton.State)));
-
-            // Duplicate state indices
+            // Bad start state index
             Assert.Throws<ArgumentException>(
-                () =>
-                StringAutomaton.FromStates(
-                    new[]
-                        {
-                            new StringAutomaton.State(0, new StringAutomaton.Transition[0], Weight.One),
-                            new StringAutomaton.State(0, new StringAutomaton.Transition[0], Weight.One)
-                        },
-                    new StringAutomaton.State(0, new StringAutomaton.Transition[0], Weight.One)));
+                () => StringAutomaton.FromData(
+                    new StringAutomaton.DataContainer(
+                        0,
+                        true,
+                        Array.Empty<StringAutomaton.StateData>(),
+                        Array.Empty<StringAutomaton.Transition>())));
 
-            // State indices in a wrong order
+            // automaton is actually epsilon-free, but data says that it is
             Assert.Throws<ArgumentException>(
-                () =>
-                StringAutomaton.FromStates(
-                    new[]
-                        {
-                            new StringAutomaton.State(1, new StringAutomaton.Transition[0], Weight.One),
-                            new StringAutomaton.State(0, new StringAutomaton.Transition[0], Weight.One)
-                        },
-                    new StringAutomaton.State(0, new StringAutomaton.Transition[0], Weight.One)));
+                () => StringAutomaton.FromData(
+                    new StringAutomaton.DataContainer(
+                        0,
+                        false,
+                        new[] { new StringAutomaton.StateData(0, 0, Weight.Zero) },
+                        Array.Empty<StringAutomaton.Transition>())));
 
-            // Indices are not zero-based
+            // automaton is not epsilon-free
             Assert.Throws<ArgumentException>(
-                () =>
-                StringAutomaton.FromStates(
-                    new[]
-                        {
-                            new StringAutomaton.State(1, new StringAutomaton.Transition[0], Weight.One),
-                            new StringAutomaton.State(2, new StringAutomaton.Transition[0], Weight.One)
-                        },
-                    new StringAutomaton.State(1, new StringAutomaton.Transition[0], Weight.One)));
-
-            // Incorrect start state index
-            Assert.Throws<ArgumentException>(
-                () =>
-                StringAutomaton.FromStates(
-                    new[]
-                        {
-                            new StringAutomaton.State(0, new StringAutomaton.Transition[0], Weight.One),
-                            new StringAutomaton.State(1, new StringAutomaton.Transition[0], Weight.One)
-                        },
-                    new StringAutomaton.State(2, new StringAutomaton.Transition[0], Weight.One)));
+                () => StringAutomaton.FromData(
+                    new StringAutomaton.DataContainer(
+                        0,
+                        false,
+                        new[] { new StringAutomaton.StateData(0, 1, Weight.Zero) },
+                        new[] { new StringAutomaton.Transition(Option.None, Weight.One, 1) })));
 
             // Incorrect transition index
             Assert.Throws<ArgumentException>(
-                () =>
-                StringAutomaton.FromStates(
-                    new[]
-                        {
-                            new StringAutomaton.State(0, new[] { new StringAutomaton.Transition(Option.None, Weight.One, 2) }, Weight.One),
-                            new StringAutomaton.State(1, new StringAutomaton.Transition[0], Weight.One)
-                        },
-                    new StringAutomaton.State(1, new StringAutomaton.Transition[0], Weight.One)));
+                () => StringAutomaton.FromData(
+                    new StringAutomaton.DataContainer(
+                        0,
+                        true,
+                        new[] { new StringAutomaton.StateData(0, 1, Weight.One) },
+                        new[] { new StringAutomaton.Transition(Option.None, Weight.One, 2) })));
         }
 
         #region ToString tests
@@ -879,8 +866,9 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToString1()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.One).AddSelfTransition('b', Weight.One).AddTransition('c', Weight.One).SetEndWeight(Weight.One);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.One).AddSelfTransition('b', Weight.One).AddTransition('c', Weight.One).SetEndWeight(Weight.One);
+            var automaton = builder.GetAutomaton();
             Assert.Equal("ab*c", automaton.ToString(AutomatonFormats.Friendly));
             Assert.Equal("ab*c", automaton.ToString(AutomatonFormats.Regexp));
         }
@@ -893,10 +881,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToString2()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            var middleState = automaton.Start.AddTransition('b', Weight.One).AddTransition('c', Weight.One);
-            automaton.Start.AddTransition('a', Weight.One, middleState);
+            var builder = StringAutomaton.Builder.Zero();
+            var middleState = builder.Start.AddTransition('b', Weight.One).AddTransition('c', Weight.One);
+            builder.Start.AddTransition('a', Weight.One, middleState.Index);
             middleState.AddTransition('d', Weight.One).SetEndWeight(Weight.One);
+            var automaton = builder.GetAutomaton();
             Assert.Equal("(bc|a)d", automaton.ToString(AutomatonFormats.Friendly));
             Assert.Equal("(bc|a)d", automaton.ToString(AutomatonFormats.Regexp));
         }
@@ -908,8 +897,9 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToString3()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransitionsForSequence("hello").SetEndWeight(Weight.One);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransitionsForSequence("hello").SetEndWeight(Weight.One);
+            var automaton = builder.GetAutomaton();
             Assert.Equal("hello", automaton.ToString(AutomatonFormats.Friendly));
             Assert.Equal("hello", automaton.ToString(AutomatonFormats.Regexp));
         }
@@ -921,8 +911,9 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToString4()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransitionsForSequence("hello").SetEndWeight(Weight.Zero);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransitionsForSequence("hello").SetEndWeight(Weight.Zero);
+            var automaton = builder.GetAutomaton();
             Assert.Equal("Ø", automaton.ToString(AutomatonFormats.Friendly));
             Assert.Equal("Ø", automaton.ToString(AutomatonFormats.Regexp));
         }
@@ -934,10 +925,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToString5()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransitionsForSequence("hello").SetEndWeight(Weight.One);
-            automaton.Start.AddEpsilonTransition(Weight.One).AddTransitionsForSequence("hi").SetEndWeight(Weight.One);
-            automaton.Start.AddEpsilonTransition(Weight.One).AddTransitionsForSequence("hey").SetEndWeight(Weight.One);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransitionsForSequence("hello").SetEndWeight(Weight.One);
+            builder.Start.AddEpsilonTransition(Weight.One).AddTransitionsForSequence("hi").SetEndWeight(Weight.One);
+            builder.Start.AddEpsilonTransition(Weight.One).AddTransitionsForSequence("hey").SetEndWeight(Weight.One);
+            var automaton = builder.GetAutomaton();
             Assert.Equal("hey|hi|hello", automaton.ToString(AutomatonFormats.Friendly));
             Assert.Equal("hey|hi|hello", automaton.ToString(AutomatonFormats.Regexp));
         }
@@ -1037,24 +1029,26 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void RegexForAutomatonWithNonTrivialComponent()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.AddStates(7);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.AddStates(7);
 
-            automaton.States[0].AddTransition('a', Weight.FromValue(1), automaton.States[1]);
-            automaton.States[1].AddTransition('b', Weight.FromValue(1), automaton.States[1]);
-            automaton.States[1].AddTransition('c', Weight.FromValue(1), automaton.States[1]);
-            automaton.States[1].AddTransition('d', Weight.FromValue(1), automaton.States[2]);
-            automaton.States[2].AddTransition('e', Weight.FromValue(1), automaton.States[3]);
-            automaton.States[3].AddTransition('f', Weight.FromValue(1), automaton.States[3]);
-            automaton.States[3].AddTransition('g', Weight.FromValue(1), automaton.States[4]);
-            automaton.States[3].AddTransition('h', Weight.FromValue(1), automaton.States[5]);
-            automaton.States[4].AddTransition('i', Weight.FromValue(1), automaton.States[7]);
-            automaton.States[4].AddTransition('j', Weight.FromValue(1), automaton.States[5]);
-            automaton.States[5].AddTransition('k', Weight.FromValue(1), automaton.States[6]);
-            automaton.States[5].AddTransition('l', Weight.FromValue(1), automaton.States[6]);
-            automaton.States[6].AddTransition('m', Weight.FromValue(1), automaton.States[3]);
-            automaton.States[6].AddTransition('n', Weight.FromValue(1), automaton.States[1]);
-            automaton.States[7].SetEndWeight(Weight.FromValue(1));
+            builder[0].AddTransition('a', Weight.FromValue(1), 1);
+            builder[1].AddTransition('b', Weight.FromValue(1), 1);
+            builder[1].AddTransition('c', Weight.FromValue(1), 1);
+            builder[1].AddTransition('d', Weight.FromValue(1), 2);
+            builder[2].AddTransition('e', Weight.FromValue(1), 3);
+            builder[3].AddTransition('f', Weight.FromValue(1), 3);
+            builder[3].AddTransition('g', Weight.FromValue(1), 4);
+            builder[3].AddTransition('h', Weight.FromValue(1), 5);
+            builder[4].AddTransition('i', Weight.FromValue(1), 7);
+            builder[4].AddTransition('j', Weight.FromValue(1), 5);
+            builder[5].AddTransition('k', Weight.FromValue(1), 6);
+            builder[5].AddTransition('l', Weight.FromValue(1), 6);
+            builder[6].AddTransition('m', Weight.FromValue(1), 3);
+            builder[6].AddTransition('n', Weight.FromValue(1), 1);
+            builder[7].SetEndWeight(Weight.FromValue(1));
+
+            var automaton = builder.GetAutomaton();
 
             var distribution = StringDistribution.FromWorkspace(automaton);
             var regexPattern = distribution.ToRegex();
@@ -1080,28 +1074,30 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void RegexForAutomatonWithNonTrivialComponent2()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.AddStates(7);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.AddStates(7);
 
-            automaton.States[0].AddTransition('a', Weight.FromValue(1), automaton.States[1]);
-            automaton.States[1].AddTransition('b', Weight.FromValue(1), automaton.States[1]);
-            automaton.States[1].AddTransition('c', Weight.FromValue(1), automaton.States[1]);
-            automaton.States[1].AddTransition('d', Weight.FromValue(1), automaton.States[2]);
-            automaton.States[2].AddTransition('e', Weight.FromValue(1), automaton.States[3]);
-            automaton.States[3].AddTransition('f', Weight.FromValue(1), automaton.States[3]);
-            automaton.States[3].AddTransition('g', Weight.FromValue(1), automaton.States[4]);
-            automaton.States[3].AddTransition('h', Weight.FromValue(1), automaton.States[5]);
-            automaton.States[4].AddTransition('i', Weight.FromValue(1), automaton.States[7]);
-            automaton.States[4].AddTransition('j', Weight.FromValue(1), automaton.States[5]);
-            automaton.States[5].AddTransition('k', Weight.FromValue(1), automaton.States[6]);
-            automaton.States[5].AddTransition('l', Weight.FromValue(1), automaton.States[6]);
-            automaton.States[6].AddTransition('m', Weight.FromValue(1), automaton.States[3]);
-            automaton.States[6].AddTransition('n', Weight.FromValue(1), automaton.States[1]);
+            builder[0].AddTransition('a', Weight.FromValue(1), 1);
+            builder[1].AddTransition('b', Weight.FromValue(1), 1);
+            builder[1].AddTransition('c', Weight.FromValue(1), 1);
+            builder[1].AddTransition('d', Weight.FromValue(1), 2);
+            builder[2].AddTransition('e', Weight.FromValue(1), 3);
+            builder[3].AddTransition('f', Weight.FromValue(1), 3);
+            builder[3].AddTransition('g', Weight.FromValue(1), 4);
+            builder[3].AddTransition('h', Weight.FromValue(1), 5);
+            builder[4].AddTransition('i', Weight.FromValue(1), 7);
+            builder[4].AddTransition('j', Weight.FromValue(1), 5);
+            builder[5].AddTransition('k', Weight.FromValue(1), 6);
+            builder[5].AddTransition('l', Weight.FromValue(1), 6);
+            builder[6].AddTransition('m', Weight.FromValue(1), 3);
+            builder[6].AddTransition('n', Weight.FromValue(1), 1);
 
-            automaton.States[0].AddTransition('o', Weight.FromValue(1), automaton.States[6]);
-            automaton.States[1].AddTransition('p', Weight.FromValue(1), automaton.States[7]);
-            automaton.States[6].AddTransition('q', Weight.FromValue(1), automaton.States[7]);
-            automaton.States[7].SetEndWeight(Weight.FromValue(1));
+            builder[0].AddTransition('o', Weight.FromValue(1), 6);
+            builder[1].AddTransition('p', Weight.FromValue(1), 7);
+            builder[6].AddTransition('q', Weight.FromValue(1), 7);
+            builder[7].SetEndWeight(Weight.FromValue(1));
+
+            var automaton = builder.GetAutomaton();
 
             var distribution = StringDistribution.FromWorkspace(automaton);
             var regexPattern = distribution.ToRegex();
@@ -1181,9 +1177,10 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Equality3()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.SetEndWeight(Weight.One);
-            automaton.Start.AddTransition(DiscreteChar.Lower(), Weight.FromLogValue(26 + 1e-3), automaton.Start);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.SetEndWeight(Weight.One);
+            builder.Start.AddSelfTransition(DiscreteChar.Lower(), Weight.FromLogValue(26 + 1e-3));
+            var automaton = builder.GetAutomaton();
 
             AssertEquals(automaton, automaton);
             AssertNotEquals(automaton, automaton.Product(automaton));
@@ -1196,9 +1193,10 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Equality4()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.SetEndWeight(Weight.One);
-            automaton.Start.AddTransition('a', Weight.FromLogValue(1.0 - 1e-3), automaton.Start);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.SetEndWeight(Weight.One);
+            builder.Start.AddSelfTransition('a', Weight.FromLogValue(1.0 - 1e-3));
+            var automaton = builder.GetAutomaton();
 
             AssertEquals(automaton, automaton);
             AssertNotEquals(automaton, automaton.Product(automaton));
@@ -1214,9 +1212,11 @@ namespace Microsoft.ML.Probabilistic.Tests
             AssertEquals(StringAutomaton.Zero(), StringAutomaton.Zero());
             AssertNotEquals(StringAutomaton.Zero(), StringAutomaton.Constant(1.0));
 
-            StringAutomaton zero = StringAutomaton.Zero();
-            zero.Start.AddTransition('a', Weight.One);
-            AssertEquals(StringAutomaton.Zero(), zero);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.One);
+            var automaton = builder.GetAutomaton();
+
+            AssertEquals(StringAutomaton.Zero(), automaton);
         }
 
         /// <summary>
@@ -1227,8 +1227,10 @@ namespace Microsoft.ML.Probabilistic.Tests
         public void Equality6()
         {
             StringAutomaton func1 = StringAutomaton.Constant(1.0, DiscreteChar.OneOf('a', 'b'));
-            StringAutomaton func2 = StringAutomaton.Zero();
-            func2.Start.AddSelfTransition('a', Weight.One).AddSelfTransition('b', Weight.One).SetEndWeight(Weight.One);
+
+            var func2Builder = StringAutomaton.Builder.Zero();
+            func2Builder.Start.AddSelfTransition('a', Weight.One).AddSelfTransition('b', Weight.One).SetEndWeight(Weight.One);
+            var func2 = func2Builder.GetAutomaton();
 
             AssertEquals(func1, func2);
         }
@@ -1240,14 +1242,16 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Equality7()
         {
-            StringAutomaton func1 = StringAutomaton.Zero();
-            func1.Start.AddSelfTransition(DiscreteChar.PointMass('a'), Weight.One).SetEndWeight(Weight.One);
+            var func1Builder = StringAutomaton.Builder.Zero();
+            func1Builder.Start.AddSelfTransition(DiscreteChar.PointMass('a'), Weight.One).SetEndWeight(Weight.One);
+            var func1 = func1Builder.GetAutomaton();
 
-            StringAutomaton func2 = StringAutomaton.Zero();
-            func2.Start
+            var func2Builder = StringAutomaton.Builder.Zero();
+            func2Builder.Start
                 .AddEpsilonTransition(Weight.One)
-                .AddTransition(DiscreteChar.PointMass('a'), Weight.One, func2.Start)
+                .AddTransition(DiscreteChar.PointMass('a'), Weight.One, func2Builder.StartStateIndex)
                 .SetEndWeight(Weight.One);
+            var func2 = func2Builder.GetAutomaton();
 
             AssertEquals(func1, func2);
         }
@@ -1263,11 +1267,12 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify1()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.One).AddTransition('b', Weight.One).SetEndWeight(
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.One).AddTransition('b', Weight.One).SetEndWeight(
                 Weight.FromValue(2.0));
-            automaton.Start.AddTransition('a', Weight.One).AddSelfTransition('d', Weight.One).AddTransition('c', Weight.One).SetEndWeight(
+            builder.Start.AddTransition('a', Weight.One).AddSelfTransition('d', Weight.One).AddTransition('c', Weight.One).SetEndWeight(
                 Weight.FromValue(3.0));
+            var automaton = builder.GetAutomaton();
 
             for (int i = 0; i < 3; ++i)
         {
@@ -1286,12 +1291,13 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify2()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.One).AddSelfTransition('d', Weight.One).AddTransition('c', Weight.One).SetEndWeight(
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.One).AddSelfTransition('d', Weight.One).AddTransition('c', Weight.One).SetEndWeight(
                 Weight.FromValue(3.0));
-            automaton.Start.AddTransition('a', Weight.One).AddTransition('b', Weight.One).SetEndWeight(
+            builder.Start.AddTransition('a', Weight.One).AddTransition('b', Weight.One).SetEndWeight(
                 Weight.FromValue(2.0));
-            
+            var automaton = builder.GetAutomaton();
+
             for (int i = 0; i < 3; ++i)
         {
                 StringInferenceTestUtilities.TestValue(automaton, 2.0, "ab");
@@ -1309,12 +1315,13 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify3()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.One).AddTransition('d', Weight.One).AddTransition('c', Weight.One).SetEndWeight(
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.One).AddTransition('d', Weight.One).AddTransition('c', Weight.One).SetEndWeight(
                 Weight.FromValue(2.0));
-            automaton.Start.AddTransition('a', Weight.One).AddSelfTransition('d', Weight.One).AddTransition('c', Weight.One).SetEndWeight(
+            builder.Start.AddTransition('a', Weight.One).AddSelfTransition('d', Weight.One).AddTransition('c', Weight.One).SetEndWeight(
                 Weight.FromValue(3.0));
-            
+            var automaton = builder.GetAutomaton();
+
             for (int i = 0; i < 3; ++i)
         {
                 StringInferenceTestUtilities.TestValue(automaton, 5.0, "adc");
@@ -1331,13 +1338,14 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify4()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddEpsilonTransition(Weight.One).AddSelfTransition('a', Weight.One)
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddEpsilonTransition(Weight.One).AddSelfTransition('a', Weight.One)
                            .AddEpsilonTransition(Weight.One).AddSelfTransition('b', Weight.One).SetEndWeight(Weight.FromValue(2.0));
-            automaton.Start.AddEpsilonTransition(Weight.One).AddSelfTransition('a', Weight.One)
+            builder.Start.AddEpsilonTransition(Weight.One).AddSelfTransition('a', Weight.One)
                            .AddEpsilonTransition(Weight.One).AddSelfTransition('c', Weight.One).SetEndWeight(Weight.FromValue(3.0));
-            automaton.Start.AddSelfTransition('x', Weight.One);
-            automaton.Start.SetEndWeight(Weight.One);
+            builder.Start.AddSelfTransition('x', Weight.One);
+            builder.Start.SetEndWeight(Weight.One);
+            var automaton = builder.GetAutomaton();
 
             for (int i = 0; i < 3; ++i)
             {
@@ -1357,13 +1365,13 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify5()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
+            var builder = StringAutomaton.Builder.Zero();
             const string AcceptedSequence = "aaaaaaaaaa";
-            StringAutomaton.State state = automaton.Start;
+            var state = builder.Start;
             for (int i = 0; i < AcceptedSequence.Length; ++i)
             {
-                StringAutomaton.State nextState = state.AddTransition(AcceptedSequence[i], Weight.One);
-                state.AddTransition(AcceptedSequence[i], Weight.One, nextState);
+                var nextState = state.AddTransition(AcceptedSequence[i], Weight.One);
+                state.AddTransition(AcceptedSequence[i], Weight.One, nextState.Index);
                 state = nextState;
             }
 
@@ -1371,10 +1379,12 @@ namespace Microsoft.ML.Probabilistic.Tests
 
             const int AdditionalSequenceCount = 5;
             for (int i = 0; i < AdditionalSequenceCount; ++i)
-        {
-            automaton.Start.AddTransitionsForSequence(AcceptedSequence).SetEndWeight(Weight.One);
+            {
+                builder.Start.AddTransitionsForSequence(AcceptedSequence).SetEndWeight(Weight.One);
             }
-            
+
+            var automaton = builder.GetAutomaton();
+
             for (int i = 0; i < 3; ++i)
             {
                 StringInferenceTestUtilities.TestValue(automaton, (1 << AcceptedSequence.Length) + AdditionalSequenceCount, AcceptedSequence);
@@ -1390,20 +1400,22 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify6()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.AddStates(5);
-            automaton.States[0].AddTransition('a', Weight.FromValue(1.0), automaton.States[1]);
-            automaton.States[0].AddTransition('a', Weight.FromValue(4.0), automaton.States[4]);
-            automaton.States[1].AddTransition('a', Weight.FromValue(2.0), automaton.States[2]);
-            automaton.States[2].AddTransition('a', Weight.FromValue(3.0), automaton.States[3]);
-            automaton.States[2].AddTransition('a', Weight.FromValue(6.0), automaton.States[5]);
-            automaton.States[4].AddTransition('a', Weight.FromValue(5.0), automaton.States[2]);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.AddStates(5);
+            builder[0].AddTransition('a', Weight.FromValue(1.0), 1);
+            builder[0].AddTransition('a', Weight.FromValue(4.0), 4);
+            builder[1].AddTransition('a', Weight.FromValue(2.0), 2);
+            builder[2].AddTransition('a', Weight.FromValue(3.0), 3);
+            builder[2].AddTransition('a', Weight.FromValue(6.0), 5);
+            builder[4].AddTransition('a', Weight.FromValue(5.0), 2);
 
-            automaton.States[3].SetEndWeight(Weight.FromValue(2.0));
-            automaton.States[5].SetEndWeight(Weight.FromValue(3.0));
+            builder[3].SetEndWeight(Weight.FromValue(2.0));
+            builder[5].SetEndWeight(Weight.FromValue(3.0));
+
+            var automaton = builder.GetAutomaton();
 
             for (int i = 0; i < 3; ++i)
-        {
+            {
                 StringInferenceTestUtilities.TestValue(automaton, 528.0, "aaa");
                 StringInferenceTestUtilities.TestValue(automaton, 0.0, "a", "aa", "aaaa", string.Empty);
 
@@ -1421,15 +1433,16 @@ namespace Microsoft.ML.Probabilistic.Tests
             DiscreteChar lowerEnglish = DiscreteChar.UniformInRange('a', 'z');
             DiscreteChar upperEnglish = DiscreteChar.UniformInRange('A', 'Z');
 
-            StringAutomaton automaton = StringAutomaton.Zero();
-            var branch1 = automaton.Start.AddEpsilonTransition(Weight.FromValue(0.5)).AddTransition('a', Weight.FromValue(1.0 / 3.0)).AddTransition('B', Weight.FromValue(1.0 / 4.0));
+            var builder = StringAutomaton.Builder.Zero();
+            var branch1 = builder.Start.AddEpsilonTransition(Weight.FromValue(0.5)).AddTransition('a', Weight.FromValue(1.0 / 3.0)).AddTransition('B', Weight.FromValue(1.0 / 4.0));
             branch1.SetEndWeight(Weight.FromValue(3.0));
             branch1.AddTransition('X', Weight.FromValue(1.0 / 6.0)).SetEndWeight(Weight.FromValue(5.0));
             branch1.AddEpsilonTransition(Weight.FromValue(1.0 / 8.0)).SetEndWeight(Weight.FromValue(7.0));
-            var branch2 = automaton.Start.AddTransition(lowerEnglish, Weight.FromValue(2.0));
+            var branch2 = builder.Start.AddTransition(lowerEnglish, Weight.FromValue(2.0));
             branch2.SetEndWeight(Weight.FromValue(4.0));
-            branch2.AddTransition(upperEnglish, Weight.FromValue(3.0), branch2);
+            branch2.AddTransition(upperEnglish, Weight.FromValue(3.0), branch2.Index);
             branch2.AddTransition('X', Weight.FromValue(4.0)).SetEndWeight(Weight.FromValue(5.0));
+            var automaton = builder.GetAutomaton();
 
             for (int i = 0; i < 3; ++i)
             {
@@ -1450,30 +1463,32 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Simplify8()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.AddStates(10);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.AddStates(10);
 
-            automaton.States[0].AddTransition('a', Weight.One, automaton.States[0]);
-            automaton.States[0].AddTransition('a', Weight.One, automaton.States[1]);
-            automaton.States[0].AddTransition('b', Weight.One, automaton.States[2]);
-            automaton.States[0].AddTransition('a', Weight.One, automaton.States[4]);
-            automaton.States[0].AddEpsilonTransition(Weight.One, automaton.States[7]);
-            automaton.States[0].AddTransition('b', Weight.One, automaton.States[8]);
-            automaton.States[0].AddTransition('c', Weight.One, automaton.States[10]);
-            automaton.States[0].AddTransition('c', Weight.One, automaton.States[10]);
-            automaton.States[1].AddTransition('b', Weight.One, automaton.States[2]);
-            automaton.States[2].AddTransition('a', Weight.One, automaton.States[3]);
-            automaton.States[4].AddTransition('a', Weight.One, automaton.States[5]);
-            automaton.States[5].AddTransition('b', Weight.One, automaton.States[6]);
-            automaton.States[5].AddTransition('a', Weight.One, automaton.States[6]);
-            automaton.States[7].AddTransition('b', Weight.One, automaton.States[5]);
-            automaton.States[8].AddTransition('b', Weight.One, automaton.States[8]);
-            automaton.States[8].AddTransition('a', Weight.One, automaton.States[9]);
+            builder[0].AddTransition('a', Weight.One, 0);
+            builder[0].AddTransition('a', Weight.One, 1);
+            builder[0].AddTransition('b', Weight.One, 2);
+            builder[0].AddTransition('a', Weight.One, 4);
+            builder[0].AddEpsilonTransition(Weight.One, 7);
+            builder[0].AddTransition('b', Weight.One, 8);
+            builder[0].AddTransition('c', Weight.One, 10);
+            builder[0].AddTransition('c', Weight.One, 10);
+            builder[1].AddTransition('b', Weight.One, 2);
+            builder[2].AddTransition('a', Weight.One, 3);
+            builder[4].AddTransition('a', Weight.One, 5);
+            builder[5].AddTransition('b', Weight.One, 6);
+            builder[5].AddTransition('a', Weight.One, 6);
+            builder[7].AddTransition('b', Weight.One, 5);
+            builder[8].AddTransition('b', Weight.One, 8);
+            builder[8].AddTransition('a', Weight.One, 9);
 
-            automaton.States[3].SetEndWeight(Weight.FromValue(0.1));
-            automaton.States[6].SetEndWeight(Weight.FromValue(0.2));
-            automaton.States[9].SetEndWeight(Weight.FromValue(0.3));
-            automaton.States[10].SetEndWeight(Weight.FromValue(0.4));
+            builder[3].SetEndWeight(Weight.FromValue(0.1));
+            builder[6].SetEndWeight(Weight.FromValue(0.2));
+            builder[9].SetEndWeight(Weight.FromValue(0.3));
+            builder[10].SetEndWeight(Weight.FromValue(0.4));
+
+            var automaton = builder.GetAutomaton();
 
             for (int i = 0; i < 3; ++i)
             {
@@ -1523,11 +1538,13 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize1()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.FromValue(2)).AddTransition('b', Weight.FromValue(3)).SetEndWeight(Weight.FromValue(4));
-            automaton.Start.AddTransition('a', Weight.FromValue(5)).AddTransition('c', Weight.FromValue(6)).SetEndWeight(Weight.FromValue(7));
-            automaton.Start.SetEndWeight(Weight.FromValue(17));
-            
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.FromValue(2)).AddTransition('b', Weight.FromValue(3)).SetEndWeight(Weight.FromValue(4));
+            builder.Start.AddTransition('a', Weight.FromValue(5)).AddTransition('c', Weight.FromValue(6)).SetEndWeight(Weight.FromValue(7));
+            builder.Start.SetEndWeight(Weight.FromValue(17));
+
+            var automaton = builder.GetAutomaton();
+
             Assert.False(automaton.IsDeterministic());
 
             // Test: original automaton, determinized automaton, determinization of the determinized automaton (shouldn't break anything)
@@ -1551,10 +1568,12 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize2()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition(DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(2)).AddTransition('b', Weight.FromValue(3)).SetEndWeight(Weight.FromValue(4));
-            automaton.Start.AddTransition(DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(5)).AddTransition('c', Weight.FromValue(6)).SetEndWeight(Weight.FromValue(7));
-            automaton.Start.SetEndWeight(Weight.FromValue(17));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition(DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(2)).AddTransition('b', Weight.FromValue(3)).SetEndWeight(Weight.FromValue(4));
+            builder.Start.AddTransition(DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(5)).AddTransition('c', Weight.FromValue(6)).SetEndWeight(Weight.FromValue(7));
+            builder.Start.SetEndWeight(Weight.FromValue(17));
+
+            var automaton = builder.GetAutomaton();
 
             Assert.False(automaton.IsDeterministic());
 
@@ -1579,11 +1598,13 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize3()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition(DiscreteChar.Uniform(), Weight.FromValue(2)).AddTransition('b', Weight.FromValue(3)).SetEndWeight(Weight.FromValue(4));
-            automaton.Start.AddTransition(DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(5)).AddTransition('c', Weight.FromValue(6)).SetEndWeight(Weight.FromValue(7));
-            automaton.Start.AddTransition(DiscreteChar.UniformInRange('x', 'z'), Weight.FromValue(8)).AddTransition('d', Weight.FromValue(9)).SetEndWeight(Weight.FromValue(10));
-            automaton.Start.SetEndWeight(Weight.FromValue(17));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition(DiscreteChar.Uniform(), Weight.FromValue(2)).AddTransition('b', Weight.FromValue(3)).SetEndWeight(Weight.FromValue(4));
+            builder.Start.AddTransition(DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(5)).AddTransition('c', Weight.FromValue(6)).SetEndWeight(Weight.FromValue(7));
+            builder.Start.AddTransition(DiscreteChar.UniformInRange('x', 'z'), Weight.FromValue(8)).AddTransition('d', Weight.FromValue(9)).SetEndWeight(Weight.FromValue(10));
+            builder.Start.SetEndWeight(Weight.FromValue(17));
+
+            var automaton = builder.GetAutomaton();
 
             Assert.False(automaton.IsDeterministic());
 
@@ -1612,9 +1633,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize4()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.FromValue(2)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(3.0)).SetEndWeight(Weight.FromValue(4));
-            automaton.Start.AddTransition('a', Weight.FromValue(5)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('d', Weight.FromValue(6.0)).SetEndWeight(Weight.FromValue(7));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.FromValue(2)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(3.0)).SetEndWeight(Weight.FromValue(4));
+            builder.Start.AddTransition('a', Weight.FromValue(5)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('d', Weight.FromValue(6.0)).SetEndWeight(Weight.FromValue(7));
+
+            var automaton = builder.GetAutomaton();
 
             Assert.False(automaton.IsDeterministic());
 
@@ -1642,9 +1665,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize5()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.FromValue(2)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(3.0)).SetEndWeight(Weight.FromValue(4));
-            automaton.Start.AddTransition('a', Weight.FromValue(5)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(6.0)).SetEndWeight(Weight.FromValue(7));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.FromValue(2)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(3.0)).SetEndWeight(Weight.FromValue(4));
+            builder.Start.AddTransition('a', Weight.FromValue(5)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(6.0)).SetEndWeight(Weight.FromValue(7));
+
+            var automaton = builder.GetAutomaton();
 
             Assert.False(automaton.IsDeterministic());
 
@@ -1669,12 +1694,14 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize6()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition(DiscreteChar.UniformInRange('a', 'c'), Weight.FromValue(2)).SetEndWeight(Weight.FromValue(3.0));
-            automaton.Start.AddTransition(DiscreteChar.UniformInRange('b', 'c'), Weight.FromValue(4)).SetEndWeight(Weight.FromValue(5.0));
-            automaton.Start.AddTransition(DiscreteChar.UniformInRange('b', 'd'), Weight.FromValue(6)).SetEndWeight(Weight.FromValue(7.0));
-            automaton.Start.AddTransition(DiscreteChar.UniformInRange('d', 'd'), Weight.FromValue(8)).SetEndWeight(Weight.FromValue(9.0));
-            automaton.Start.AddTransition(DiscreteChar.UniformInRange('d', 'e'), Weight.FromValue(10)).SetEndWeight(Weight.FromValue(11.0));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition(DiscreteChar.UniformInRange('a', 'c'), Weight.FromValue(2)).SetEndWeight(Weight.FromValue(3.0));
+            builder.Start.AddTransition(DiscreteChar.UniformInRange('b', 'c'), Weight.FromValue(4)).SetEndWeight(Weight.FromValue(5.0));
+            builder.Start.AddTransition(DiscreteChar.UniformInRange('b', 'd'), Weight.FromValue(6)).SetEndWeight(Weight.FromValue(7.0));
+            builder.Start.AddTransition(DiscreteChar.UniformInRange('d', 'd'), Weight.FromValue(8)).SetEndWeight(Weight.FromValue(9.0));
+            builder.Start.AddTransition(DiscreteChar.UniformInRange('d', 'e'), Weight.FromValue(10)).SetEndWeight(Weight.FromValue(11.0));
+
+            var automaton = builder.GetAutomaton();
 
             Assert.False(automaton.IsDeterministic());
 
@@ -1701,20 +1728,22 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize7()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.AddStates(4);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.AddStates(4);
 
-            automaton.States[0].AddTransition('a', Weight.FromValue(3), automaton.States[1]);
-            automaton.States[0].AddTransition('a', Weight.FromValue(2), automaton.States[2]);
-            automaton.States[0].AddTransition('b', Weight.FromValue(1), automaton.States[2]);
-            automaton.States[1].AddTransition('b', Weight.FromValue(4), automaton.States[3]);
-            automaton.States[2].AddTransition(DiscreteChar.UniformOver('b', 'c'), Weight.FromValue(10), automaton.States[3]);
-            automaton.States[2].AddTransition('b', Weight.FromValue(6), automaton.States[4]);
-            automaton.States[3].AddTransition('c', Weight.FromValue(7), automaton.States[4]);
+            builder[0].AddTransition('a', Weight.FromValue(3), 1);
+            builder[0].AddTransition('a', Weight.FromValue(2), 2);
+            builder[0].AddTransition('b', Weight.FromValue(1), 2);
+            builder[1].AddTransition('b', Weight.FromValue(4), 3);
+            builder[2].AddTransition(DiscreteChar.UniformOver('b', 'c'), Weight.FromValue(10), 3);
+            builder[2].AddTransition('b', Weight.FromValue(6), 4);
+            builder[3].AddTransition('c', Weight.FromValue(7), 4);
 
-            automaton.States[2].SetEndWeight(Weight.FromValue(0.5));
-            automaton.States[3].SetEndWeight(Weight.FromValue(1));
-            automaton.States[4].SetEndWeight(Weight.FromValue(2));
+            builder[2].SetEndWeight(Weight.FromValue(0.5));
+            builder[3].SetEndWeight(Weight.FromValue(1));
+            builder[4].SetEndWeight(Weight.FromValue(2));
+
+            var automaton = builder.GetAutomaton();
 
             Assert.False(automaton.IsDeterministic());
 
@@ -1742,18 +1771,20 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize8()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            StringAutomaton.State state = automaton.Start;
+            var builder = StringAutomaton.Builder.Zero();
+            var state = builder.Start;
 
             const int AcceptedSequenceLength = 20;
             for (int i = 0; i < AcceptedSequenceLength; ++i)
             {
                 var nextState = state.AddTransition(DiscreteChar.Uniform(), Weight.One);
-                state.AddTransition(DiscreteChar.Uniform(), Weight.One, nextState);
+                state.AddTransition(DiscreteChar.Uniform(), Weight.One, nextState.Index);
                 state = nextState;
             }
 
             state.SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
 
             Assert.False(automaton.IsDeterministic());
             
@@ -1778,17 +1809,19 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize9()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
+            var builder = StringAutomaton.Builder.Zero();
 
             const int TransitionsPerCharacter = 3;
             for (int i = 0; i < TransitionsPerCharacter; ++i)
             {
-                automaton.Start.AddTransition('a', Weight.One).SetEndWeight(Weight.One);
-                automaton.Start.AddTransition('b', Weight.One).SetEndWeight(Weight.One);
-                automaton.Start.AddTransition('d', Weight.One).SetEndWeight(Weight.One);
-                automaton.Start.AddTransition('e', Weight.One).SetEndWeight(Weight.One);
-                automaton.Start.AddTransition('g', Weight.One).SetEndWeight(Weight.One);    
+                builder.Start.AddTransition('a', Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition('b', Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition('d', Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition('e', Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition('g', Weight.One).SetEndWeight(Weight.One);    
             }
+
+            var automaton = builder.GetAutomaton();
 
             Assert.False(automaton.IsDeterministic() || TransitionsPerCharacter <= 1);
 
@@ -1812,20 +1845,22 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void Determinize10()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.AddStates(4);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.AddStates(4);
 
-            automaton.States[0].AddTransition('a', Weight.FromValue(3), automaton.States[1]);
-            automaton.States[0].AddTransition('a', Weight.Infinity, automaton.States[2]);
-            automaton.States[0].AddTransition('b', Weight.FromValue(1), automaton.States[2]);
-            automaton.States[1].AddTransition('b', Weight.FromValue(4), automaton.States[3]);
-            automaton.States[2].AddTransition(DiscreteChar.UniformOver('b', 'c'), Weight.FromValue(10), automaton.States[3]);
-            automaton.States[2].AddTransition('b', Weight.FromValue(6), automaton.States[4]);
-            automaton.States[3].AddTransition('c', Weight.FromValue(7), automaton.States[4]);
+            builder[0].AddTransition('a', Weight.FromValue(3), 1);
+            builder[0].AddTransition('a', Weight.Infinity, 2);
+            builder[0].AddTransition('b', Weight.FromValue(1), 2);
+            builder[1].AddTransition('b', Weight.FromValue(4), 3);
+            builder[2].AddTransition(DiscreteChar.UniformOver('b', 'c'), Weight.FromValue(10), 3);
+            builder[2].AddTransition('b', Weight.FromValue(6), 4);
+            builder[3].AddTransition('c', Weight.FromValue(7), 4);
 
-            automaton.States[2].SetEndWeight(Weight.FromValue(0.5));
-            automaton.States[3].SetEndWeight(Weight.FromValue(1));
-            automaton.States[4].SetEndWeight(Weight.FromValue(2));
+            builder[2].SetEndWeight(Weight.FromValue(0.5));
+            builder[3].SetEndWeight(Weight.FromValue(1));
+            builder[4].SetEndWeight(Weight.FromValue(2));
+
+            var automaton = builder.GetAutomaton();
 
             Assert.False(automaton.IsDeterministic());
 
@@ -1851,9 +1886,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NonDeterminizable1()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.FromValue(2)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(3.0)).SetEndWeight(Weight.FromValue(4));
-            automaton.Start.AddTransition('a', Weight.FromValue(5)).AddSelfTransition('b', Weight.FromValue(0.1)).AddTransition('c', Weight.FromValue(6.0)).SetEndWeight(Weight.FromValue(7));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.FromValue(2)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(3.0)).SetEndWeight(Weight.FromValue(4));
+            builder.Start.AddTransition('a', Weight.FromValue(5)).AddSelfTransition('b', Weight.FromValue(0.1)).AddTransition('c', Weight.FromValue(6.0)).SetEndWeight(Weight.FromValue(7));
+
+            var automaton = builder.GetAutomaton();
 
             Assert.False(automaton.IsDeterministic());
 
@@ -1888,17 +1925,19 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         internal void DeterminizeList()
         {
-            var automaton = ListAutomaton<string,StringDistribution>.Zero();
+            var builder = ListAutomaton<string, StringDistribution>.Builder.Zero();
 
             const int TransitionsPerCharacter = 3;
             for (int i = 0; i < TransitionsPerCharacter; ++i)
             {
-                automaton.Start.AddTransition("a", Weight.One).SetEndWeight(Weight.One);
-                automaton.Start.AddTransition("b", Weight.One).SetEndWeight(Weight.One);
-                automaton.Start.AddTransition("d", Weight.One).SetEndWeight(Weight.One);
-                automaton.Start.AddTransition("e", Weight.One).SetEndWeight(Weight.One);
-                automaton.Start.AddTransition("g", Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition("a", Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition("b", Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition("d", Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition("e", Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition("g", Weight.One).SetEndWeight(Weight.One);
             }
+
+            var automaton = builder.GetAutomaton();
 
             Assert.False(automaton.IsDeterministic() || TransitionsPerCharacter <= 1);
 
@@ -1922,19 +1961,21 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         internal void DeterminizeList2()
         {
-            var automaton = ListAutomaton<string, StringDistribution>.Zero();
+            var builder = ListAutomaton<string, StringDistribution>.Builder.Zero();
             var unif = StringDistribution.Uniform();
             var scaledUniform = StringDistribution.FromWorkspace(unif.GetWorkspaceOrPoint().Scale(1.0 / 1000));
    
             const int TransitionsPerCharacter = 3;
             for (int i = 0; i < TransitionsPerCharacter; ++i)
             {
-                automaton.Start.AddTransition("a", Weight.One).SetEndWeight(Weight.One);
-                automaton.Start.AddTransition("b", Weight.One).SetEndWeight(Weight.One);
-                automaton.Start.AddTransition("d", Weight.One).SetEndWeight(Weight.One);
-                automaton.Start.AddTransition("e", Weight.One).SetEndWeight(Weight.One);
-                automaton.Start.AddTransition(scaledUniform, Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition("a", Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition("b", Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition("d", Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition("e", Weight.One).SetEndWeight(Weight.One);
+                builder.Start.AddTransition(scaledUniform, Weight.One).SetEndWeight(Weight.One);
             }
+
+            var automaton = builder.GetAutomaton();
 
             Assert.False(automaton.IsDeterministic() || TransitionsPerCharacter <= 1);
 
@@ -1960,20 +2001,22 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void EnumerateSupport()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.AddStates(6);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.AddStates(6);
 
-            automaton.States[0].AddTransition(DiscreteChar.UniformOver('a', 'b'), Weight.FromValue(1), automaton.States[1]);
-            automaton.States[0].AddTransition(DiscreteChar.UniformOver('c', 'd'), Weight.FromValue(1), automaton.States[2]);
-            automaton.States[2].AddTransition(DiscreteChar.UniformOver('e', 'f'), Weight.FromValue(1), automaton.States[3]);
-            automaton.States[2].AddTransition(DiscreteChar.UniformOver('g', 'h'), Weight.FromValue(1), automaton.States[4]);
-            automaton.States[4].AddTransition(DiscreteChar.UniformOver('i', 'j'), Weight.FromValue(1), automaton.States[5]);
-            automaton.States[4].AddTransition(DiscreteChar.UniformOver('k', 'l'), Weight.FromValue(1), automaton.States[5]);
+            builder[0].AddTransition(DiscreteChar.UniformOver('a', 'b'), Weight.FromValue(1), 1);
+            builder[0].AddTransition(DiscreteChar.UniformOver('c', 'd'), Weight.FromValue(1), 2);
+            builder[2].AddTransition(DiscreteChar.UniformOver('e', 'f'), Weight.FromValue(1), 3);
+            builder[2].AddTransition(DiscreteChar.UniformOver('g', 'h'), Weight.FromValue(1), 4);
+            builder[4].AddTransition(DiscreteChar.UniformOver('i', 'j'), Weight.FromValue(1), 5);
+            builder[4].AddTransition(DiscreteChar.UniformOver('k', 'l'), Weight.FromValue(1), 5);
 
-            automaton.States[1].SetEndWeight(Weight.FromValue(1));
-            automaton.States[3].SetEndWeight(Weight.FromValue(1));
-            automaton.States[5].SetEndWeight(Weight.FromValue(1));
-            automaton.States[6].SetEndWeight(Weight.FromValue(1));
+            builder[1].SetEndWeight(Weight.FromValue(1));
+            builder[3].SetEndWeight(Weight.FromValue(1));
+            builder[5].SetEndWeight(Weight.FromValue(1));
+            builder[6].SetEndWeight(Weight.FromValue(1));
+
+            var automaton = builder.GetAutomaton();
 
             var expectedSupport = new HashSet<string>
             {
@@ -1995,20 +2038,22 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Fact]
         public void TryEnumerateSupportPerfTest()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.AddStates(6);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.AddStates(6);
 
-            automaton.States[0].AddTransition(DiscreteChar.UniformOver('a', 'b'), Weight.FromValue(1), automaton.States[1]);
-            automaton.States[0].AddTransition(DiscreteChar.UniformOver('c', 'd'), Weight.FromValue(1), automaton.States[2]);
-            automaton.States[2].AddTransition(DiscreteChar.UniformOver('e', 'f'), Weight.FromValue(1), automaton.States[3]);
-            automaton.States[2].AddTransition(DiscreteChar.UniformOver('g', 'h'), Weight.FromValue(1), automaton.States[4]);
-            automaton.States[4].AddTransition(DiscreteChar.UniformOver('i', 'j'), Weight.FromValue(1), automaton.States[5]);
-            automaton.States[4].AddTransition(DiscreteChar.UniformOver('k', 'l'), Weight.FromValue(1), automaton.States[5]);
+            builder[0].AddTransition(DiscreteChar.UniformOver('a', 'b'), Weight.FromValue(1), 1);
+            builder[0].AddTransition(DiscreteChar.UniformOver('c', 'd'), Weight.FromValue(1), 2);
+            builder[2].AddTransition(DiscreteChar.UniformOver('e', 'f'), Weight.FromValue(1), 3);
+            builder[2].AddTransition(DiscreteChar.UniformOver('g', 'h'), Weight.FromValue(1), 4);
+            builder[4].AddTransition(DiscreteChar.UniformOver('i', 'j'), Weight.FromValue(1), 5);
+            builder[4].AddTransition(DiscreteChar.UniformOver('k', 'l'), Weight.FromValue(1), 5);
 
-            automaton.States[1].SetEndWeight(Weight.FromValue(1));
-            automaton.States[3].SetEndWeight(Weight.FromValue(1));
-            automaton.States[5].SetEndWeight(Weight.FromValue(1));
-            automaton.States[6].SetEndWeight(Weight.FromValue(1));
+            builder[1].SetEndWeight(Weight.FromValue(1));
+            builder[3].SetEndWeight(Weight.FromValue(1));
+            builder[5].SetEndWeight(Weight.FromValue(1));
+            builder[6].SetEndWeight(Weight.FromValue(1));
+
+            var automaton = builder.GetAutomaton();
 
             int numPasses = 10000;
             Stopwatch watch = new Stopwatch();

--- a/test/Tests/Strings/LoopyAutomatonTests.cs
+++ b/test/Tests/Strings/LoopyAutomatonTests.cs
@@ -2,18 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Probabilistic.Collections;
+
 namespace Microsoft.ML.Probabilistic.Tests
 {
     using System;
-
-    using Microsoft.ML.Probabilistic.Core.Collections;
 
     using Xunit;
     using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;
     using Microsoft.ML.Probabilistic.Distributions;
     using Microsoft.ML.Probabilistic.Distributions.Automata;
-    using Microsoft.ML.Probabilistic.Math;
-    using Microsoft.ML.Probabilistic.Utilities;
 
     /// <summary>
     /// Contains a set of tests for automata with non-trivial loops,

--- a/test/Tests/Strings/LoopyAutomatonTests.cs
+++ b/test/Tests/Strings/LoopyAutomatonTests.cs
@@ -5,6 +5,9 @@
 namespace Microsoft.ML.Probabilistic.Tests
 {
     using System;
+
+    using Microsoft.ML.Probabilistic.Core.Collections;
+
     using Xunit;
     using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;
     using Microsoft.ML.Probabilistic.Distributions;
@@ -108,10 +111,10 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void PointMassDetectionWithEpsilonLoop()
         {
-            StringAutomaton f = StringAutomaton.Zero();
+            var f = StringAutomaton.Builder.Zero();
             AddEpsilonLoop(f.Start, 5, 0.5);
             f.Start.AddTransitionsForSequence("abc").SetEndWeight(Weight.One);
-            Assert.Equal("abc", f.TryComputePoint());
+            Assert.Equal("abc", f.GetAutomaton().TryComputePoint());
         }
 
         /// <summary>
@@ -121,10 +124,10 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void PointMassDetectionWithDeadLoop()
         {
-            StringAutomaton f = StringAutomaton.Zero();
-            f.Start.AddTransition('a', Weight.FromValue(0.5)).AddTransition('b', Weight.Zero, f.Start);
+            var f = StringAutomaton.Builder.Zero();
+            f.Start.AddTransition('a', Weight.FromValue(0.5)).AddTransition('b', Weight.Zero, f.Start.Index);
             f.Start.AddTransitionsForSequence("abc").SetEndWeight(Weight.One);
-            Assert.Equal("abc", f.TryComputePoint());
+            Assert.Equal("abc", f.GetAutomaton().TryComputePoint());
         }
 
         /// <summary>
@@ -134,10 +137,10 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void PointMassDetectionLoopInDeadEnd()
         {
-            StringAutomaton f = StringAutomaton.Zero();
+            var f = StringAutomaton.Builder.Zero();
             f.Start.AddTransition('a', Weight.FromValue(0.5)).AddSelfTransition('a', Weight.FromValue(0.5)).AddTransition('b', Weight.One);
             f.Start.AddTransition('b', Weight.FromValue(0.5)).SetEndWeight(Weight.One);
-            Assert.Equal("b", f.TryComputePoint());
+            Assert.Equal("b", f.GetAutomaton().TryComputePoint());
         }
 
         /// <summary>
@@ -147,9 +150,9 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NoPoint1()
         {
-            StringAutomaton f = StringAutomaton.Zero();
-            f.Start.AddTransition('a', Weight.FromValue(0.5)).AddTransition('b', Weight.FromValue(0.5), f.Start).SetEndWeight(Weight.One);
-            Assert.Null(f.TryComputePoint());
+            var f = StringAutomaton.Builder.Zero();
+            f.Start.AddTransition('a', Weight.FromValue(0.5)).AddTransition('b', Weight.FromValue(0.5), f.Start.Index).SetEndWeight(Weight.One);
+            Assert.Null(f.GetAutomaton().TryComputePoint());
         }
 
         /// <summary>
@@ -159,11 +162,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NoPoint2()
         {
-            StringAutomaton f = StringAutomaton.Zero();
+            var f = StringAutomaton.Builder.Zero();
             var state = f.Start.AddTransition('a', Weight.FromValue(0.5));
             state.SetEndWeight(Weight.One);
-            state.AddTransition('b', Weight.FromValue(0.5), f.Start);
-            Assert.Null(f.TryComputePoint());
+            state.AddTransition('b', Weight.FromValue(0.5), f.Start.Index);
+            Assert.Null(f.GetAutomaton().TryComputePoint());
         }
 
         /// <summary>
@@ -173,7 +176,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NoPointZero()
         {
-            StringAutomaton f = StringAutomaton.Zero();
+            var f = StringAutomaton.Zero();
             Assert.Null(f.TryComputePoint());
         }
 
@@ -188,8 +191,10 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ZeroDetectionWithEpsilonLoop1()
         {
-            StringAutomaton f = StringAutomaton.Zero();
-            AddEpsilonLoop(f.Start, 5, 0);
+            var builder = StringAutomaton.Builder.Zero();
+            AddEpsilonLoop(builder.Start, 5, 0);
+
+            var f = builder.GetAutomaton();
             Assert.False(f.IsCanonicZero());
             Assert.True(f.IsZero());
         }
@@ -201,9 +206,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ZeroDetectionWithEpsilonLoop2()
         {
-            StringAutomaton f = StringAutomaton.Zero();
-            AddEpsilonLoop(f.Start, 5, 2.0);
-            f.Start.AddTransition('a', Weight.One);
+            var builder = StringAutomaton.Builder.Zero();
+            AddEpsilonLoop(builder.Start, 5, 2.0);
+            builder.Start.AddTransition('a', Weight.One);
+
+            var f = builder.GetAutomaton();
             Assert.False(f.IsCanonicZero());
             Assert.True(f.IsZero());
         }
@@ -215,10 +222,10 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ZeroDetectionWithDeadSelfLoop()
         {
-            StringAutomaton f = StringAutomaton.Zero();
+            var f = StringAutomaton.Builder.Zero();
             f.Start.AddSelfTransition('x', Weight.Zero);
             f.Start.AddTransition('y', Weight.Zero).SetEndWeight(Weight.One);
-            Assert.True(f.IsZero());
+            Assert.True(f.GetAutomaton().IsZero());
         }
         
         #endregion
@@ -232,11 +239,19 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void LoopyArithmetic()
         {
-            StringAutomaton automaton1 = StringAutomaton.Zero();
-            automaton1.Start.AddTransition('a', Weight.FromValue(4.0)).AddTransition('b', Weight.One, automaton1.Start).SetEndWeight(Weight.One);
+            var builder1 = StringAutomaton.Builder.Zero();
+            builder1.Start
+                .AddTransition('a', Weight.FromValue(4.0))
+                .AddTransition('b', Weight.One, builder1.Start.Index)
+                .SetEndWeight(Weight.One);
+            var automaton1 = builder1.GetAutomaton();
 
-            StringAutomaton automaton2 = StringAutomaton.Zero();
-            automaton2.Start.AddSelfTransition('a', Weight.FromValue(2)).AddSelfTransition('b', Weight.FromValue(3)).SetEndWeight(Weight.One);
+            var builder2 = StringAutomaton.Builder.Zero();
+            builder2.Start
+                .AddSelfTransition('a', Weight.FromValue(2))
+                .AddSelfTransition('b', Weight.FromValue(3))
+                .SetEndWeight(Weight.One);
+            var automaton2 = builder2.GetAutomaton();
 
             StringAutomaton sum = automaton1.Sum(automaton2);
             StringInferenceTestUtilities.TestValue(sum, 2.0, string.Empty);
@@ -271,9 +286,10 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerSimple1()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddSelfTransition('a', Weight.FromValue(0.7));
-            automaton.Start.SetEndWeight(Weight.FromValue(0.3));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddSelfTransition('a', Weight.FromValue(0.7));
+            builder.Start.SetEndWeight(Weight.FromValue(0.3));
+            var automaton = builder.GetAutomaton();
 
             AssertStochastic(automaton);
             Assert.Equal(0.0, automaton.GetLogNormalizer(), 1e-6);
@@ -288,13 +304,14 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerSimple2()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            var state = automaton.Start;
+            var builder = StringAutomaton.Builder.Zero();
+            var state = builder.Start;
             state.SetEndWeight(Weight.FromValue(0.1));
             state.AddSelfTransition('a', Weight.FromValue(0.7));
             state = state.AddTransition('b', Weight.FromValue(0.2));
             state.AddSelfTransition('a', Weight.FromValue(0.4));
             state.SetEndWeight(Weight.FromValue(0.6));
+            var automaton = builder.GetAutomaton();
 
             AssertStochastic(automaton);
             Assert.Equal(0.0, automaton.GetLogNormalizer(), 1e-6);
@@ -309,17 +326,19 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerSimple3()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
+            var builder = StringAutomaton.Builder.Zero();
 
-            automaton.Start.AddSelfTransition('a', Weight.FromValue(0.7));
-            automaton.Start.SetEndWeight(Weight.FromValue(0.1));
+            builder.Start.AddSelfTransition('a', Weight.FromValue(0.7));
+            builder.Start.SetEndWeight(Weight.FromValue(0.1));
 
-            var state1 = automaton.Start.AddTransition('b', Weight.FromValue(0.15));
+            var state1 = builder.Start.AddTransition('b', Weight.FromValue(0.15));
             state1.AddSelfTransition('a', Weight.FromValue(0.4));
             state1.SetEndWeight(Weight.FromValue(0.6));
 
-            var state2 = automaton.Start.AddTransition('c', Weight.FromValue(0.05));
+            var state2 = builder.Start.AddTransition('c', Weight.FromValue(0.05));
             state2.SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
 
             AssertStochastic(automaton);
             Assert.Equal(0.0, automaton.GetLogNormalizer(), 1e-6);
@@ -334,14 +353,16 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerWithNonTrivialLoop1()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
+            var builder = StringAutomaton.Builder.Zero();
 
-            var state = automaton.Start.AddTransition('a', Weight.FromValue(0.9));
+            var state = builder.Start.AddTransition('a', Weight.FromValue(0.9));
             state.AddTransition('a', Weight.FromValue(0.1)).SetEndWeight(Weight.One);
             state = state.AddTransition('a', Weight.FromValue(0.9));
             state.AddTransition('a', Weight.FromValue(0.1)).SetEndWeight(Weight.One);
-            state = state.AddTransition('a', Weight.FromValue(0.9), automaton.Start);
+            state = state.AddTransition('a', Weight.FromValue(0.9), builder.Start.Index);
             state.AddTransition('a', Weight.FromValue(0.1)).SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
 
             AssertStochastic(automaton);
             Assert.Equal(0.0, automaton.GetLogNormalizer(), 1e-6);
@@ -356,12 +377,14 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerWithNonTrivialLoop2()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
+            var builder = StringAutomaton.Builder.Zero();
 
-            var endState = automaton.Start.AddTransition('a', Weight.FromValue(2.0));
+            var endState = builder.Start.AddTransition('a', Weight.FromValue(2.0));
             endState.SetEndWeight(Weight.FromValue(5.0));
-            endState.AddTransition('b', Weight.FromValue(0.25), automaton.Start);
-            endState.AddTransition('c', Weight.FromValue(0.2), automaton.Start);
+            endState.AddTransition('b', Weight.FromValue(0.25), builder.Start.Index);
+            endState.AddTransition('c', Weight.FromValue(0.2), builder.Start.Index);
+
+            var automaton = builder.GetAutomaton();
 
             Assert.Equal(Math.Log(100.0), automaton.GetLogNormalizer(), 1e-6);
             Assert.Equal(Math.Log(100.0), GetLogNormalizerByGetValue(automaton), 1e-6);
@@ -375,13 +398,15 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NormalizeValuesWithNonTrivialLoop()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
+            var builder = StringAutomaton.Builder.Zero();
 
-            var endState = automaton.Start.AddTransition('a', Weight.FromValue(2.0));
+            var endState = builder.Start.AddTransition('a', Weight.FromValue(2.0));
             endState.SetEndWeight(Weight.FromValue(5.0));
-            endState.AddTransition('b', Weight.FromValue(0.1), automaton.Start);
-            endState.AddTransition('c', Weight.FromValue(0.05), automaton.Start);
+            endState.AddTransition('b', Weight.FromValue(0.1), builder.Start.Index);
+            endState.AddTransition('c', Weight.FromValue(0.05), builder.Start.Index);
             endState.AddSelfTransition('!', Weight.FromValue(0.5));
+
+            var automaton = builder.GetAutomaton();
 
             var normalizedAutomaton = automaton.Clone();
             double logNormalizer = normalizedAutomaton.NormalizeValues();
@@ -404,17 +429,19 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerWithManyNonTrivialLoops1()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
+            var builder = StringAutomaton.Builder.Zero();
 
-            AddEpsilonLoop(automaton.Start, 3, 0.2);
-            AddEpsilonLoop(automaton.Start, 5, 0.3);
-            automaton.Start.SetEndWeight(Weight.FromValue(0.1));
-            var nextState = automaton.Start.AddTransition('a', Weight.FromValue(0.4));
+            AddEpsilonLoop(builder.Start, 3, 0.2);
+            AddEpsilonLoop(builder.Start, 5, 0.3);
+            builder.Start.SetEndWeight(Weight.FromValue(0.1));
+            var nextState = builder.Start.AddTransition('a', Weight.FromValue(0.4));
             nextState.SetEndWeight(Weight.FromValue(0.6));
             AddEpsilonLoop(nextState, 0, 0.3);
             nextState = nextState.AddTransition('b', Weight.FromValue(0.1));
             AddEpsilonLoop(nextState, 1, 0.9);
             nextState.SetEndWeight(Weight.FromValue(0.1));
+
+            var automaton = builder.GetAutomaton();
 
             AssertStochastic(automaton);
             Assert.Equal(0.0, automaton.GetLogNormalizer(), 1e-6);
@@ -429,26 +456,28 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerWithManyNonTrivialLoops2()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.AddStates(6);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.AddStates(6);
 
-            automaton.States[0].AddEpsilonTransition(Weight.FromValue(0.2), automaton.States[1]);
-            automaton.States[0].AddEpsilonTransition(Weight.FromValue(0.5), automaton.States[3]);
-            automaton.States[0].SetEndWeight(Weight.FromValue(0.3));
-            automaton.States[1].AddEpsilonTransition(Weight.FromValue(0.8), automaton.States[0]);
-            automaton.States[1].AddEpsilonTransition(Weight.FromValue(0.1), automaton.States[2]);
-            automaton.States[1].SetEndWeight(Weight.FromValue(0.1));
-            automaton.States[2].SetEndWeight(Weight.FromValue(1.0));
-            automaton.States[3].AddEpsilonTransition(Weight.FromValue(0.2), automaton.States[4]);
-            automaton.States[3].AddEpsilonTransition(Weight.FromValue(0.1), automaton.States[5]);
-            automaton.States[3].SetEndWeight(Weight.FromValue(0.7));
-            automaton.States[4].AddEpsilonTransition(Weight.FromValue(0.5), automaton.States[2]);
-            automaton.States[4].AddEpsilonTransition(Weight.FromValue(0.5), automaton.States[6]);
-            automaton.States[4].SetEndWeight(Weight.FromValue(0.0));
-            automaton.States[5].AddEpsilonTransition(Weight.FromValue(0.1), automaton.States[3]);
-            automaton.States[5].AddEpsilonTransition(Weight.FromValue(0.9), automaton.States[6]);
-            automaton.States[5].SetEndWeight(Weight.Zero);
-            automaton.States[6].SetEndWeight(Weight.One);
+            builder[0].AddEpsilonTransition(Weight.FromValue(0.2), 1);
+            builder[0].AddEpsilonTransition(Weight.FromValue(0.5), 3);
+            builder[0].SetEndWeight(Weight.FromValue(0.3));
+            builder[1].AddEpsilonTransition(Weight.FromValue(0.8), 0);
+            builder[1].AddEpsilonTransition(Weight.FromValue(0.1), 2);
+            builder[1].SetEndWeight(Weight.FromValue(0.1));
+            builder[2].SetEndWeight(Weight.FromValue(1.0));
+            builder[3].AddEpsilonTransition(Weight.FromValue(0.2), 4);
+            builder[3].AddEpsilonTransition(Weight.FromValue(0.1), 5);
+            builder[3].SetEndWeight(Weight.FromValue(0.7));
+            builder[4].AddEpsilonTransition(Weight.FromValue(0.5), 2);
+            builder[4].AddEpsilonTransition(Weight.FromValue(0.5), 6);
+            builder[4].SetEndWeight(Weight.FromValue(0.0));
+            builder[5].AddEpsilonTransition(Weight.FromValue(0.1), 3);
+            builder[5].AddEpsilonTransition(Weight.FromValue(0.9), 6);
+            builder[5].SetEndWeight(Weight.Zero);
+            builder[6].SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
 
             AssertStochastic(automaton);
             Assert.Equal(0.0, automaton.GetLogNormalizer(), 1e-6);
@@ -463,13 +492,15 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NonNormalizableLoop1()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
+            var builder = StringAutomaton.Builder.Zero();
 
-            var endState = automaton.Start.AddTransition('a', Weight.FromValue(3.5));
+            var endState = builder.Start.AddTransition('a', Weight.FromValue(3.5));
             endState.SetEndWeight(Weight.FromValue(5.0));
-            endState.AddTransition('b', Weight.FromValue(0.1), automaton.Start);
-            endState.AddTransition('c', Weight.FromValue(0.05), automaton.Start);
+            endState.AddTransition('b', Weight.FromValue(0.1), builder.Start.Index);
+            endState.AddTransition('c', Weight.FromValue(0.05), builder.Start.Index);
             endState.AddSelfTransition('!', Weight.FromValue(0.5));
+
+            var automaton = builder.GetAutomaton();
 
             StringAutomaton copyOfAutomaton = automaton.Clone();
             Assert.Throws<InvalidOperationException>(() => copyOfAutomaton.NormalizeValues());
@@ -484,13 +515,15 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NonNormalizableLoop2()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
+            var builder = StringAutomaton.Builder.Zero();
 
-            var endState = automaton.Start.AddTransition('a', Weight.FromValue(2.0));
+            var endState = builder.Start.AddTransition('a', Weight.FromValue(2.0));
             endState.SetEndWeight(Weight.FromValue(5.0));
-            endState.AddTransition('b', Weight.FromValue(0.1), automaton.Start);
-            endState.AddTransition('c', Weight.FromValue(0.05), automaton.Start);
+            endState.AddTransition('b', Weight.FromValue(0.1), builder.Start.Index);
+            endState.AddTransition('c', Weight.FromValue(0.05), builder.Start.Index);
             endState.AddSelfTransition('!', Weight.FromValue(0.75));
+
+            var automaton = builder.GetAutomaton();
 
             StringAutomaton copyOfAutomaton = automaton.Clone();
             Assert.Throws<InvalidOperationException>(() => copyOfAutomaton.NormalizeValues());
@@ -505,9 +538,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NonNormalizableLoop3()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.FromValue(2.0), automaton.Start);
-            automaton.Start.SetEndWeight(Weight.FromValue(5.0));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.FromValue(2.0), builder.Start.Index);
+            builder.Start.SetEndWeight(Weight.FromValue(5.0));
+
+            var automaton = builder.GetAutomaton();
 
             StringAutomaton copyOfAutomaton = automaton.Clone();
             Assert.Throws<InvalidOperationException>(() => automaton.NormalizeValues());
@@ -522,14 +557,16 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NonNormalizableLoop4()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddSelfTransition('a', Weight.FromValue(0.1));
-            var branch1 = automaton.Start.AddTransition('a', Weight.FromValue(2.0));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddSelfTransition('a', Weight.FromValue(0.1));
+            var branch1 = builder.Start.AddTransition('a', Weight.FromValue(2.0));
             branch1.AddSelfTransition('a', Weight.FromValue(2.0));
             branch1.SetEndWeight(Weight.One);
-            var branch2 = automaton.Start.AddTransition('a', Weight.FromValue(2.0));
+            var branch2 = builder.Start.AddTransition('a', Weight.FromValue(2.0));
             branch2.SetEndWeight(Weight.One);
-            
+
+            var automaton = builder.GetAutomaton();
+
             StringAutomaton copyOfAutomaton = automaton.Clone();
             Assert.Throws<InvalidOperationException>(() => automaton.NormalizeValues());
             Assert.False(copyOfAutomaton.TryNormalizeValues());
@@ -543,8 +580,10 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NormalizeWithInfiniteEpsilon1()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.One).AddSelfTransition(Option.None, Weight.FromValue(3)).SetEndWeight(Weight.One);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.One).AddSelfTransition(Option.None, Weight.FromValue(3)).SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
 
             // The automaton takes an infinite value on "a", and yet the normalization must work
             Assert.True(automaton.TryNormalizeValues());
@@ -559,9 +598,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NormalizeWithInfiniteEpsilon2()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransition('a', Weight.One).AddSelfTransition(Option.None, Weight.FromValue(2)).SetEndWeight(Weight.One);
-            automaton.Start.AddTransition('b', Weight.One).AddSelfTransition(Option.None, Weight.FromValue(1)).SetEndWeight(Weight.One);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('a', Weight.One).AddSelfTransition(Option.None, Weight.FromValue(2)).SetEndWeight(Weight.One);
+            builder.Start.AddTransition('b', Weight.One).AddSelfTransition(Option.None, Weight.FromValue(1)).SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
 
             // "a" branch infinitely dominates over the "b" branch
             Assert.True(automaton.TryNormalizeValues());
@@ -580,11 +621,13 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void LoopyEpsilonClosure1()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddEpsilonTransition(Weight.FromValue(0.5), automaton.Start);
-            var nextState = automaton.Start.AddEpsilonTransition(Weight.FromValue(0.4));
-            nextState.AddEpsilonTransition(Weight.One).AddEpsilonTransition(Weight.One, automaton.Start);
-            automaton.Start.SetEndWeight(Weight.FromValue(0.1));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddEpsilonTransition(Weight.FromValue(0.5), builder.Start.Index);
+            var nextState = builder.Start.AddEpsilonTransition(Weight.FromValue(0.4));
+            nextState.AddEpsilonTransition(Weight.One).AddEpsilonTransition(Weight.One, builder.Start.Index);
+            builder.Start.SetEndWeight(Weight.FromValue(0.1));
+
+            var automaton = builder.GetAutomaton();
 
             AssertStochastic(automaton);
 
@@ -611,11 +654,13 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToStringWithLoops1()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            var middleNode = automaton.Start.AddTransition('a', Weight.One);
-            middleNode.AddTransitionsForSequence("bbb", automaton.Start);
-            middleNode.AddTransition('c', Weight.One, automaton.Start);
-            automaton.Start.SetEndWeight(Weight.One);
+            var builder = StringAutomaton.Builder.Zero();
+            var middleNode = builder.Start.AddTransition('a', Weight.One);
+            middleNode.AddTransitionsForSequence("bbb", builder.Start.Index);
+            middleNode.AddTransition('c', Weight.One, builder.Start.Index);
+            builder.Start.SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
 
             Assert.Equal("(a(c|bbb))*", automaton.ToString(AutomatonFormats.Friendly));
             Assert.Equal("(a(c|bbb))*", automaton.ToString(AutomatonFormats.Regexp));
@@ -628,10 +673,12 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToStringWithLoops2()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddSelfTransition('a', Weight.One);
-            automaton.Start.AddSelfTransition('b', Weight.One);
-            automaton.Start.SetEndWeight(Weight.One);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddSelfTransition('a', Weight.One);
+            builder.Start.AddSelfTransition('b', Weight.One);
+            builder.Start.SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
 
             Assert.Equal("(a|b)*", automaton.ToString(AutomatonFormats.Friendly));
             Assert.Equal("(a|b)*", automaton.ToString(AutomatonFormats.Regexp));
@@ -645,13 +692,15 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToStringWithLoops3()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            var state = automaton.Start.AddTransition('x', Weight.One);
-            automaton.Start.AddTransition('y', Weight.One, state);
+            var builder = StringAutomaton.Builder.Zero();
+            var state = builder.Start.AddTransition('x', Weight.One);
+            builder.Start.AddTransition('y', Weight.One, state.Index);
             state.AddSelfTransition('a', Weight.One);
             state.AddSelfTransition('b', Weight.One);
             state.SetEndWeight(Weight.One);
             state.AddTransitionsForSequence("zzz").SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
 
             Assert.Equal("(x|y)(a|b)*[zzz]", automaton.ToString(AutomatonFormats.Friendly));
             Assert.Equal("(x|y)(a|b)*(|zzz)", automaton.ToString(AutomatonFormats.Regexp));
@@ -664,9 +713,10 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToStringWithLoops4()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddTransitionsForSequence("xyz", automaton.Start);
-            automaton.Start.AddTransition('!', Weight.One).SetEndWeight(Weight.One);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransitionsForSequence("xyz", builder.Start.Index);
+            builder.Start.AddTransition('!', Weight.One).SetEndWeight(Weight.One);
+            var automaton = builder.GetAutomaton();
             Assert.Equal("(xyz)*!", automaton.ToString(AutomatonFormats.Friendly));
             Assert.Equal("(xyz)*!", automaton.ToString(AutomatonFormats.Regexp));
         }
@@ -678,11 +728,13 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToStringWithDeadTransitions1()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            var state = automaton.Start.AddTransition('x', Weight.One);
-            automaton.Start.AddTransition('y', Weight.Zero, state);
+            var builder = StringAutomaton.Builder.Zero();
+            var state = builder.Start.AddTransition('x', Weight.One);
+            builder.Start.AddTransition('y', Weight.Zero, state.Index);
             state.AddSelfTransition('a', Weight.One);
             state.SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
 
             Assert.Equal("xa*", automaton.ToString(AutomatonFormats.Friendly));
             Assert.Equal("xa*", automaton.ToString(AutomatonFormats.Regexp));
@@ -695,9 +747,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToStringWithDeadTransitions2()
         {
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start.AddSelfTransition('x', Weight.Zero);
-            automaton.Start.AddTransition('y', Weight.Zero).SetEndWeight(Weight.One);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddSelfTransition('x', Weight.Zero);
+            builder.Start.AddTransition('y', Weight.Zero).SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
 
             Assert.Equal("Ø", automaton.ToString(AutomatonFormats.Friendly));
             Assert.Equal("Ø", automaton.ToString(AutomatonFormats.Regexp));
@@ -716,7 +770,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         private static double GetLogNormalizerByGetValue(StringAutomaton automaton)
         {
             var epsilonAutomaton = new StringAutomaton();
-            epsilonAutomaton.SetToFunction(automaton, (dist, weight, group) => Tuple.Create<Option<DiscreteChar>, Weight>(Option.None, weight)); // Convert all the edges to epsilon edges
+            epsilonAutomaton.SetToFunction(automaton, (dist, weight, group) => ValueTuple.Create<Option<DiscreteChar>, Weight>(Option.None, weight)); // Convert all the edges to epsilon edges
             return epsilonAutomaton.GetLogValue(string.Empty); // Now this will be exactly the normalizer
         }
 
@@ -745,9 +799,9 @@ namespace Microsoft.ML.Probabilistic.Tests
             for (int i = 0; i < automatonClone.States.Count; ++i)
             {
                 Weight weightSum = automatonClone.States[i].EndWeight;
-                for (int j = 0; j < automatonClone.States[i].TransitionCount; ++j)
+                for (int j = 0; j < automatonClone.States[i].Transitions.Count; ++j)
                 {
-                    weightSum = Weight.Sum(weightSum, automatonClone.States[i].GetTransition(j).Weight);
+                    weightSum = Weight.Sum(weightSum, automatonClone.States[i].Transitions[j].Weight);
                 }
 
                 Assert.Equal(0.0, weightSum.LogValue, 1e-6);
@@ -760,14 +814,14 @@ namespace Microsoft.ML.Probabilistic.Tests
         /// <param name="state">The state.</param>
         /// <param name="loopSize">The number of intermediate states in the loop.</param>
         /// <param name="loopWeight">The weight of the loop.</param>
-        private static void AddEpsilonLoop(StringAutomaton.State state, int loopSize, double loopWeight)
+        private static void AddEpsilonLoop(StringAutomaton.Builder.StateBuilder state, int loopSize, double loopWeight)
         {
-            StringAutomaton.State currentState = state;
+            var currentState = state;
             for (int i = 0; i <= loopSize; ++i)
             {
                 currentState = currentState.AddEpsilonTransition(
                     i == 0 ? Weight.FromValue(loopWeight) : Weight.One,
-                    i == loopSize ? state : default(StringAutomaton.State));
+                    i == loopSize ? (int?)state.Index : null);
             }
         }
 

--- a/test/Tests/Strings/LoopyAutomatonTests.cs
+++ b/test/Tests/Strings/LoopyAutomatonTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void PointMassDetectionWithEpsilonLoop()
         {
-            var f = StringAutomaton.Builder.Zero();
+            var f = new StringAutomaton.Builder();
             AddEpsilonLoop(f.Start, 5, 0.5);
             f.Start.AddTransitionsForSequence("abc").SetEndWeight(Weight.One);
             Assert.Equal("abc", f.GetAutomaton().TryComputePoint());
@@ -122,7 +122,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void PointMassDetectionWithDeadLoop()
         {
-            var f = StringAutomaton.Builder.Zero();
+            var f = new StringAutomaton.Builder();
             f.Start.AddTransition('a', Weight.FromValue(0.5)).AddTransition('b', Weight.Zero, f.Start.Index);
             f.Start.AddTransitionsForSequence("abc").SetEndWeight(Weight.One);
             Assert.Equal("abc", f.GetAutomaton().TryComputePoint());
@@ -135,7 +135,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void PointMassDetectionLoopInDeadEnd()
         {
-            var f = StringAutomaton.Builder.Zero();
+            var f = new StringAutomaton.Builder();
             f.Start.AddTransition('a', Weight.FromValue(0.5)).AddSelfTransition('a', Weight.FromValue(0.5)).AddTransition('b', Weight.One);
             f.Start.AddTransition('b', Weight.FromValue(0.5)).SetEndWeight(Weight.One);
             Assert.Equal("b", f.GetAutomaton().TryComputePoint());
@@ -148,7 +148,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NoPoint1()
         {
-            var f = StringAutomaton.Builder.Zero();
+            var f = new StringAutomaton.Builder();
             f.Start.AddTransition('a', Weight.FromValue(0.5)).AddTransition('b', Weight.FromValue(0.5), f.Start.Index).SetEndWeight(Weight.One);
             Assert.Null(f.GetAutomaton().TryComputePoint());
         }
@@ -160,7 +160,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NoPoint2()
         {
-            var f = StringAutomaton.Builder.Zero();
+            var f = new StringAutomaton.Builder();
             var state = f.Start.AddTransition('a', Weight.FromValue(0.5));
             state.SetEndWeight(Weight.One);
             state.AddTransition('b', Weight.FromValue(0.5), f.Start.Index);
@@ -189,7 +189,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ZeroDetectionWithEpsilonLoop1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             AddEpsilonLoop(builder.Start, 5, 0);
 
             var f = builder.GetAutomaton();
@@ -204,7 +204,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ZeroDetectionWithEpsilonLoop2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             AddEpsilonLoop(builder.Start, 5, 2.0);
             builder.Start.AddTransition('a', Weight.One);
 
@@ -220,7 +220,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ZeroDetectionWithDeadSelfLoop()
         {
-            var f = StringAutomaton.Builder.Zero();
+            var f = new StringAutomaton.Builder();
             f.Start.AddSelfTransition('x', Weight.Zero);
             f.Start.AddTransition('y', Weight.Zero).SetEndWeight(Weight.One);
             Assert.True(f.GetAutomaton().IsZero());
@@ -237,14 +237,14 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void LoopyArithmetic()
         {
-            var builder1 = StringAutomaton.Builder.Zero();
+            var builder1 = new StringAutomaton.Builder();
             builder1.Start
                 .AddTransition('a', Weight.FromValue(4.0))
                 .AddTransition('b', Weight.One, builder1.Start.Index)
                 .SetEndWeight(Weight.One);
             var automaton1 = builder1.GetAutomaton();
 
-            var builder2 = StringAutomaton.Builder.Zero();
+            var builder2 = new StringAutomaton.Builder();
             builder2.Start
                 .AddSelfTransition('a', Weight.FromValue(2))
                 .AddSelfTransition('b', Weight.FromValue(3))
@@ -284,7 +284,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerSimple1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddSelfTransition('a', Weight.FromValue(0.7));
             builder.Start.SetEndWeight(Weight.FromValue(0.3));
             var automaton = builder.GetAutomaton();
@@ -302,7 +302,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerSimple2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             var state = builder.Start;
             state.SetEndWeight(Weight.FromValue(0.1));
             state.AddSelfTransition('a', Weight.FromValue(0.7));
@@ -324,7 +324,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerSimple3()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
 
             builder.Start.AddSelfTransition('a', Weight.FromValue(0.7));
             builder.Start.SetEndWeight(Weight.FromValue(0.1));
@@ -351,7 +351,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerWithNonTrivialLoop1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
 
             var state = builder.Start.AddTransition('a', Weight.FromValue(0.9));
             state.AddTransition('a', Weight.FromValue(0.1)).SetEndWeight(Weight.One);
@@ -375,7 +375,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerWithNonTrivialLoop2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
 
             var endState = builder.Start.AddTransition('a', Weight.FromValue(2.0));
             endState.SetEndWeight(Weight.FromValue(5.0));
@@ -396,7 +396,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NormalizeValuesWithNonTrivialLoop()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
 
             var endState = builder.Start.AddTransition('a', Weight.FromValue(2.0));
             endState.SetEndWeight(Weight.FromValue(5.0));
@@ -427,7 +427,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerWithManyNonTrivialLoops1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
 
             AddEpsilonLoop(builder.Start, 3, 0.2);
             AddEpsilonLoop(builder.Start, 5, 0.3);
@@ -454,7 +454,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ComputeNormalizerWithManyNonTrivialLoops2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.AddStates(6);
 
             builder[0].AddEpsilonTransition(Weight.FromValue(0.2), 1);
@@ -490,7 +490,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NonNormalizableLoop1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
 
             var endState = builder.Start.AddTransition('a', Weight.FromValue(3.5));
             endState.SetEndWeight(Weight.FromValue(5.0));
@@ -513,7 +513,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NonNormalizableLoop2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
 
             var endState = builder.Start.AddTransition('a', Weight.FromValue(2.0));
             endState.SetEndWeight(Weight.FromValue(5.0));
@@ -536,7 +536,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NonNormalizableLoop3()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.FromValue(2.0), builder.Start.Index);
             builder.Start.SetEndWeight(Weight.FromValue(5.0));
 
@@ -555,7 +555,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NonNormalizableLoop4()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddSelfTransition('a', Weight.FromValue(0.1));
             var branch1 = builder.Start.AddTransition('a', Weight.FromValue(2.0));
             branch1.AddSelfTransition('a', Weight.FromValue(2.0));
@@ -578,7 +578,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NormalizeWithInfiniteEpsilon1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.One).AddSelfTransition(Option.None, Weight.FromValue(3)).SetEndWeight(Weight.One);
 
             var automaton = builder.GetAutomaton();
@@ -596,7 +596,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void NormalizeWithInfiniteEpsilon2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.One).AddSelfTransition(Option.None, Weight.FromValue(2)).SetEndWeight(Weight.One);
             builder.Start.AddTransition('b', Weight.One).AddSelfTransition(Option.None, Weight.FromValue(1)).SetEndWeight(Weight.One);
 
@@ -619,7 +619,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void LoopyEpsilonClosure1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddEpsilonTransition(Weight.FromValue(0.5), builder.Start.Index);
             var nextState = builder.Start.AddEpsilonTransition(Weight.FromValue(0.4));
             nextState.AddEpsilonTransition(Weight.One).AddEpsilonTransition(Weight.One, builder.Start.Index);
@@ -652,7 +652,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToStringWithLoops1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             var middleNode = builder.Start.AddTransition('a', Weight.One);
             middleNode.AddTransitionsForSequence("bbb", builder.Start.Index);
             middleNode.AddTransition('c', Weight.One, builder.Start.Index);
@@ -671,7 +671,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToStringWithLoops2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddSelfTransition('a', Weight.One);
             builder.Start.AddSelfTransition('b', Weight.One);
             builder.Start.SetEndWeight(Weight.One);
@@ -690,7 +690,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToStringWithLoops3()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             var state = builder.Start.AddTransition('x', Weight.One);
             builder.Start.AddTransition('y', Weight.One, state.Index);
             state.AddSelfTransition('a', Weight.One);
@@ -711,7 +711,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToStringWithLoops4()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransitionsForSequence("xyz", builder.Start.Index);
             builder.Start.AddTransition('!', Weight.One).SetEndWeight(Weight.One);
             var automaton = builder.GetAutomaton();
@@ -726,7 +726,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToStringWithDeadTransitions1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             var state = builder.Start.AddTransition('x', Weight.One);
             builder.Start.AddTransition('y', Weight.Zero, state.Index);
             state.AddSelfTransition('a', Weight.One);
@@ -745,7 +745,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void ConvertToStringWithDeadTransitions2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddSelfTransition('x', Weight.Zero);
             builder.Start.AddTransition('y', Weight.Zero).SetEndWeight(Weight.One);
 

--- a/test/Tests/Strings/SequenceDistributionTests.cs
+++ b/test/Tests/Strings/SequenceDistributionTests.cs
@@ -178,11 +178,15 @@ namespace Microsoft.ML.Probabilistic.Tests
         public void ProductWithGroups()
         {
             StringDistribution lhsWithoutGroup = StringDistribution.String("ab");
-            var weightFunction = lhsWithoutGroup.GetWorkspaceOrPoint();
-            var transitionWithGroup = weightFunction.Start.GetTransitions()[0];
+
+            // add a group to first transition of the start state
+            var weightFunctionBuilder = StringAutomaton.Builder.FromAutomaton(lhsWithoutGroup.GetWorkspaceOrPoint());
+            var transitionIterator = weightFunctionBuilder.Start.TransitionIterator;
+            var transitionWithGroup = transitionIterator.Value;
             transitionWithGroup.Group = 1;
-            weightFunction.Start.SetTransition(0, transitionWithGroup);
-            StringDistribution lhs = StringDistribution.FromWeightFunction(weightFunction);
+            transitionIterator.Value = transitionWithGroup;
+
+            StringDistribution lhs = StringDistribution.FromWeightFunction(weightFunctionBuilder.GetAutomaton());
             StringDistribution rhs = StringDistribution.OneOf("ab", "ac");
             Assert.True(lhs.GetWorkspaceOrPoint().HasGroup(1));
             Assert.False(rhs.GetWorkspaceOrPoint().UsesGroups());
@@ -577,11 +581,11 @@ namespace Microsoft.ML.Probabilistic.Tests
             const double StoppingProbability = 0.7;
 
             // The length of sequences sampled from this distribution must follow a geometric distribution
-            StringAutomaton automaton = StringAutomaton.Zero();
-            automaton.Start = automaton.AddState();
-            automaton.Start.SetEndWeight(Weight.FromValue(StoppingProbability));
-            automaton.Start.AddTransition('a', Weight.FromValue(1 - StoppingProbability), automaton.Start);
-            StringDistribution dist = StringDistribution.FromWeightFunction(automaton);
+            var builder = StringAutomaton.Builder.Zero();
+            builder.StartStateIndex = builder.AddState().Index;
+            builder.Start.SetEndWeight(Weight.FromValue(StoppingProbability));
+            builder.Start.AddTransition('a', Weight.FromValue(1 - StoppingProbability), builder.Start.Index);
+            StringDistribution dist = StringDistribution.FromWeightFunction(builder.GetAutomaton());
 
             var acc = new MeanVarianceAccumulator();
             const int SampleCount = 30000;

--- a/test/Tests/Strings/SequenceDistributionTests.cs
+++ b/test/Tests/Strings/SequenceDistributionTests.cs
@@ -581,7 +581,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             const double StoppingProbability = 0.7;
 
             // The length of sequences sampled from this distribution must follow a geometric distribution
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.StartStateIndex = builder.AddState().Index;
             builder.Start.SetEndWeight(Weight.FromValue(StoppingProbability));
             builder.Start.AddTransition('a', Weight.FromValue(1 - StoppingProbability), builder.Start.Index);

--- a/test/Tests/Strings/StringAutomatonTests.cs
+++ b/test/Tests/Strings/StringAutomatonTests.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+using System.Collections;
+
 namespace Microsoft.ML.Probabilistic.Tests
 {
     using System;
@@ -27,14 +30,16 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void GetOutgoingTransitionsForDeterminization1()
         {
-            var wrapper = new StringAutomatonWrapper();
-            wrapper.Start.AddTransition(DiscreteChar.Uniform(), Weight.FromValue(2));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition(DiscreteChar.Uniform(), Weight.FromValue(2));
+
+            var wrapper = new StringAutomatonWrapper(builder);
             
             var outgoingTransitions =
                 wrapper.GetOutgoingTransitionsForDeterminization(new Dictionary<int, Weight> { { 0, Weight.FromValue(3) } });
             var expectedOutgoingTransitions = new[]
             {
-                new Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
                     DiscreteChar.Uniform(), Weight.FromValue(6), new Dictionary<int, Weight> { { 1, Weight.FromValue(1) } })
             };
 
@@ -49,17 +54,19 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void GetOutgoingTransitionsForDeterminization2()
         {
-            var wrapper = new StringAutomatonWrapper();
-            wrapper.Start.AddTransition(DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(2));
-            wrapper.Start.AddTransition(DiscreteChar.UniformInRanges('a', 'z', 'A', 'Z'), Weight.FromValue(3));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition(DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(2));
+            builder.Start.AddTransition(DiscreteChar.UniformInRanges('a', 'z', 'A', 'Z'), Weight.FromValue(3));
+
+            var wrapper = new StringAutomatonWrapper(builder);
             
             var outgoingTransitions =
                 wrapper.GetOutgoingTransitionsForDeterminization(new Dictionary<int, Weight> { { 0, Weight.FromValue(5) } });
             var expectedOutgoingTransitions = new[]
             {
-                new Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
                     DiscreteChar.UniformInRange('A', 'Z'), Weight.FromValue(7.5), new Dictionary<int, Weight> { { 2, Weight.FromValue(1) } }),
-                new Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
                     DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(17.5), new Dictionary<int, Weight> { { 1, Weight.FromValue(10 / 17.5) }, { 2, Weight.FromValue(7.5 / 17.5) } }),
             };
 
@@ -74,33 +81,36 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void GetOutgoingTransitionsForDeterminization3()
         {
-            var wrapper = new StringAutomatonWrapper();
-            wrapper.Start.AddTransition(DiscreteChar.UniformInRange('a', 'b'), Weight.FromValue(2));
-            wrapper.Start.AddTransition(DiscreteChar.UniformInRanges('b', 'd'), Weight.FromValue(3));
-            wrapper.Start.AddTransition(DiscreteChar.UniformInRanges('e', 'g'), Weight.FromValue(4));
-            wrapper.Start.AddTransition(DiscreteChar.UniformInRanges(char.MinValue, 'a'), Weight.FromValue(5));
+            var builder = StringAutomaton.Builder.Zero();
+
+            builder.Start.AddTransition(DiscreteChar.UniformInRange('a', 'b'), Weight.FromValue(2));
+            builder.Start.AddTransition(DiscreteChar.UniformInRanges('b', 'd'), Weight.FromValue(3));
+            builder.Start.AddTransition(DiscreteChar.UniformInRanges('e', 'g'), Weight.FromValue(4));
+            builder.Start.AddTransition(DiscreteChar.UniformInRanges(char.MinValue, 'a'), Weight.FromValue(5));
+
+            var wrapper = new StringAutomatonWrapper(builder);
 
             var outgoingTransitions =
                 wrapper.GetOutgoingTransitionsForDeterminization(new Dictionary<int, Weight> { { 0, Weight.FromValue(6) } });
             var expectedOutgoingTransitions = new[]
             {
-                new Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
                     DiscreteChar.UniformInRange(char.MinValue, (char)('a' - 1)),
                     Weight.FromValue(30.0 * 97.0 / 98.0),
                     new Dictionary<int, Weight> { { 4, Weight.FromValue(1) } }),
-                new Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
                     DiscreteChar.PointMass('a'),
                     Weight.FromValue((30.0 / 98.0) + 6.0),
                     new Dictionary<int, Weight> { { 1, Weight.FromValue(6.0 / ((30.0 / 98.0) + 6.0)) }, { 4, Weight.FromValue((30.0 / 98.0) / ((30.0 / 98.0) + 6.0)) } }),
-                new Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
                     DiscreteChar.PointMass('b'),
                     Weight.FromValue(12.0),
                     new Dictionary<int, Weight> { { 1, Weight.FromValue(0.5) }, { 2, Weight.FromValue(0.5)} }),
-                new Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
                     DiscreteChar.UniformInRange('c', 'd'),
                     Weight.FromValue(12.0),
                     new Dictionary<int, Weight> { { 2, Weight.FromValue(1.0) } }),
-                new Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
                     DiscreteChar.UniformInRange('e', 'g'),
                     Weight.FromValue(24.0),
                     new Dictionary<int, Weight> { { 3, Weight.FromValue(1.0) } }),
@@ -117,10 +127,12 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void GetOutgoingTransitionsForDeterminization4()
         {
-            var wrapper = new StringAutomatonWrapper();
-            wrapper.Start.AddTransition(DiscreteChar.UniformInRange(char.MinValue, char.MaxValue), Weight.FromValue(2));
-            wrapper.Start.AddTransition(DiscreteChar.UniformInRange('a', char.MaxValue), Weight.FromValue(3));
-            wrapper.Start.AddTransition(DiscreteChar.UniformInRanges('z', char.MaxValue), Weight.FromValue(4));
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition(DiscreteChar.UniformInRange(char.MinValue, char.MaxValue), Weight.FromValue(2));
+            builder.Start.AddTransition(DiscreteChar.UniformInRange('a', char.MaxValue), Weight.FromValue(3));
+            builder.Start.AddTransition(DiscreteChar.UniformInRanges('z', char.MaxValue), Weight.FromValue(4));
+
+            var wrapper = new StringAutomatonWrapper(builder);
             
             var outgoingTransitions =
                 wrapper.GetOutgoingTransitionsForDeterminization(new Dictionary<int, Weight> { { 0, Weight.FromValue(5) } });
@@ -133,11 +145,11 @@ namespace Microsoft.ML.Probabilistic.Tests
             double transition3Segment1Weight = 20.0;
             var expectedOutgoingTransitions = new[]
             {
-                new Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
                     DiscreteChar.UniformInRange(char.MinValue, (char)('a' - 1)),
                     Weight.FromValue(transition1Segment1Weight),
                     new Dictionary<int, Weight> { { 1, Weight.FromValue(1) } }),
-                new Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
                     DiscreteChar.UniformInRange('a', (char)('z' - 1)),
                     Weight.FromValue(transition1Segment2Weight + transition2Segment1Weight),
                     new Dictionary<int, Weight>
@@ -145,7 +157,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                             { 1, Weight.FromValue(transition1Segment2Weight / (transition1Segment2Weight + transition2Segment1Weight)) },
                             { 2, Weight.FromValue(transition2Segment1Weight / (transition1Segment2Weight + transition2Segment1Weight)) }
                         }),
-                new Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
                     DiscreteChar.UniformInRange('z', char.MaxValue),
                     Weight.FromValue(transition1Segment3Weight + transition2Segment2Weight + transition3Segment1Weight),
                     new Dictionary<int, Weight>
@@ -163,17 +175,18 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void GetOutgoingTrainsitionsForDeterminization5()
         {
-            var wrapper = new StringAutomatonWrapper();
+            var builder = StringAutomaton.Builder.Zero();
+            builder.Start.AddTransition('A', Weight.FromValue(2.49999999999995));
+            builder.Start.AddTransition('A', Weight.FromValue(4.49999999999959));
+            builder.Start.AddTransition('D', Weight.FromValue(2.49999999999996));
+            builder.Start.AddTransition('D', Weight.FromValue(4.49999999999966));
+            builder.Start.AddTransition('K', Weight.FromValue(5.00000001783332));
+            builder.Start.AddTransition('M', Weight.FromValue(2.49999999999996));
+            builder.Start.AddTransition('M', Weight.FromValue(2.49999999999991));
+            builder.Start.AddTransition('N', Weight.FromValue(2.49999999999996));
+            builder.Start.AddTransition('N', Weight.FromValue(2.49999999999994));
 
-            wrapper.Start.AddTransition('A', Weight.FromValue(2.49999999999995));
-            wrapper.Start.AddTransition('A', Weight.FromValue(4.49999999999959));
-            wrapper.Start.AddTransition('D', Weight.FromValue(2.49999999999996));
-            wrapper.Start.AddTransition('D', Weight.FromValue(4.49999999999966));
-            wrapper.Start.AddTransition('K', Weight.FromValue(5.00000001783332));
-            wrapper.Start.AddTransition('M', Weight.FromValue(2.49999999999996));
-            wrapper.Start.AddTransition('M', Weight.FromValue(2.49999999999991));
-            wrapper.Start.AddTransition('N', Weight.FromValue(2.49999999999996));
-            wrapper.Start.AddTransition('N', Weight.FromValue(2.49999999999994));
+            var wrapper = new StringAutomatonWrapper(builder);
 
             var outgoingTransitions = wrapper.GetOutgoingTransitionsForDeterminization(
                 new Dictionary<int, Weight> { { 0, Weight.FromValue(1) } }).ToArray();
@@ -285,7 +298,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         /// A comparer for transition information that allows for some tolerance when comparing weights.
         /// </summary>
         private class TransitionInfoEqualityComparer :
-            EqualityComparerBase<Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>, TransitionInfoEqualityComparer>
+            EqualityComparerBase<ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>, TransitionInfoEqualityComparer>
         {
             /// <summary>
             /// Checks whether two objects are equal.
@@ -297,8 +310,8 @@ namespace Microsoft.ML.Probabilistic.Tests
             /// <see langword="false"/> otherwise.
             /// </returns>
             public override bool Equals(
-                Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>> x,
-                Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>> y)
+                ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>> x,
+                ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>> y)
             {
                 return
                     object.Equals(x.Item1, y.Item1) &&
@@ -314,12 +327,9 @@ namespace Microsoft.ML.Probabilistic.Tests
         /// </summary>
         private class StringAutomatonWrapper : StringAutomaton
         {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="StringAutomatonWrapper"/> class.
-            /// </summary>
-            public StringAutomatonWrapper()
+            public StringAutomatonWrapper(StringAutomaton.Builder builder)
             {
-                this.SetToZero();
+                this.Data = builder.GetData();
             }
 
             /// <summary>
@@ -328,11 +338,11 @@ namespace Microsoft.ML.Probabilistic.Tests
             /// <param name="sourceState">The source state.</param>
             /// <returns>The produced transitions.</returns>
             /// <remarks>See the doc of the original method.</remarks>
-            public IEnumerable<Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>>
+            public IEnumerable<(DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>)>
                 GetOutgoingTransitionsForDeterminization(IEnumerable<KeyValuePair<int, Weight>> sourceState)
             {
                 var result = base.GetOutgoingTransitionsForDeterminization(new Determinization.WeightedStateSet(sourceState));
-                return result.Select(t => new Tuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(t.Item1, t.Item2, t.Item3));
+                return result.Select(t => (t.Item1, t.Item2, (IEnumerable<KeyValuePair<int, Weight>>)t.Item3));
             }
         }
 

--- a/test/Tests/Strings/StringAutomatonTests.cs
+++ b/test/Tests/Strings/StringAutomatonTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void GetOutgoingTransitionsForDeterminization1()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition(DiscreteChar.Uniform(), Weight.FromValue(2));
 
             var wrapper = new StringAutomatonWrapper(builder);
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void GetOutgoingTransitionsForDeterminization2()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition(DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(2));
             builder.Start.AddTransition(DiscreteChar.UniformInRanges('a', 'z', 'A', 'Z'), Weight.FromValue(3));
 
@@ -81,7 +81,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void GetOutgoingTransitionsForDeterminization3()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
 
             builder.Start.AddTransition(DiscreteChar.UniformInRange('a', 'b'), Weight.FromValue(2));
             builder.Start.AddTransition(DiscreteChar.UniformInRanges('b', 'd'), Weight.FromValue(3));
@@ -127,7 +127,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void GetOutgoingTransitionsForDeterminization4()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition(DiscreteChar.UniformInRange(char.MinValue, char.MaxValue), Weight.FromValue(2));
             builder.Start.AddTransition(DiscreteChar.UniformInRange('a', char.MaxValue), Weight.FromValue(3));
             builder.Start.AddTransition(DiscreteChar.UniformInRanges('z', char.MaxValue), Weight.FromValue(4));
@@ -175,7 +175,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Trait("Category", "StringInference")]
         public void GetOutgoingTrainsitionsForDeterminization5()
         {
-            var builder = StringAutomaton.Builder.Zero();
+            var builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('A', Weight.FromValue(2.49999999999995));
             builder.Start.AddTransition('A', Weight.FromValue(4.49999999999959));
             builder.Start.AddTransition('D', Weight.FromValue(2.49999999999996));

--- a/test/Tests/Strings/StringInferencePerformanceTests.cs
+++ b/test/Tests/Strings/StringInferencePerformanceTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             Assert.Timeout(() =>
             {
-                var builder = StringAutomaton.Builder.Zero();
+                var builder = new StringAutomaton.Builder();
                 var nextState = builder.Start.AddTransitionsForSequence("abc");
                 nextState.AddSelfTransition('d', Weight.FromValue(0.1));
                 nextState.AddTransitionsForSequence("efg").SetEndWeight(Weight.One);
@@ -57,7 +57,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             Assert.Timeout(() =>
             {
-                var builder = StringAutomaton.Builder.Zero();
+                var builder = new StringAutomaton.Builder();
                 var nextState = builder.Start.AddTransitionsForSequence("abc");
                 nextState.SetEndWeight(Weight.One);
                 nextState.AddSelfTransition('d', Weight.FromValue(0.1));
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             Assert.Timeout(() =>
             {
-                var builder = StringAutomaton.Builder.Zero();
+                var builder = new StringAutomaton.Builder();
                 builder.Start.AddSelfTransition('a', Weight.FromValue(0.5));
                 builder.Start.SetEndWeight(Weight.One);
                 var nextState = builder.Start.AddTransitionsForSequence("aa");

--- a/test/Tests/Strings/StringInferencePerformanceTests.cs
+++ b/test/Tests/Strings/StringInferencePerformanceTests.cs
@@ -35,11 +35,13 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             Assert.Timeout(() =>
             {
-                StringAutomaton automaton = StringAutomaton.Zero();
-                var nextState = automaton.Start.AddTransitionsForSequence("abc");
+                var builder = StringAutomaton.Builder.Zero();
+                var nextState = builder.Start.AddTransitionsForSequence("abc");
                 nextState.AddSelfTransition('d', Weight.FromValue(0.1));
                 nextState.AddTransitionsForSequence("efg").SetEndWeight(Weight.One);
                 nextState.AddTransitionsForSequence("hejfhoenmf").SetEndWeight(Weight.One);
+
+                var automaton = builder.GetAutomaton();
 
                 ProfileAction(() => automaton.GetLogNormalizer(), 100000);
             }, 10000);
@@ -55,8 +57,8 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             Assert.Timeout(() =>
             {
-                StringAutomaton automaton = StringAutomaton.Zero();
-                var nextState = automaton.Start.AddTransitionsForSequence("abc");
+                var builder = StringAutomaton.Builder.Zero();
+                var nextState = builder.Start.AddTransitionsForSequence("abc");
                 nextState.SetEndWeight(Weight.One);
                 nextState.AddSelfTransition('d', Weight.FromValue(0.1));
                 nextState = nextState.AddTransitionsForSequence("efg");
@@ -65,6 +67,8 @@ namespace Microsoft.ML.Probabilistic.Tests
                 nextState = nextState.AddTransitionsForSequence("grlkhgn;lk3rng");
                 nextState.SetEndWeight(Weight.One);
                 nextState.AddSelfTransition('h', Weight.FromValue(0.3));
+
+                var automaton = builder.GetAutomaton();
 
                 ProfileAction(() => automaton.GetLogNormalizer(), 100000);
             }, 20000);
@@ -80,13 +84,14 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             Assert.Timeout(() =>
             {
-                StringAutomaton automaton = StringAutomaton.Zero();
-                automaton.Start.AddSelfTransition('a', Weight.FromValue(0.5));
-                automaton.Start.SetEndWeight(Weight.One);
-                var nextState = automaton.Start.AddTransitionsForSequence("aa");
+                var builder = StringAutomaton.Builder.Zero();
+                builder.Start.AddSelfTransition('a', Weight.FromValue(0.5));
+                builder.Start.SetEndWeight(Weight.One);
+                var nextState = builder.Start.AddTransitionsForSequence("aa");
                 nextState.AddSelfTransition('a', Weight.FromValue(0.5));
                 nextState.SetEndWeight(Weight.One);
 
+                var automaton = builder.GetAutomaton();
                 for (int i = 0; i < 3; ++i)
                 {
                     automaton = automaton.Product(automaton);

--- a/test/Tests/Strings/TransducerTests.cs
+++ b/test/Tests/Strings/TransducerTests.cs
@@ -6,6 +6,9 @@ namespace Microsoft.ML.Probabilistic.Tests
 {
     using System;
     using System.Linq;
+
+    using Microsoft.ML.Probabilistic.Core.Collections;
+
     using Xunit;
     using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;
     using Microsoft.ML.Probabilistic.Distributions;
@@ -25,10 +28,12 @@ namespace Microsoft.ML.Probabilistic.Tests
         public void LargeTransducer()
         {
             StringAutomaton.MaxStateCount = 1200000; // Something big
-            StringAutomaton bigAutomaton = StringAutomaton.Zero();
-            bigAutomaton.AddStates(StringAutomaton.MaxStateCount - bigAutomaton.States.Count);
-            Func<DiscreteChar, Weight, Tuple<Option<PairDistribution<char, DiscreteChar>>, Weight>> transitionConverter =
-                (dist, weight) => Tuple.Create(Option.Some(PairDistribution<char, DiscreteChar>.FromFirstSecond(dist, dist)), weight);
+            var bigAutomatonBuilder = StringAutomaton.Builder.Zero();
+            bigAutomatonBuilder.AddStates(StringAutomaton.MaxStateCount - bigAutomatonBuilder.StatesCount);
+            Func<Option<DiscreteChar>, Weight, ValueTuple<Option<PairDistribution<char, DiscreteChar>>, Weight>> transitionConverter =
+                (dist, weight) => ValueTuple.Create(Option.Some(PairDistribution<char, DiscreteChar>.FromFirstSecond(dist, dist)), weight);
+
+            var bigAutomaton = bigAutomatonBuilder.GetAutomaton();
             
             Assert.Throws<AutomatonTooLargeException>(() => StringTransducer.FromAutomaton(bigAutomaton, transitionConverter));
 
@@ -514,8 +519,6 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             StringTransducer transducer = StringTransducer.Consume(StringAutomaton.Constant(3.0));
             StringTransducer transpose1 = StringTransducer.Transpose(transducer);
-            StringTransducer transpose2 = transducer.Clone();
-            transpose2.TransposeInPlace();
 
             var pairs = new[]
             {
@@ -529,11 +532,9 @@ namespace Microsoft.ML.Probabilistic.Tests
             {
                 double referenceValue1 = transducer.GetValue(valuePair[0], valuePair[1]);
                 Assert.Equal(referenceValue1, transpose1.GetValue(valuePair[1], valuePair[0]));
-                Assert.Equal(referenceValue1, transpose2.GetValue(valuePair[1], valuePair[0]));
 
                 double referenceValue2 = transducer.GetValue(valuePair[1], valuePair[0]);
                 Assert.Equal(referenceValue2, transpose1.GetValue(valuePair[0], valuePair[1]));
-                Assert.Equal(referenceValue2, transpose2.GetValue(valuePair[0], valuePair[1]));
             }
         }
     }

--- a/test/Tests/Strings/TransducerTests.cs
+++ b/test/Tests/Strings/TransducerTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         public void LargeTransducer()
         {
             StringAutomaton.MaxStateCount = 1200000; // Something big
-            var bigAutomatonBuilder = StringAutomaton.Builder.Zero();
+            var bigAutomatonBuilder = new StringAutomaton.Builder();
             bigAutomatonBuilder.AddStates(StringAutomaton.MaxStateCount - bigAutomatonBuilder.StatesCount);
             Func<Option<DiscreteChar>, Weight, ValueTuple<Option<PairDistribution<char, DiscreteChar>>, Weight>> transitionConverter =
                 (dist, weight) => ValueTuple.Create(Option.Some(PairDistribution<char, DiscreteChar>.FromFirstSecond(dist, dist)), weight);

--- a/test/Tests/Strings/TransducerTests.cs
+++ b/test/Tests/Strings/TransducerTests.cs
@@ -2,18 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Probabilistic.Collections;
+
 namespace Microsoft.ML.Probabilistic.Tests
 {
     using System;
     using System.Linq;
 
-    using Microsoft.ML.Probabilistic.Core.Collections;
-
     using Xunit;
     using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;
     using Microsoft.ML.Probabilistic.Distributions;
     using Microsoft.ML.Probabilistic.Distributions.Automata;
-    using Microsoft.ML.Probabilistic.Utilities;
 
     /// <summary>
     /// Tests for transducers.


### PR DESCRIPTION
To reduce memory pressure automaton data (states and transitions) was
converted from classess to structs and "vectorized" into just two large arrays.

Now, one state costs just 16 bytes and one transition costs 24 bytes.
Previously cost was at least twice of that, due to additional indirection,
object headers and pre-reservation of arrays capacity: 8 bytes pre reference
to state + 16 bytes per state header + 24 bytes per transitions array per state).
In practice memory consumption by automatons was reduced approximately
by the factor of 3.

Important changes:
  * `Automaton.StateData` is now a struct instead of class.
  * All transitions of automaton are stored in single array instead of
    "transition array per state"
  * Automatons can not be mutated. All immutable data was moved
    to new `DataContainer` struct.
  * New Automaton.Builder class was introduces for construction
    of new automatons from scratch. All mutation is done through
   "copy to builder, mutate, get immutable data" pattern.
  * Widely used `AppendInPlace()` method is not actually inplace anymore
    and became way more expensive. Multiple `AppendInPlace()` calls
    should be replaced with 1 `Automaton.Builder` instance with
    multiple `Builder.Append()` calls. Places which were hot in profiler were rewritten.
    `AppendInPlace()` will be removed completely in separate pull-request.

Technical changes:
  * `Optional<>` struct was moved into Containers namespace. Logically it is
     a container of "0-or-1" elements.
  * To enforce immutable data-structures new `ReadOnlyArray`, `ReadOnlyArraySegment`
    and `ReadOnlyArraySegment` enumerator structs were introduced. They wrap regular
    arrays but do not allow to mutate them. Unlike `ReadOnlyList<>` these are value types
    and do not introduce any memory-costs.
  * In quite a few places Tuples were replaced with ValueTuples.
  * Most recursive helper methods were "inlined" as local functions at their call-sites.
    Not strictly necessary, but mady refactoring a lot easier by bringing related code together.
  * Some code was reformated/updated to more modern style. Either by tooling or manually.