### PR TITLE
Turn Automaton.UsesGroups into property & optimize SetGroups()

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -382,6 +382,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 }
 
                 var hasEpsilonTransitions = false;
+                var usesGroups = false;
                 var resultStates = new StateData[this.states.Count];
                 var resultTransitions = new Transition[this.transitions.Count - this.numRemovedTransitions];
                 var nextResultTransitionIndex = 0;
@@ -401,6 +402,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         resultTransitions[nextResultTransitionIndex] = transition;
                         ++nextResultTransitionIndex;
                         hasEpsilonTransitions = hasEpsilonTransitions || transition.IsEpsilon;
+                        usesGroups = usesGroups || (transition.Group != 0);
 
                         transitionIndex = node.Next;
                     }
@@ -413,7 +415,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     nextResultTransitionIndex == resultTransitions.Length,
                     "number of copied transitions must match result array size");
 
-                return new DataContainer(this.StartStateIndex, !hasEpsilonTransitions, resultStates, resultTransitions);
+                return new DataContainer(this.StartStateIndex, !hasEpsilonTransitions, usesGroups, resultStates, resultTransitions);
             }
 
             #endregion

--- a/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
@@ -20,15 +20,15 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public struct DataContainer : ISerializable
         {
             /// <summary>
+            /// Stores
+            /// </summary>
+            private readonly Flags flags;
+
+            /// <summary>
             /// Index of start state of automaton.
             /// </summary>
             public readonly int StartStateIndex;
-
-            /// <summary>
-            /// Value indicating whether this automaton is epsilon-free.
-            /// </summary>
-            public readonly bool IsEpsilonFree;
-
+            
             /// <summary>
             /// All automaton states.
             /// </summary>
@@ -41,17 +41,30 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             public readonly ReadOnlyArray<Transition> Transitions;
 
             /// <summary>
+            /// Gets value indicating whether this automaton is epsilon-free.
+            /// </summary>
+            public bool IsEpsilonFree => (this.flags & Flags.IsEpsilonFree) != 0;
+
+            /// <summary>
+            /// Get value indicating whether this automaton uses groups.
+            /// </summary>
+            public bool UsesGroups => (this.flags & Flags.UsesGroups) != 0;
+
+            /// <summary>
             /// Initializes instance of <see cref="DataContainer"/>.
             /// </summary>
-            [Construction("StartStateIndex", "IsEpsilonFree", "States", "Transitions")]
+            [Construction("StartStateIndex", "IsEpsilonFree", "UsesGroups", "States", "Transitions")]
             public DataContainer(
                 int startStateIndex,
                 bool isEpsilonFree,
+                bool usesGroups,
                 ReadOnlyArray<StateData> states,
                 ReadOnlyArray<Transition> transitions)
             {
+                this.flags =
+                    (isEpsilonFree ? Flags.IsEpsilonFree : 0) |
+                    (usesGroups ? Flags.UsesGroups : 0);
                 this.StartStateIndex = startStateIndex;
-                this.IsEpsilonFree = isEpsilonFree;
                 this.States = states;
                 this.Transitions = transitions;
             }
@@ -102,8 +115,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// </summary>
             internal DataContainer(SerializationInfo info, StreamingContext context)
             {
+                this.flags = (Flags)info.GetValue(nameof(this.flags), typeof(Flags));
                 this.StartStateIndex = (int)info.GetValue(nameof(this.StartStateIndex), typeof(int));
-                this.IsEpsilonFree = (bool)info.GetValue(nameof(this.IsEpsilonFree), typeof(bool));
                 this.States = (StateData[])info.GetValue(nameof(this.States), typeof(StateData[]));
                 this.Transitions = (Transition[])info.GetValue(nameof(this.Transitions), typeof(Transition[]));
 
@@ -119,10 +132,17 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 info.AddValue(nameof(this.States), this.States.CloneArray());
                 info.AddValue(nameof(this.Transitions), this.Transitions.CloneArray());
                 info.AddValue(nameof(this.StartStateIndex), this.StartStateIndex);
-                info.AddValue(nameof(this.IsEpsilonFree), this.IsEpsilonFree);
+                info.AddValue(nameof(this.flags), this.flags);
             }
 
             #endregion
+
+            [Flags]
+            private enum Flags
+            {
+                IsEpsilonFree = 0x1,
+                UsesGroups = 0x2,
+            }
         }
     }
 }

--- a/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
             this.MakeEpsilonFree(); // Deterministic automata cannot have epsilon-transitions
 
-            if (this.UsesGroups())
+            if (this.UsesGroups)
             {
                 // Determinization will result in lost of group information, which we cannot allow
                 return false;

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -825,6 +825,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="group">The specified group.</param>
         public void SetGroup(int group)
         {
+            if (group == 0 && !this.UsesGroups)
+            {
+                return;
+            }
+
             var builder = Builder.FromAutomaton(this);
             for (var i = 0; i < builder.StatesCount; ++i)
             {

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -809,27 +809,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             return false;
         }
 
-        /// <summary>
-        /// Determines whether this automaton has groups.
-        /// </summary>
-        /// <returns>True if it the automaton has groups, false otherwise.</returns>
-        public bool UsesGroups()
-        {
-            for (int stateIndex = 0; stateIndex < this.States.Count; stateIndex++)
-            {
-                var state = this.States[stateIndex];
-                foreach (var transition in state.Transitions)
-                {
-                    if (transition.Group != 0)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
         public Dictionary<int, TThis> GetGroups() => GroupExtractor.ExtractGroups(this);
 
         /// <summary>
@@ -1235,7 +1214,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 return;
             }
 
-            if (automaton1.UsesGroups())
+            if (automaton1.UsesGroups)
             {
                 // We cannot swap automaton 1 and automaton 2 as groups from first are used.
                 if (!automaton2.IsEpsilonFree)
@@ -1517,7 +1496,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </summary>
         public void SetToZero()
         {
-            this.Data = new DataContainer(0, true, ZeroStates, ZeroTransitions);
+            this.Data = new DataContainer(0, true, false, ZeroStates, ZeroTransitions);
         }
 
         /// <summary>
@@ -1858,6 +1837,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// Gets a value indicating whether this automaton is epsilon-free.
         /// </summary>
         public bool IsEpsilonFree => this.Data.IsEpsilonFree;
+
+        /// <summary>
+        /// Determines whether this automaton has groups.
+        /// </summary>
+        /// <value>True if it the automaton has groups, false otherwise.</value>
+        public bool UsesGroups => this.Data.UsesGroups;
 
         /// <summary>
         /// Tests whether the automaton is deterministic,

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -1815,7 +1815,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 return false;
             }
 
-            return this.sequenceToWeight.UsesGroups();
+            return this.sequenceToWeight.UsesGroups;
         }
 
         /// <summary>

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -802,6 +802,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 new StringAutomaton.DataContainer(
                     0,
                     true,
+                    false,
                     new[]
                         {
                             new StringAutomaton.StateData(0, 1, Weight.One),
@@ -817,6 +818,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 new StringAutomaton.DataContainer(
                     0,
                     true,
+                    false,
                     new[] { new StringAutomaton.StateData(0, 0, Weight.Zero) },
                     Array.Empty<StringAutomaton.Transition>()));
             Assert.True(automaton2.IsZero());
@@ -827,6 +829,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                     new StringAutomaton.DataContainer(
                         0,
                         true,
+                        false,
                         Array.Empty<StringAutomaton.StateData>(),
                         Array.Empty<StringAutomaton.Transition>())));
 
@@ -835,6 +838,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 () => StringAutomaton.FromData(
                     new StringAutomaton.DataContainer(
                         0,
+                        false,
                         false,
                         new[] { new StringAutomaton.StateData(0, 0, Weight.Zero) },
                         Array.Empty<StringAutomaton.Transition>())));
@@ -845,6 +849,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                     new StringAutomaton.DataContainer(
                         0,
                         false,
+                        false,
                         new[] { new StringAutomaton.StateData(0, 1, Weight.Zero) },
                         new[] { new StringAutomaton.Transition(Option.None, Weight.One, 1) })));
 
@@ -854,6 +859,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                     new StringAutomaton.DataContainer(
                         0,
                         true,
+                        false,
                         new[] { new StringAutomaton.StateData(0, 1, Weight.One) },
                         new[] { new StringAutomaton.Transition(Option.None, Weight.One, 2) })));
         }

--- a/test/Tests/Strings/SequenceDistributionTests.cs
+++ b/test/Tests/Strings/SequenceDistributionTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             StringDistribution lhs = StringDistribution.FromWeightFunction(weightFunctionBuilder.GetAutomaton());
             StringDistribution rhs = StringDistribution.OneOf("ab", "ac");
             Assert.True(lhs.GetWorkspaceOrPoint().HasGroup(1));
-            Assert.False(rhs.GetWorkspaceOrPoint().UsesGroups());
+            Assert.False(rhs.GetWorkspaceOrPoint().UsesGroups);
             var result = StringDistribution.Zero();
             result.SetToProduct(lhs, rhs);
             Assert.True(result.GetWorkspaceOrPoint().HasGroup(1));


### PR DESCRIPTION
* `UsesGroups` can be precalculated almost for free during automaton construction time
* `SetGroups()` doesn't need to rebuild automaton if requested group = 0 and groups are not used already