### PR TITLE
Added EnumerableExtensions.ValueEquals and removed Util.ValueEquals.

### DIFF
--- a/src/Compiler/TransformFramework/CodeModel/TypeDeclaration.cs
+++ b/src/Compiler/TransformFramework/CodeModel/TypeDeclaration.cs
@@ -60,7 +60,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.CodeModel.Concrete
 
             if (Name != type.Name ||
                 Namespace != type.Namespace ||
-                !Util.SafeEquals(BaseType, type.BaseType))
+                !Util.AreEqual(BaseType, type.BaseType))
                 return false;
             return true;
             if (Interface != type.Interface ||

--- a/src/Runtime/Core/Collections/CursorArray.cs
+++ b/src/Runtime/Core/Collections/CursorArray.cs
@@ -319,7 +319,7 @@ namespace Microsoft.ML.Probabilistic.Collections
 
         public bool IsCompatibleWith(ICursorArray that)
         {
-            return Util.ValueEquals(Lengths, that.Lengths);
+            return Lengths.ValueEquals(that.Lengths);
         }
 
         public void CheckCompatible(ICursorArray that)

--- a/src/Runtime/Core/Collections/Enumerable.cs
+++ b/src/Runtime/Core/Collections/Enumerable.cs
@@ -128,16 +128,22 @@ namespace Microsoft.ML.Probabilistic.Collections
             return true;
         }
 
+        public static bool JaggedValueEquals<T>(this IEnumerable<IEnumerable<T>> a, IEnumerable<IEnumerable<T>> b)
+        {
+            if (b == null) return false;
+            else return TrueForAll(a, b, AreEqual);
+        }
+
+        public static bool ValueEquals<T>(this IEnumerable<T> a, IEnumerable<T> b)
+        {
+            return AreEqual(a, b);
+        }
+
         public static bool AreEqual<T>(IEnumerable<T> a, IEnumerable<T> b)
         {
             if (a == null) return (b == null);
-            else return TrueForAll(a, b, ItemsAreEqual<T>);
-        }
-
-        private static bool ItemsAreEqual<T>(T a, T b)
-        {
-            if ((object) a == null) return ((object) b == null);
-            else return a.Equals(b);
+            else if (b == null) return false;
+            else return TrueForAll(a, b, Util.AreEqual);
         }
 
         public static bool AreEqual(IEnumerable a, IEnumerable b)
@@ -343,8 +349,10 @@ namespace Microsoft.ML.Probabilistic.Collections
 
         public static bool EqualLists(IList<T> x, IList<T> y)
         {
+            if (x == null) return y == null;
+            if (y == null) return false;
             if (x.Count != y.Count) return false;
-            for (int i = 0; i < x.Count; i++) if (!x[i].Equals(y[i])) return false;
+            for (int i = 0; i < x.Count; i++) if (!Util.AreEqual(x[i], y[i])) return false;
             return true;
         }
 

--- a/src/Runtime/Core/Collections/ParallelCursorArray.cs
+++ b/src/Runtime/Core/Collections/ParallelCursorArray.cs
@@ -179,7 +179,7 @@ namespace Microsoft.ML.Probabilistic.Collections
 
         public bool IsCompatibleWith(ICursorArray that)
         {
-            return Util.ValueEquals(Lengths, that.Lengths);
+            return Lengths.ValueEquals(that.Lengths);
         }
 
         protected void CheckMembers()

--- a/src/Runtime/Core/Collections/SortedSet.cs
+++ b/src/Runtime/Core/Collections/SortedSet.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Probabilistic.Collections
     /// The items are stored in the keys of a SortedList, which does the sorting
     /// via its own comparer function.
     /// </remarks>
-    public class SortedSet<T> : IList<T>, ICloneable
+    public class SortedSet<T> : IList<T>, IReadOnlyList<T>, ICloneable
     {
         protected struct EmptyStruct
         {
@@ -220,8 +220,7 @@ namespace Microsoft.ML.Probabilistic.Collections
         {
             SortedSet<T> thatSet = that as SortedSet<T>;
             if (thatSet == null) return false;
-            //if(Count != thatSet.Count) return false;
-            return Util.ValueEquals((ICollection<T>) this, (ICollection<T>) that);
+            return this.ValueEquals(thatSet);
         }
 
         public override int GetHashCode()

--- a/src/Runtime/Core/Utils/Util.cs
+++ b/src/Runtime/Core/Utils/Util.cs
@@ -39,65 +39,11 @@ namespace Microsoft.ML.Probabilistic.Utilities
             else return EqualityComparer<T>.Default;
         }
 
-        public static bool ValueEquals(IList<int> a, IList<int> b)
-        {
-            if (a == null) return (b == null);
-            if (b == null) return false;
-            if (a.Count != b.Count) return false;
-            for (int i = 0; i < a.Count; i++)
-            {
-                if (a[i] != b[i]) return false;
-            }
-            return true;
-        }
-
-        public static bool ValueEquals(IReadOnlyList<double> a, IReadOnlyList<double> b)
-        {
-            if (a == null) return (b == null);
-            if (b == null) return false;
-            if (a.Count != b.Count) return false;
-            for (int i = 0; i < a.Count; i++)
-            {
-                if (!a[i].Equals(b[i])) return false;
-            }
-            return true;
-        }
-
-        public static bool JaggedValueEquals(IReadOnlyList<IReadOnlyList<double>> a, IReadOnlyList<IReadOnlyList<double>> b)
-        {
-            if (a == null) return (b == null);
-            if (b == null) return false;
-            if (a.Count != b.Count) return false;
-            for (int i = 0; i < a.Count; i++)
-            {
-                if (!ValueEquals(a[i], b[i])) return false;
-            }
-            return true;
-        }
-
         // parameters may be null
-        public static bool SafeEquals<T>(T a, T b)
-        {
-            bool aIsNull = object.ReferenceEquals(a, null);
-            bool bIsNull = object.ReferenceEquals(b, null);
-            if (aIsNull) return bIsNull;
-            if (bIsNull) return false; // a is not null
-            return a.Equals(b);
-        }
-
-        public static bool ValueEquals<T>(ICollection<T> a, ICollection<T> b)
+        public static bool AreEqual<T>(T a, T b)
         {
             if (a == null) return (b == null);
-            if (b == null) return false;
-            if (a.Count != b.Count) return false;
-            if (a.Count == 0) return true;
-            IEnumerator<T> iter = a.GetEnumerator();
-            foreach (T item in b)
-            {
-                iter.MoveNext();
-                if (!SafeEquals<T>(iter.Current, item)) return false;
-            }
-            return true;
+            else return a.Equals(b);
         }
 
         public static string CollectionToString<T>(IEnumerable<T> list)

--- a/src/Runtime/Distributions/Automata/ListManipulator.cs
+++ b/src/Runtime/Distributions/Automata/ListManipulator.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="sequence1">The first list.</param>
         /// <param name="sequence2">The second list.</param>
         /// <returns><see langword="true"/> if the lists are equal, <see langword="false"/> otherwise.</returns>
-        public bool SequencesAreEqual(TList sequence1, TList sequence2) => Util.ValueEquals(sequence1, sequence2);
+        public bool SequencesAreEqual(TList sequence1, TList sequence2) => ListComparer<TElement>.EqualLists(sequence1, sequence2);
 
         /// <summary>
         /// Creates a list by copying the first list and then appending the second list to it.

--- a/src/Runtime/Distributions/QuantileEstimator.cs
+++ b/src/Runtime/Distributions/QuantileEstimator.cs
@@ -10,6 +10,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
     using System.Linq;
     using System.Runtime.Serialization;
     using System.Text;
+    using Microsoft.ML.Probabilistic.Collections;
     using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Utilities;
 
@@ -326,8 +327,8 @@ namespace Microsoft.ML.Probabilistic.Distributions
         public bool ValueEquals(QuantileEstimator that)
         {
             return (this.MaximumError == that.MaximumError) &&
-                Util.JaggedValueEquals(this.buffers, that.buffers) &&
-                Util.ValueEquals(this.countInBuffer, that.countInBuffer) &&
+                this.buffers.JaggedValueEquals(that.buffers) &&
+                this.countInBuffer.ValueEquals(that.countInBuffer) &&
                 (this.lowestBufferIndex == that.lowestBufferIndex) &&
                 (this.lowestBufferHeight == that.lowestBufferHeight) &&
                 (this.nextSample == that.nextSample) &&

--- a/src/Runtime/Distributions/QuantileEstimator.cs
+++ b/src/Runtime/Distributions/QuantileEstimator.cs
@@ -121,6 +121,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <returns></returns>
         public double GetQuantile(double probability)
         {
+            if (double.IsNaN(probability)) throw new ArgumentOutOfRangeException(nameof(probability), "probability is NaN");
             if (probability < 0) throw new ArgumentOutOfRangeException(nameof(probability), "probability < 0");
             if (probability > 1.0) throw new ArgumentOutOfRangeException(nameof(probability), "probability > 1.0");
             // compute the min and max of the retained items
@@ -165,6 +166,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                         if (probability < probabilityLessThanOrEqualUpperItem) return upperItem;
                         lowerBound = MMath.NextDouble(upperItem);
                     }
+                    if (lowerBound > upperBound) throw new Exception("lowerBound > upperBound");
                 }
                 else if (InterpolationType == 1)
                 {
@@ -179,8 +181,8 @@ namespace Microsoft.ML.Probabilistic.Distributions
                         return lowerItem;
                     // probability of upperItem ranges from (lowerRank + 0.5) / itemCount
                     // to (lowerRank + upperWeight - 0.5) / itemCount
-                    if (scaledProbability == lowerRank+0.5) return upperItem;
-                    if ((scaledProbability > lowerRank+0.5) && (scaledProbability < lowerRank + upperWeight - 0.5))
+                    if (scaledProbability == lowerRank + 0.5) return upperItem;
+                    if ((scaledProbability > lowerRank + 0.5) && (scaledProbability < lowerRank + upperWeight - 0.5))
                         return upperItem;
                     double frac = scaledProbability - (lowerRank - 0.5);
                     if (frac < 0)
@@ -193,7 +195,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                     }
                     else
                     {
-                        return OuterQuantiles.GetQuantile(probability, lowerRank - 0.5, lowerItem, upperItem, itemCount+1);
+                        return OuterQuantiles.GetQuantile(probability, lowerRank - 0.5, lowerItem, upperItem, itemCount + 1);
                     }
                 }
                 else

--- a/src/Runtime/Distributions/QuantileEstimator.cs
+++ b/src/Runtime/Distributions/QuantileEstimator.cs
@@ -288,6 +288,16 @@ namespace Microsoft.ML.Probabilistic.Distributions
             reservoirCount /= 2;
         }
 
+        /// <summary>
+        /// Multiply all sample weights by 2.
+        /// </summary>
+        public void Inflate()
+        {
+            if (lowestBufferHeight >= 30) throw new InvalidOperationException($"Cannot inflate when lowestBufferHeight = {lowestBufferHeight}");
+            lowestBufferHeight++;
+            reservoirCount *= 2;
+        }
+
         public override string ToString()
         {
             return $"QuantileEstimator({MaximumError}, lowestBufferHeight = {lowestBufferHeight}, buffer sizes = {StringUtil.CollectionToString(countInBuffer, ",")})";

--- a/test/Tests/QuantileTests.cs
+++ b/test/Tests/QuantileTests.cs
@@ -140,6 +140,33 @@ namespace Microsoft.ML.Probabilistic.Tests
         }
 
         [Fact]
+        public void QuantileEstimatorInflationTest()
+        {
+            double maximumError = 0.05;
+            int n = 1000;
+            // g1 has weight 2/3, g2 has weight 1/3
+            Gaussian g1 = new Gaussian(2, 3);
+            Gaussian g2 = new Gaussian(5, 1);
+            var est = new QuantileEstimator(maximumError);
+            List<double> x = new List<double>();
+            for (int i = 0; i < n; i++)
+            {
+                double sample = g1.Sample();
+                x.Add(sample);
+                x.Add(sample);
+                est.Add(sample);
+            }
+            est.Inflate();
+            for (int i = 0; i < n; i++)
+            {
+                double sample = g2.Sample();
+                x.Add(sample);
+                est.Add(sample);
+            }
+            CheckProbLessThan(est, x, maximumError);
+        }
+
+        [Fact]
         public void QuantileEstimatorMergingTest()
         {
             double maximumError = 0.05;

--- a/test/Tests/VmpTests.cs
+++ b/test/Tests/VmpTests.cs
@@ -2039,7 +2039,8 @@ namespace Microsoft.ML.Probabilistic.Tests
 
             var alg = new VariationalMessagePassing();
             var engine = new InferenceEngine(alg);
-            Assert.Throws<ArgumentException>(() => engine.Infer(mean));
+            var exception = Record.Exception(() => engine.Infer(mean));
+            Assert.NotNull(exception);
         }
 
         [Fact]


### PR DESCRIPTION
Renamed Util.SafeEquals to AreEqual.
VectorSoftmax_PointSoftmax_Throws allows any exception type.
QuantileEstimator uses less memory.
Added QuantileEstimator.Inflate.
QuantileEstimator.GetQuantile checks for probability is NaN.