### PR TITLE
Make GetValidatedFormatString() work with automatons with groups

### DIFF
--- a/src/Runtime/Factors/StringFormatOp.cs
+++ b/src/Runtime/Factors/StringFormatOp.cs
@@ -502,6 +502,7 @@ namespace Microsoft.ML.Probabilistic.Factors
             {
                 StringAutomaton validatingAutomaton = GetArgumentValidatingAutomaton(i, argNames);
                 result.SetToProduct(i == 0 ? format : result, validatingAutomaton);
+                result.ClearGroups();
                 result.SetToConstantOnSupportOfLog(0.0, result);
             }
 


### PR DESCRIPTION
SetToConstantOnSupportOfLog() fails on automatons with groups,
but validatedFormat doesn't need them anyway