### PR TITLE
Solve numerical issues in StringFormatOp

### DIFF
--- a/src/Runtime/Factors/StringFormatOp.cs
+++ b/src/Runtime/Factors/StringFormatOp.cs
@@ -502,6 +502,7 @@ namespace Microsoft.ML.Probabilistic.Factors
             {
                 StringAutomaton validatingAutomaton = GetArgumentValidatingAutomaton(i, argNames);
                 result.SetToProduct(i == 0 ? format : result, validatingAutomaton);
+                result.SetToConstantOnSupportOfLog(0.0, result);
             }
 
             return result;


### PR DESCRIPTION
Too many arguments in StringFormatOp.GetValidatedFormat string cause multiple successive products, which can lead to numerical problems.