### PR TITLE
Get rid of recursive implementations

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -214,14 +214,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     }
                 }
 
-                this.StartStateIndex = oldToNewStateIdMapping[this.StartStateIndex];
-                if (this.StartStateIndex == -1)
+                if (deadStateCount == 0)
                 {
-                    // Cannot reach any end state from the start state => the automaton is zero everywhere
-                    this.Clear();
-                    this.AddState();
-                    return deadStateCount;
+                    return 0;
                 }
+
+                // may invalidate automaton
+                this.StartStateIndex = oldToNewStateIdMapping[this.StartStateIndex];
 
                 for (var i = 0; i < this.states.Count; ++i)
                 {

--- a/src/Runtime/Distributions/Automata/Automaton.Condensation.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Condensation.cs
@@ -215,7 +215,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
                 while (traversalStack.Count > 0)
                 {
-                    restart:
                     var (current, currentTransitionIndex) = traversalStack.Pop();
                     var currentState = states[current];
 
@@ -253,7 +252,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                                 // traverse destination
                                 traversalStack.Push((destination, -1));
                                 // Processing of this state will effectively be resumed after destination is processed
-                                goto restart;
+                                break;
                             }
                             
                             if (info[destination].InStack)
@@ -262,6 +261,14 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                                     Math.Min(info[current].Lowlink, info[destination].TraversalIndex);
                             }
                         }
+                    }
+
+                    // We can break from for-loop above before end condition is met only if we pushed some
+                    // work to do onto traversal stack. One of the things pushed to stack will effectively
+                    // resume the loop from the currentTransitionIndex.
+                    if (currentTransitionIndex < currentState.Transitions.Count)
+                    {
+                        continue;
                     }
 
                     if (info[current].Lowlink == info[current].TraversalIndex)

--- a/src/Runtime/Distributions/Automata/Automaton.Condensation.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Condensation.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.ML.Probabilistic.Collections;
+
 namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
     using System;
@@ -108,12 +110,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 this.useApproximateClosure = useApproximateClosure;
 
                 this.components = new List<StronglyConnectedComponent>();
-                var stateIdStack = new Stack<State>();
-                var stateIdToTarjanInfo = new Dictionary<int, TarjanStateInfo>();
-                int traversalIndex = 0;
-                this.FindStronglyConnectedComponents(this.Root, ref traversalIndex, stateIdToTarjanInfo, stateIdStack);
+                this.FindStronglyConnectedComponents();
 
-                this.stateIdToInfo = new Dictionary<int, CondensationStateInfo>(stateIdToTarjanInfo.Count);
+                this.stateIdToInfo = new Dictionary<int, CondensationStateInfo>();
                 for (int i = 0; i < this.components.Count; ++i)
                 {
                     StronglyConnectedComponent component = this.components[i];
@@ -194,57 +193,92 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// Implements <a href="http://en.wikipedia.org/wiki/Tarjan's_strongly_connected_components_algorithm">Tarjan's algorithm</a>
             /// for finding the strongly connected components of the automaton graph.
             /// </summary>
-            /// <param name="currentState">The state currently being traversed.</param>
-            /// <param name="traversalIndex">The traversal index (as defined by the Tarjan's algorithm).</param>
-            /// <param name="stateIdToStateInfo">A dictionary mapping state indices to info records maintained by the Tarjan's algorithm.</param>
-            /// <param name="stateIdStack">The traversal stack (as defined by the Tarjan's algorithm).</param>
-            private void FindStronglyConnectedComponents(
-                State currentState,
-                ref int traversalIndex,
-                Dictionary<int, TarjanStateInfo> stateIdToStateInfo,
-                Stack<State> stateIdStack)
+            /// <remarks>
+            /// This implementation closely follows algorithm from wikipedia. But is rewritten to use explicit
+            /// traversal stack instead of recursion.
+            ///
+            /// Basic idea is each time we need to do a recursive call we save all needed state into traversal
+            /// stack, and push this "continuation" onto the stack. All state that need to be preserved are:
+            ///   - currentStateIndex - state being processed
+            ///   - currentTransitionIndex - index of the transition which was recursed last.
+            ///     If it is -1, that means that state was not processed yet at all.
+            /// </remarks>
+            private void FindStronglyConnectedComponents()
             {
-                Debug.Assert(!stateIdToStateInfo.ContainsKey(currentState.Index), "Visited states must not be revisited.");
+                var states = this.Root.Owner.States;
+                var traversalIndex = 0;
+                var stateIdStack = new Stack<int>(); // Stack that maintains Tarjan algorithm invariant
+                var info = new TarjanStateInfo[this.Root.Owner.States.Count];
+                var traversalStack = new Stack<(int currentStateIndex, int lastDestination)>();
 
-                var stateInfo = new TarjanStateInfo(traversalIndex);
-                stateIdToStateInfo.Add(currentState.Index, stateInfo);
-                ++traversalIndex;
+                traversalStack.Push((this.Root.Index, -1));
 
-                stateIdStack.Push(currentState);
-                stateInfo.InStack = true;
-
-                foreach (var transition in currentState.Transitions)
+                while (traversalStack.Count > 0)
                 {
-                    if (!this.transitionFilter(transition))
+                    restart:
+                    var (current, currentTransitionIndex) = traversalStack.Pop();
+                    var currentState = states[current];
+
+                    if (currentTransitionIndex < 0)
                     {
-                        continue;
+                        // Just entered
+                        Debug.Assert(!info[current].Visited);
+                        info[current].Visited = true;
+                        info[current].TraversalIndex = traversalIndex;
+                        info[current].Lowlink = traversalIndex;
+                        info[current].InStack = true;
+                        stateIdStack.Push(current);
+                        ++traversalIndex;
+                        currentTransitionIndex = 0;
+                    }
+                    else
+                    {
+                        // we already traversed some state, and its index is in enumerator
+                        var lastTraversed = currentState.Transitions[currentTransitionIndex].DestinationStateIndex;
+                        info[current].Lowlink = Math.Min(info[current].Lowlink, info[lastTraversed].Lowlink);
+                        ++currentTransitionIndex;
                     }
 
-                    if (!stateIdToStateInfo.TryGetValue(transition.DestinationStateIndex, out TarjanStateInfo destinationStateInfo))
+                    // Continue processing 
+                    for (; currentTransitionIndex < currentState.Transitions.Count; ++currentTransitionIndex)
                     {
-                        this.FindStronglyConnectedComponents(
-                            this.Root.Owner.States[transition.DestinationStateIndex], ref traversalIndex, stateIdToStateInfo, stateIdStack);
-                        stateInfo.Lowlink = Math.Min(stateInfo.Lowlink, stateIdToStateInfo[transition.DestinationStateIndex].Lowlink);
+                        var transition = currentState.Transitions[currentTransitionIndex];
+                        if (transitionFilter(transition))
+                        {
+                            var destination = transition.DestinationStateIndex;
+                            if (!info[destination].Visited)
+                            {
+                                // return to this state after destination is traversed
+                                traversalStack.Push((current, currentTransitionIndex));
+                                // traverse destination
+                                traversalStack.Push((destination, -1));
+                                // Processing of this state will effectively be resumed after destination is processed
+                                goto restart;
+                            }
+                            
+                            if (info[destination].InStack)
+                            {
+                                info[current].Lowlink =
+                                    Math.Min(info[current].Lowlink, info[destination].TraversalIndex);
+                            }
+                        }
                     }
-                    else if (destinationStateInfo.InStack)
-                    {
-                        stateInfo.Lowlink = Math.Min(stateInfo.Lowlink, destinationStateInfo.TraversalIndex);
-                    }
-                }
 
-                if (stateInfo.Lowlink == stateInfo.TraversalIndex)
-                {
-                    var statesInComponent = new List<State>();
-                    State state;
-                    do
+                    if (info[current].Lowlink == info[current].TraversalIndex)
                     {
-                        state = stateIdStack.Pop();
-                        stateIdToStateInfo[state.Index].InStack = false;
-                        statesInComponent.Add(state);
-                    }
-                    while (state.Index != currentState.Index);
+                        var statesInComponent = new List<State>();
+                        State state;
+                        do
+                        {
+                            state = states[stateIdStack.Pop()];
+                            info[state.Index].InStack = false;
+                            statesInComponent.Add(state);
+                        } while (state.Index != current);
 
-                    this.components.Add(new StronglyConnectedComponent(this.transitionFilter, statesInComponent, this.useApproximateClosure));
+                        this.components.Add(
+                            new StronglyConnectedComponent(
+                                this.transitionFilter, statesInComponent, this.useApproximateClosure));
+                    }
                 }
             }
 
@@ -407,17 +441,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// Stores the information maintained by the Tarjan's algorithm.
             /// </summary>
-            private class TarjanStateInfo
+            private struct TarjanStateInfo
             {
                 /// <summary>
-                /// Initializes a new instance of the <see cref="TarjanStateInfo"/> class.
+                /// Gets or sets value indicating whether this node has already been visited
                 /// </summary>
-                /// <param name="traversalIndex">The current traversal index.</param>
-                public TarjanStateInfo(int traversalIndex)
-                {
-                    this.TraversalIndex = traversalIndex;
-                    this.Lowlink = traversalIndex;
-                }
+                public bool Visited { get; set; }
 
                 /// <summary>
                 /// Gets or sets a value indicating whether the state is currently in stack.
@@ -427,7 +456,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 /// <summary>
                 /// Gets the traversal index of the state.
                 /// </summary>
-                public int TraversalIndex { get; private set; }
+                public int TraversalIndex { get; set; }
 
                 /// <summary>
                 /// Gets or sets the lowlink of the state.

--- a/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
@@ -123,11 +123,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 }
             }
 
-            var simplification = new Simplification(builder, this.PruneTransitionsWithLogWeightLessThan);
+            var simplification = new Simplification(builder, this.PruneStatesWithLogEndWeightLessThan);
             simplification.MergeParallelTransitions(); // Determinization produces a separate transition for each segment
 
             var result = builder.GetAutomaton();
-            result.PruneTransitionsWithLogWeightLessThan = this.PruneTransitionsWithLogWeightLessThan;
+            result.PruneStatesWithLogEndWeightLessThan = this.PruneStatesWithLogEndWeightLessThan;
             result.LogValueOverride = this.LogValueOverride;
             this.SwapWith(result);
 

--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -165,23 +165,26 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         for (; iterator2.Ok; iterator2.Next())
                         {
                             var transition2 = iterator2.Value;
-                            if (transition1.DestinationStateIndex == transition2.DestinationStateIndex &&
-                                transition1.Group == transition2.Group)
+                            var mergedTransition = TryMergeTransitions(transition1, transition2);
+                            if (mergedTransition != null)
                             {
-                                var mergedTransition = TryMergeTransitions(transition1, transition2);
-                                if (mergedTransition != null)
-                                {
-                                    iterator1.Value = mergedTransition.Value;
-                                    transition1 = mergedTransition.Value;
-                                    iterator2.Remove();
-                                }
+                                iterator1.Value = mergedTransition.Value;
+                                transition1 = mergedTransition.Value;
+                                iterator2.Remove();
                             }
+
                         }
                     }
                 }
 
                 Transition? TryMergeTransitions(Transition transition1, Transition transition2)
                 {
+                    if (transition1.DestinationStateIndex != transition2.DestinationStateIndex ||
+                        transition1.Group != transition2.Group)
+                    {
+                        return null;
+                    }
+
                     if (transition1.IsEpsilon && transition2.IsEpsilon)
                     {
                         transition1.Weight = Weight.Sum(transition1.Weight, transition2.Weight);

--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -2,17 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.ML.Probabilistic.Collections;
 
 namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Linq;
-    using System.Text;
 
     using Microsoft.ML.Probabilistic.Collections;
-    using Microsoft.ML.Probabilistic.Utilities;
+
 
     /// <content>
     /// Contains classes and methods for automata simplification.
@@ -25,7 +23,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public bool Simplify()
         {
             var builder = Builder.FromAutomaton(this);
-            var simplification = new Simplification(builder, this.PruneTransitionsWithLogWeightLessThan);
+            var simplification = new Simplification(builder, this.PruneStatesWithLogEndWeightLessThan);
             if (simplification.Simplify())
             {
                 this.Data = builder.GetData();
@@ -41,8 +39,10 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public bool RemoveDeadStates()
         {
             var builder = Builder.FromAutomaton(this);
-            var simplification = new Simplification(builder, this.PruneTransitionsWithLogWeightLessThan);
-            if (simplification.RemoveDeadStates())
+            var initialStatesCount = builder.StatesCount;
+            var simplification = new Simplification(builder, this.PruneStatesWithLogEndWeightLessThan);
+            simplification.RemoveDeadStates();
+            if (builder.StatesCount != initialStatesCount)
             {
                 this.Data = builder.GetData();
                 return true;
@@ -66,15 +66,15 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// If non-null, any transition whose weight falls below this value in a normalized
             /// automaton will be removed.
             /// </summary>
-            private readonly double? pruneTransitionsWithLogWeightLessThan;
+            private readonly double? pruneStatesWithLogEndWeightLessThan;
 
             /// <summary>
             /// Initializes new instance of <see cref="Simplification"/> class.
             /// </summary>
-            public Simplification(Builder builder, double? pruneTransitionsWithLogWeightLessThan)
+            public Simplification(Builder builder, double? pruneStatesWithLogEndWeightLessThan)
             {
                 this.builder = builder;
-                this.pruneTransitionsWithLogWeightLessThan = pruneTransitionsWithLogWeightLessThan;
+                this.pruneStatesWithLogEndWeightLessThan = pruneStatesWithLogEndWeightLessThan;
             }
 
             /// <summary>
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             public bool SimplifyIfNeeded()
             {
                 if (this.builder.StatesCount > MaxStateCountBeforeSimplification ||
-                    this.pruneTransitionsWithLogWeightLessThan != null)
+                    this.pruneStatesWithLogEndWeightLessThan != null)
                 {
                     return this.Simplify();
                 }
@@ -96,60 +96,307 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// Attempts to simplify the structure of the automaton, reducing the number of states and transitions.
             /// </summary>
             /// <remarks>
-            /// <para>
+            /// Only generalized tree part of automaton is simplified. Generalized tree is a tree with self-loops
+            /// allowed. Any non-trivial loops (consisting of more than 1 state) are left untouched.
+            /// 
             /// The simplification procedure works as follows:
-            /// <list type="number">
-            /// <item><description>
-            /// If a pair of states has more than one transition between them, the transitions get merged.
-            /// </description></item>
-            /// <item><description>
-            /// A part of the automaton that is a tree is found.
-            /// </description></item>
-            /// <item><description>
-            /// States and transitions that don't belong to the found tree part are simply copied to the result.
-            /// </description></item>
-            /// <item><description>
-            /// The found tree part is rebuild from scratch. The new tree is essentially a trie:
-            /// for example, if the original tree has two paths accepting <c>"abc"</c> and one path accepting <c>"ab"</c>,
-            /// the resulting tree has a single path accepting both <c>"ab"</c> and <c>"abc"</c>.
-            /// </description></item>
-            /// </list>
-            /// </para>
-            /// <para>The simplification procedure doesn't support automata with non-trivial loops.</para>
+            ///   * If a pair of states has more than one transition between them, the transitions get merged.
+            ///   * A part of the automaton that is a tree is found.
+            ///     For example in this automaton:
+            ///       a--->b--->c--->d---\
+            ///       v              ^   |
+            ///       e--->f--->g     \--/
+            ///       |          
+            ///       v
+            ///       h--->i--->j-->k
+            ///            ^    |
+            ///             \--/
+            ///     Nodes "a" to "h" form the tree. Nodes "i" to "k" are not part of the tree.
+            ///     Note 1: h has child nodes which form loop (i, j) but is still considered a part of tree.
+            ///     Because path leading to it from root has no loops.
+            ///     Note 2: d is also considered to be a part of tree. Self-loops are allowed.
+            ///   * After that, states in the tree part of automaton are recursively merged if they are compatible.
+            ///     Two states are considered compatible if path from root to them has exactly same element
+            ///     distributions and groups on transitions, and they have compatible self-loops. Weights in
+            ///     transitions from root can be different - weights will be adjusted as necessary.
+            ///     For example if in previous automaton transitions (a-b) and (a-e) have the same
+            ///     element distribution then result will look like this:
+            ///
+            ///            a--->b--->c--->d---\
+            ///            | \            ^   |
+            ///       e    |   f--->g      \--/
+            ///            |          
+            ///            v
+            ///            h--->i--->j-->k
+            ///                 ^    |
+            ///                  \--/
+            ///   * If pruneStatesWithLogEndWeightLessThan is not null then log normalizer and graph
+            ///     condensation computed. All states which do not have high enough end probability are deleted
             /// </remarks>
             public bool Simplify()
             {
-                this.MergeParallelTransitions();
+                var initialStatesCount = builder.StatesCount;
+                var initialTransitionsCount = builder.TransitionsCount;
 
-                if (AutomatonHasNonTrivialLoops())
+                this.MergeParallelTransitions();
+                this.MergeTrees();
+
+                if (this.pruneStatesWithLogEndWeightLessThan != null)
                 {
-                    return false; // TODO: make this stuff work with non-trivial loops
+                    this.RemoveLowWeightEndStates();
                 }
 
-                var generalizedTreeNodes = this.FindGeneralizedTrees();
-                var sequenceToLogWeight = this.BuildAcceptedSequenceList(generalizedTreeNodes);
-                this.builder.RemoveStates(generalizedTreeNodes, true);
+                Console.WriteLine($"s:{initialStatesCount}->{builder.StatesCount}, t:{initialTransitionsCount}->{builder.TransitionsCount}");
 
-                var firstNonCopiedStateIndex = this.builder.StatesCount;
+                return builder.StatesCount != initialStatesCount ||
+                       builder.TransitionsCount != initialTransitionsCount;
+            }
 
-                // Before we rebuild the tree part, we prune out the low probability sequences
-                if (this.pruneTransitionsWithLogWeightLessThan != null)
+            /// <summary>
+            /// Merges outgoing transitions with the same destination state.
+            /// </summary>
+            public void MergeParallelTransitions()
+            {
+                for (var stateIndex = 0; stateIndex < this.builder.StatesCount; ++stateIndex)
                 {
-                    double logNorm = this.builder.GetAutomaton().GetLogNormalizer();
-                    if (!double.IsInfinity(logNorm))
+                    var state = this.builder[stateIndex];
+                    for (var iterator1 = state.TransitionIterator; iterator1.Ok; iterator1.Next())
                     {
-                        sequenceToLogWeight = sequenceToLogWeight
-                            .Where(s => s.Weight.LogValue - logNorm >= this.pruneTransitionsWithLogWeightLessThan.Value)
-                            .ToList();
+                        var transition1 = iterator1.Value;
+                        var iterator2 = iterator1;
+                        iterator2.Next();
+                        for (; iterator2.Ok; iterator2.Next())
+                        {
+                            var transition2 = iterator2.Value;
+                            if (transition1.DestinationStateIndex == transition2.DestinationStateIndex &&
+                                transition1.Group == transition2.Group)
+                            {
+                                var mergedTransition = TryMergeTransitions(transition1, transition2);
+                                if (mergedTransition != null)
+                                {
+                                    iterator1.Value = mergedTransition.Value;
+                                    transition1 = mergedTransition.Value;
+                                    iterator2.Remove();
+                                }
+                            }
+                        }
                     }
                 }
 
-                foreach (var weightedSequence in sequenceToLogWeight)
+                Transition? TryMergeTransitions(Transition transition1, Transition transition2)
                 {
-                    this.AddGeneralizedSequence(firstNonCopiedStateIndex, weightedSequence.Sequence, weightedSequence.Weight);
+                    if (transition1.IsEpsilon && transition2.IsEpsilon)
+                    {
+                        transition1.Weight = Weight.Sum(transition1.Weight, transition2.Weight);
+                        return transition1;
+                    }
+                    
+                    if (!transition1.IsEpsilon && !transition2.IsEpsilon)
+                    {
+                        var newElementDistribution = new TElementDistribution();
+                        if (transition1.Weight.IsInfinity && transition2.Weight.IsInfinity)
+                        {
+                            newElementDistribution.SetToSum(
+                                1.0,
+                                transition1.ElementDistribution.Value,
+                                1.0,
+                                transition2.ElementDistribution.Value);
+                        }
+                        else
+                        {
+                            newElementDistribution.SetToSum(
+                                transition1.Weight.Value,
+                                transition1.ElementDistribution.Value,
+                                transition2.Weight.Value,
+                                transition2.ElementDistribution.Value);
+                        }
+
+                        return new Transition(
+                            newElementDistribution,
+                            Weight.Sum(transition1.Weight, transition2.Weight),
+                            transition1.DestinationStateIndex,
+                            transition1.Group);
+                    }
+
+                    return null;
+                }
+            }
+
+            public void MergeTrees()
+            {
+                var builder = this.builder;
+                var isRemovedNode = new bool[builder.StatesCount];
+                var isTreeNode = FindTreeNodes();
+
+                var stack = new Stack<int>();
+                stack.Push(builder.StartStateIndex);
+
+                while (stack.Count > 0)
+                {
+                    var stateIndex = stack.Pop();
+                    var state = builder[stateIndex];
+                    for (var iterator1 = state.TransitionIterator; iterator1.Ok; iterator1.Next())
+                    {
+                        var transition1 = iterator1.Value;
+
+                        // ignore non-tree nodes and self-loops
+                        if (!isTreeNode[transition1.DestinationStateIndex] ||
+                            transition1.DestinationStateIndex == stateIndex)
+                        {
+                            continue;
+                        }
+
+                        var iterator2 = iterator1;
+                        iterator2.Next();
+                        for (; iterator2.Ok; iterator2.Next())
+                        {
+                            var transition2 = iterator2.Value;
+
+                            Debug.Assert(
+                                transition1.DestinationStateIndex != transition2.DestinationStateIndex,
+                                "Parallel transitions must be merged earlier by MergeParallelTransitions()");
+
+                            // ignore non-tree nodes and self-loops
+                            if (isTreeNode[transition1.DestinationStateIndex] &&
+                                transition1.DestinationStateIndex != stateIndex &&
+                                CanMerge(transition1, transition2))
+                            {
+                                MergeStates(
+                                    transition1.DestinationStateIndex,
+                                    transition2.DestinationStateIndex,
+                                    Weight.Product(transition2.Weight, Weight.Inverse(transition1.Weight)));
+                                isRemovedNode[transition2.DestinationStateIndex] = true;
+                                iterator2.Remove();
+                            }
+                        }
+                    }
                 }
 
-                return true;
+                builder.RemoveStates(isRemovedNode, true);
+                return;
+
+                // Returns a boolean array in which for each automaton state a "isTree" flag is stored.
+                // State is considered to be tree node if its in degree = 1 and it's parent is also a tree node.
+                bool[] FindTreeNodes()
+                {
+                    var inDegree = new int[builder.StatesCount];
+                    for (var i = 0; i < builder.StatesCount; ++i)
+                    {
+                        for (var iterator = builder[i].TransitionIterator; iterator.Ok; iterator.Next())
+                        {
+                            var destinationIndex = iterator.Value.DestinationStateIndex;
+                            // Ignore self-loops
+                            if (destinationIndex != i)
+                            {
+                                ++inDegree[destinationIndex];
+                            }
+                        }
+                    }
+
+                    var result = new bool[builder.StatesCount];
+
+                    var treeSearchStack = new Stack<int>();
+                    treeSearchStack.Push(builder.StartStateIndex);
+                    while (treeSearchStack.Count > 0)
+                    {
+                        var stateIndex = treeSearchStack.Pop();
+                        result[stateIndex] = true;
+                        for (var iterator = builder[stateIndex].TransitionIterator; iterator.Ok; iterator.Next())
+                        {
+                            var destinationIndex = iterator.Value.DestinationStateIndex;
+                            if (destinationIndex != stateIndex && inDegree[destinationIndex] == 1)
+                            {
+                                treeSearchStack.Push(destinationIndex);
+                            }
+                        }
+                    }
+
+                    return result;
+                }
+
+                bool CanMerge(Transition transition1, Transition transition2)
+                {
+                    // Check that group and element distribution match
+                    if (transition1.Group != transition2.Group ||
+                        !EqualDistributions(transition1.ElementDistribution, transition2.ElementDistribution))
+                    {
+                        return false;
+                    }
+
+                    var selfLoop1 = TryFindSelfLoop(transition1.DestinationStateIndex);
+                    var selfLoop2 = TryFindSelfLoop(transition2.DestinationStateIndex);
+
+                    // Can merge only if both destination states don't have self-loops
+                    // or these loops are exactly the same.
+                    return
+                        selfLoop1.HasValue == selfLoop2.HasValue
+                        && (!selfLoop1.HasValue
+                            || (selfLoop1.Value.Group == selfLoop2.Value.Group &&
+                                selfLoop1.Value.Weight == selfLoop2.Value.Weight &&
+                                EqualDistributions(selfLoop1.Value.ElementDistribution, selfLoop2.Value.ElementDistribution)));
+                }
+
+                // Compares element distributions in transition. Epsilon transitions are considered equal.
+                bool EqualDistributions(Option<TElementDistribution> dist1, Option<TElementDistribution> dist2) =>
+                    dist1.HasValue == dist2.HasValue &&
+                    (!dist1.HasValue || dist1.Value.Equals(dist2.Value));
+
+                // Finds transition which points to state itself
+                // It is assumed that there's only one such transition
+                Transition? TryFindSelfLoop(int stateIndex)
+                {
+                    for (var iterator = builder[stateIndex].TransitionIterator; iterator.Ok; iterator.Next())
+                    {
+                        if (iterator.Value.DestinationStateIndex == stateIndex)
+                        {
+                            return iterator.Value;
+                        }
+                    }
+
+                    return null;
+                }
+
+                // Adds EndWeight and all transitions from state2 into state1.
+                // All state2 weights are multiplied by state2WeightMultiplier
+                void MergeStates(int state1Index, int state2Index, Weight state2WeightMultiplier)
+                {
+                    var state1 = builder[state1Index];
+                    var state2 = builder[state2Index];
+
+                    // sum end weights
+                    if (!state2.EndWeight.IsZero)
+                    {
+                        var state2EndWeight = Weight.Product(state2WeightMultiplier, state2.EndWeight);
+                        state1.SetEndWeight(Weight.Sum(state1.EndWeight, state2EndWeight));
+                    }
+
+                    // Copy all transitions except self-loop.
+                    // Self-loop doesn't need to be copied because two states can be merged only if they have
+                    // identical self-loops. Thus if there is self-loop in state2 then it is also already
+                    // present in state1.
+                    for (var iterator = state2.TransitionIterator; iterator.Ok; iterator.Next())
+                    {
+                        var transition = iterator.Value;
+                        if (transition.DestinationStateIndex != state2Index)
+                        {
+                            transition.Weight = Weight.Product(transition.Weight, state2WeightMultiplier);
+                            state1.AddTransition(transition);
+                        }
+                    }
+
+                }
+            }
+
+            public void RemoveLowWeightEndStates()
+            {
+                // Note: no production work-load currently uses PruneStatesWithLogEndWeightLessThan
+                // So having no implementation is not big deal
+                // TODO:
+                //   - set automaton to epsilon-closure
+                //   - compute Condensation & logNormalizer
+                //   - remove all end states with EndWeight < PruneStatesWithLogEndWeightLessThan - LogNormalizer
+                //   - remove dead states
+                //   - write lots of unit-tests
             }
 
             /// <summary>
@@ -162,37 +409,48 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             public bool RemoveDeadStates()
             {
                 var builder = this.builder;
-                var visited = new bool[builder.StatesCount];
                 var (edgesStart, edges) = BuildReversedGraph();
 
+                //// Now run a depth-first search to label all reachable nodes
+                var stack = new Stack<int>();
+                var visited = new bool[builder.StatesCount];
                 for (var i = 0; i < builder.StatesCount; ++i)
                 {
-                    if (builder[i].CanEnd)
+                    if (!visited[i] && builder[i].CanEnd)
                     {
-                        Traverse(i);
-                    }
-                }
-
-                return this.builder.RemoveStates(visited, false) > 0;
-
-                void Traverse(int index)
-                {
-                    if (!visited[index])
-                    {
-                        visited[index] = true;
-                        for (var i = edgesStart[index]; i < edgesStart[index + 1]; ++i)
+                        visited[i] = true;
+                        stack.Push(i);
+                        while (stack.Count != 0)
                         {
-                            Traverse(edges[i]);
+                            var stateIndex = stack.Pop();
+                            for (var j = edgesStart[stateIndex]; j < edgesStart[stateIndex + 1]; ++j)
+                            {
+                                var destinationIndex = edges[j];
+                                if (!visited[destinationIndex])
+                                {
+                                    visited[destinationIndex] = true;
+                                    stack.Push(destinationIndex);
+                                }
+                            }
                         }
                     }
                 }
+
+                if (!visited[builder.StartStateIndex])
+                {
+                    builder.Clear();
+                    builder.StartStateIndex = builder.AddState().Index;
+                    return true;
+                }
+
+                return this.builder.RemoveStates(visited, false) > 0;
 
                 (int[] edgesStart, int[] edges) BuildReversedGraph()
                 {
                     // [edgesStart[i]; edgesStart[i+1]) is a range `edges` array which corresponds to incoming edges for state `i`
                     var edgesStart1 = new int[builder.StatesCount + 1];
 
-                    // incomming edges for state. Represented as index of source state
+                    // incoming edges for state. Represented as index of source state
                     var edges1 = new int[builder.TransitionsCount];
 
                     // first populate edges
@@ -221,759 +479,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     }
 
                     return (edgesStart1, edges1);
-                }
-            }
-
-            /// <summary>
-            /// Removes transitions in the automaton whose log weight is less than the specified threshold.
-            /// </summary>
-            /// <remarks>
-            /// Any states which are unreachable in the resulting automaton are also removed.
-            /// </remarks>
-            /// <param name="logWeightThreshold">The smallest log weight that a transition can have and not be removed.</param>
-            public void RemoveTransitionsWithSmallWeights(double logWeightThreshold)
-            {
-                for (var i = 0; i < this.builder.StatesCount; ++i)
-                {
-                    var state = this.builder[i];
-                    for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
-                    {
-                        if (iterator.Value.Weight.LogValue < logWeightThreshold)
-                        {
-                            iterator.Remove();
-                        }
-                    }
-                }
-
-                // Calculate reachable states and remove unreachable
-                var visited = new bool[this.builder.StatesCount];
-                Traverse(this.builder.StartStateIndex);
-                this.builder.RemoveStates(visited, false);
-
-                void Traverse(int stateIndex)
-                {
-                    if (!visited[stateIndex])
-                    {
-                        visited[stateIndex] = true;
-                        var state = this.builder[stateIndex];
-                        for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
-                        {
-                            Traverse(iterator.Value.DestinationStateIndex);
-                        }
-                    }
-                }
-            }
-
-            /// <summary>
-            /// Recursively checks if the automaton has non-trivial loops
-            /// (i.e. loops consisting of more than one transition).
-            /// </summary>
-            /// <returns>
-            /// <see langword="true"/> if a non-trivial loop has been found,
-            /// <see langword="false"/> otherwise.
-            /// </returns>
-            private bool AutomatonHasNonTrivialLoops()
-            {
-                var stateInStack = new ArrayDictionary<bool>(this.builder.StatesCount);
-                return HasNonTrivialLoops(this.builder.StartStateIndex);
-
-                bool HasNonTrivialLoops(int stateIndex)
-                {
-                    if (stateInStack.TryGetValue(stateIndex, out var inStack))
-                    {
-                        return inStack;
-                    }
-
-                    stateInStack[stateIndex] = true;
-                    for (var iterator = this.builder[stateIndex].TransitionIterator; iterator.Ok; iterator.Next())
-                    {
-                        var transition = iterator.Value;
-                        if (transition.DestinationStateIndex != stateIndex)
-                        {
-                            if (HasNonTrivialLoops(transition.DestinationStateIndex))
-                            {
-                                return true;
-                            }
-                        }
-                    }
-
-                    stateInStack[stateIndex] = false;
-                    return false;
-                }
-            }
-
-            /// <summary>
-            /// Labels each state with a value indicating whether the automaton having that state as the start state is a
-            /// generalized tree (i.e. a tree with self-loops), which has single path from root leading to it
-            /// (excluding the self-loops).
-            /// </summary>
-            /// <returns>A dictionary mapping state indices to the computed labels.</returns>
-            private bool[] FindGeneralizedTrees()
-            {
-                var inDegree = CalcInDegree();
-                var isGeneralizedTree = new bool[this.builder.StatesCount];
-                Traverse(this.builder.StartStateIndex);
-                return isGeneralizedTree;
-
-                bool Traverse(int currentStateIndex)
-                {
-                    if (inDegree[currentStateIndex] > 1)
-                    {
-                        // Valid states can't have more than one incoming edge. Having more than one edge
-                        // means that there's more than one path from root or that there's a loop somewhere.
-                        // Both these cases are not considered generalized trees.
-                        return false;
-                    }
-
-                    var currentIsGeneralizedTree = true;
-                    for (var iterator = this.builder[currentStateIndex].TransitionIterator; iterator.Ok; iterator.Next())
-                    {
-                        var transition = iterator.Value;
-
-                        // Self-loops are allowed
-                        if (transition.DestinationStateIndex != currentStateIndex)
-                        {
-                            currentIsGeneralizedTree &= Traverse(transition.DestinationStateIndex);
-                        }
-                    }
-
-                    // if current node is not generalized tree then all transitions from it are also not trees
-                    if (!currentIsGeneralizedTree)
-                    {
-                        for (var iterator = this.builder[currentStateIndex].TransitionIterator; iterator.Ok; iterator.Next())
-                        {
-                            MarkAsNonTree(iterator.Value.DestinationStateIndex);
-                        }
-                    }
-
-                    isGeneralizedTree[currentStateIndex] = currentIsGeneralizedTree;
-                    return currentIsGeneralizedTree;
-                }
-
-                void MarkAsNonTree(int currentStateIndex)
-                {
-                    if (isGeneralizedTree[currentStateIndex])
-                    {
-                        isGeneralizedTree[currentStateIndex] = false;
-                        for (var iterator = this.builder[currentStateIndex].TransitionIterator; iterator.Ok; iterator.Next())
-                        {
-                            MarkAsNonTree(iterator.Value.DestinationStateIndex);
-                        }
-                    }
-                }
-
-                int[] CalcInDegree()
-                {
-                    var result = new int[this.builder.StatesCount];
-                    for (var i = 0; i < this.builder.StatesCount; ++i)
-                    {
-                        for (var iterator = this.builder[i].TransitionIterator; iterator.Ok; iterator.Next())
-                        {
-                            // do not count self-loops
-                            var destination = iterator.Value.DestinationStateIndex;
-                            if (destination != i)
-                            {
-                                ++result[destination];
-                            }
-                        }
-                    }
-
-                    return result;
-                }
-            }
-
-            /// <summary>
-            /// Merges outgoing transitions with the same destination state.
-            /// </summary>
-            public void MergeParallelTransitions()
-            {
-                for (var stateIndex = 0; stateIndex < this.builder.StatesCount; ++stateIndex)
-                {
-                    var state = this.builder[stateIndex];
-                    for (var iterator1 = state.TransitionIterator; iterator1.Ok; iterator1.Next())
-                    {
-                        var transition1 = iterator1.Value;
-                        var iterator2 = iterator1;
-                        iterator2.Next();
-                        for (; iterator2.Ok; iterator2.Next())
-                        {
-                            var transition2 = iterator2.Value;
-                            if (transition1.DestinationStateIndex == transition2.DestinationStateIndex && transition1.Group == transition2.Group)
-                            {
-                                var removeTransition2 = false;
-                                if (transition1.IsEpsilon && transition2.IsEpsilon)
-                                {
-                                    transition1.Weight = Weight.Sum(transition1.Weight, transition2.Weight);
-                                    iterator1.Value = transition1;
-                                    removeTransition2 = true;
-                                }
-                                else if (!transition1.IsEpsilon && !transition2.IsEpsilon)
-                                {
-                                    var newElementDistribution = new TElementDistribution();
-                                    if (double.IsInfinity(transition1.Weight.Value) && double.IsInfinity(transition2.Weight.Value))
-                                    {
-                                        newElementDistribution.SetToSum(
-                                            1.0, transition1.ElementDistribution.Value, 1.0, transition2.ElementDistribution.Value);
-                                    }
-                                    else
-                                    {
-                                        newElementDistribution.SetToSum(
-                                            transition1.Weight.Value, transition1.ElementDistribution.Value, transition2.Weight.Value, transition2.ElementDistribution.Value);
-                                    }
-
-                                    transition1.ElementDistribution = newElementDistribution;
-                                    transition1.Weight = Weight.Sum(transition1.Weight, transition2.Weight);
-                                    iterator1.Value = transition1;
-                                    removeTransition2 = true;
-                                }
-
-                                if (removeTransition2)
-                                {
-                                    iterator2.Remove();
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            /// <summary>
-            /// Builds a complete list of generalized sequences accepted by the simplifiable part of the automaton.
-            /// </summary>
-            /// <param name="generalizedTreeNodes">The state labels obtained from <see cref="FindGeneralizedTrees"/>.</param>
-            /// <returns>The list of generalized sequences accepted by the simplifiable part of the automaton.</returns>
-            private List<WeightedSequence> BuildAcceptedSequenceList(bool[] generalizedTreeNodes)
-            {
-                var sequenceToWeight = new List<WeightedSequence>();
-                this.DoBuildAcceptedSequenceList(
-                    this.builder.StartStateIndex,
-                    generalizedTreeNodes,
-                    sequenceToWeight,
-                    new List<GeneralizedElement>(),
-                    Weight.One);
-                return sequenceToWeight;
-            }
-
-
-            private class StackItem
-            {
-            }
-
-            private class ElementItem : StackItem
-            {
-                public readonly GeneralizedElement? Element;
-
-                public ElementItem(GeneralizedElement? element) => this.Element = element;
-
-                public override string ToString() => this.Element.ToString();
-            }
-
-            private class StateWeight : StackItem
-            {
-                public readonly int StateIndex;
-                public readonly Weight Weight;
-
-                public StateWeight(int stateIndexIndex, Weight weight)
-                {
-                    this.StateIndex = stateIndexIndex;
-                    this.Weight = weight;
-                }
-
-                public override string ToString() => $"StateIndex: {this.StateIndex}, Weight: {Weight}";
-            }
-
-            /// <summary>
-            /// Recursively builds a complete list of generalized sequences accepted by the simplifiable part of the automaton.
-            /// </summary>
-            /// <param name="stateIndex">The currently traversed state.</param>
-            /// <param name="generalizedTreeNodes">The state labels obtained from <see cref="FindGeneralizedTrees"/>.</param>
-            /// <param name="weightedSequences">The sequence list being built.</param>
-            /// <param name="currentSequenceElements">The list of elements of the sequence currently being built.</param>
-            /// <param name="currentWeight">The weight of the sequence currently being built.</param>
-            private void DoBuildAcceptedSequenceList(
-                int stateIndex,
-                bool[] generalizedTreeNodes,
-                List<WeightedSequence> weightedSequences,
-                List<GeneralizedElement> currentSequenceElements,
-                Weight currentWeight)
-            {
-                var stack = new Stack<StackItem>();
-                stack.Push(new StateWeight(stateIndex, currentWeight));
-
-                while (stack.Count > 0)
-                {
-                    var stackItem = stack.Pop();
-
-                    if (stackItem is ElementItem elementItem)
-                    {
-                        if (elementItem.Element != null)
-                            currentSequenceElements.Add(elementItem.Element.Value);
-                        else
-                            currentSequenceElements.RemoveAt(currentSequenceElements.Count - 1);
-                        continue;
-                    }
-
-                    var stateAndWeight = stackItem as StateWeight;
-
-                    stateIndex = stateAndWeight.StateIndex;
-                    var state = this.builder[stateIndex];
-                    currentWeight = stateAndWeight.Weight;
-
-                    // Find a non-epsilon self-loop if there is one
-                    Transition? selfLoop = null;
-                    for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
-                    {
-                        var transition = iterator.Value;
-                        if (transition.DestinationStateIndex == stateIndex)
-                        {
-                            Debug.Assert(
-                                selfLoop == null,
-                                "Multiple self-loops should have been merged by MergeParallelTransitions()");
-                            selfLoop = transition;
-                        }
-                    }
-
-                    // Push the found self-loop to the end of the current sequence
-                    if (selfLoop != null)
-                    {
-                        currentSequenceElements.Add(new GeneralizedElement(
-                            selfLoop.Value.ElementDistribution, selfLoop.Value.Group, selfLoop.Value.Weight));
-                        stack.Push(new ElementItem(null));
-                    }
-
-                    // Can this state produce a sequence?
-                    if (state.CanEnd && generalizedTreeNodes[stateIndex])
-                    {
-                        var sequence = new GeneralizedSequence(currentSequenceElements);
-                        // TODO: use immutable data structure instead of copying sequences
-                        weightedSequences.Add(new WeightedSequence(sequence, Weight.Product(currentWeight, state.EndWeight)));
-                    }
-
-                    // Traverse the outgoing transitions
-                    for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
-                    {
-                        var transition = iterator.Value;
-                        // Skip self-loops & disallowed states
-                        if (transition.DestinationStateIndex == stateIndex ||
-                            !generalizedTreeNodes[transition.DestinationStateIndex])
-                        {
-                            continue;
-                        }
-
-                        if (!transition.IsEpsilon)
-                        {
-                            // Non-epsilon transitions contribute to the sequence
-                            stack.Push(new ElementItem(null));
-                        }
-
-                        stack.Push(
-                            new StateWeight(
-                                transition.DestinationStateIndex,
-                                Weight.Product(currentWeight, transition.Weight)));
-
-                        if (!transition.IsEpsilon)
-                        {
-                            stack.Push(
-                                new ElementItem(
-                                    new GeneralizedElement(transition.ElementDistribution, transition.Group, null)));
-                        }
-                    }
-                }
-            }
-
-            /// <summary>
-            /// Increases the value of this automaton on <paramref name="sequence"/> by <paramref name="weight"/>.
-            /// </summary>
-            /// <param name="firstAllowedStateIndex">The minimum index of an existing state that can be used for the sequence.</param>
-            /// <param name="sequence">The generalized sequence.</param>
-            /// <param name="weight">The weight of the sequence.</param>
-            /// <remarks>
-            /// This function attempts to add as few new states and transitions as possible.
-            /// Its implementation is conceptually similar to adding string to a trie.
-            /// </remarks>
-            private void AddGeneralizedSequence(int firstAllowedStateIndex, Simplification.GeneralizedSequence sequence, Weight weight)
-            {
-                // First, try to add at start state
-                var isFreshStartState = !this.builder.Start.HasTransitions && this.builder.Start.EndWeight.IsZero;
-                if (this.DoAddGeneralizedSequence(this.builder.Start.Index, isFreshStartState, false, firstAllowedStateIndex, 0, sequence, weight))
-                {
-                    return;
-                }
-
-                // Branch the start state
-                var builder = this.builder;
-                var oldStart = builder.Start;
-                var start = builder.AddState();
-                builder.StartStateIndex = start.Index;
-                var otherBranch = builder.AddState();
-                builder.Start.AddEpsilonTransition(Weight.One, oldStart.Index);
-                builder.Start.AddEpsilonTransition(Weight.One, otherBranch.Index);
-
-                // This should always work
-                var success = this.DoAddGeneralizedSequence(otherBranch.Index, true, false, firstAllowedStateIndex, 0, sequence, weight);
-                Debug.Assert(success, "This call must always succeed.");
-            }
-
-            /// <summary>
-            /// Recursively increases the value of this automaton on <paramref name="sequence"/> by <paramref name="weight"/>.
-            /// </summary>
-            /// <param name="stateIndex">Index of currently traversed state.</param>
-            /// <param name="isNewState">Indicates whether state <paramref name="stateIndex"/> was just created.</param>
-            /// <param name="selfLoopAlreadyMatched">Indicates whether self-loop on state <paramref name="stateIndex"/> was just matched.</param>
-            /// <param name="firstAllowedStateIndex">The minimum index of an existing state that can be used for the sequence.</param>
-            /// <param name="currentSequencePos">The current position in the generalized sequence.</param>
-            /// <param name="sequence">The generalized sequence.</param>
-            /// <param name="weight">The weight of the sequence.</param>
-            /// <returns>
-            /// <see langword="true"/> if the subsequence starting at <paramref name="currentSequencePos"/> has been successfully merged in,
-            /// <see langword="false"/> otherwise.
-            /// </returns>
-            /// <remarks>
-            /// This function attempts to add as few new states and transitions as possible.
-            /// Its implementation is conceptually similar to adding string to a trie.
-            /// </remarks>
-            private bool DoAddGeneralizedSequence(
-                int stateIndex,
-                bool isNewState,
-                bool selfLoopAlreadyMatched,
-                int firstAllowedStateIndex,
-                int currentSequencePos,
-                GeneralizedSequence sequence,
-                Weight weight)
-            {
-                bool success;
-                var builder = this.builder;
-                var state = builder[stateIndex];
-
-                if (currentSequencePos == sequence.Count)
-                {
-                    if (!selfLoopAlreadyMatched)
-                    {
-                        // We can't finish in a state with a self-loop
-                        for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
-                        {
-                            if (iterator.Value.DestinationStateIndex == state.Index)
-                            {
-                                return false;
-                            }
-                        }
-                    }
-
-                    state.SetEndWeight(Weight.Sum(state.EndWeight, weight));
-                    return true;
-                }
-
-                var element = sequence[currentSequencePos];
-
-                // Treat self-loops elements separately
-                if (element.LoopWeight.HasValue)
-                {
-                    if (selfLoopAlreadyMatched)
-                    {
-                        // Previous element was also a self-loop, we should try to find an espilon transition
-                        for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
-                        {
-                            var transition = iterator.Value;
-                            if (transition.DestinationStateIndex != state.Index &&
-                                transition.IsEpsilon &&
-                                transition.DestinationStateIndex >= firstAllowedStateIndex)
-                            {
-                                if (this.DoAddGeneralizedSequence(
-                                    transition.DestinationStateIndex,
-                                    false,
-                                    false,
-                                    firstAllowedStateIndex,
-                                    currentSequencePos,
-                                    sequence,
-                                    Weight.Product(weight, Weight.Inverse(transition.Weight))))
-                                {
-                                    return true;
-                                }
-                            }
-                        }
-
-                        // Epsilon transition not found, let's create a new one
-                        var destination = state.AddEpsilonTransition(Weight.One);
-                        success = this.DoAddGeneralizedSequence(
-                            destination.Index, true, false, firstAllowedStateIndex, currentSequencePos, sequence, weight);
-                        Debug.Assert(success, "This call must always succeed.");
-                        return true;
-                    }
-
-                    // Find a matching self-loop
-                    for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
-                    {
-                        var transition = iterator.Value;
-
-                        if (transition.IsEpsilon && transition.DestinationStateIndex != state.Index && transition.DestinationStateIndex >= firstAllowedStateIndex)
-                        {
-                            // Try this epsilon transition
-                            if (this.DoAddGeneralizedSequence(
-                                transition.DestinationStateIndex, false, false, firstAllowedStateIndex, currentSequencePos, sequence, weight))
-                            {
-                                return true;
-                            }
-                        }
-
-                        // Is it a self-loop?
-                        if (transition.DestinationStateIndex == state.Index)
-                        {
-                            // Do self-loops match?
-                            if ((transition.Weight == element.LoopWeight.Value) &&
-                                (element.Group == transition.Group) &&
-                                ((transition.IsEpsilon && element.IsEpsilonSelfLoop) || (!transition.IsEpsilon && !element.IsEpsilonSelfLoop && transition.ElementDistribution.Equals(element.ElementDistribution))))
-                            {
-                                // Skip the element in the sequence, remain in the same state
-                                success = this.DoAddGeneralizedSequence(
-                                    stateIndex, false, true, firstAllowedStateIndex, currentSequencePos + 1, sequence, weight);
-                                Debug.Assert(success, "This call must always succeed.");
-                                return true;
-                            }
-
-                            // StateIndex also has a self-loop, but the two doesn't match
-                            return false;
-                        }
-                    }
-
-                    if (!isNewState)
-                    {
-                        // Can't add self-loop to an existing state, it will change the language accepted by the state
-                        return false;
-                    }
-
-                    // Add a new self-loop
-                    state.AddTransition(element.ElementDistribution, element.LoopWeight.Value, stateIndex, element.Group);
-                    success = this.DoAddGeneralizedSequence(stateIndex, false, true, firstAllowedStateIndex, currentSequencePos + 1, sequence, weight);
-                    Debug.Assert(success, "This call must always succeed.");
-                    return true;
-                }
-
-                // Try to find a transition for the element
-                for (var iterator = state.TransitionIterator; iterator.Ok; iterator.Next())
-                {
-                    var transition = iterator.Value;
-
-                    if (transition.IsEpsilon && transition.DestinationStateIndex != state.Index && transition.DestinationStateIndex >= firstAllowedStateIndex)
-                    {
-                        // Try this epsilon transition
-                        if (this.DoAddGeneralizedSequence(
-                            transition.DestinationStateIndex, false, false, firstAllowedStateIndex, currentSequencePos, sequence, weight))
-                        {
-                            return true;
-                        }
-                    }
-
-                    // Is it a self-loop?
-                    if (transition.DestinationStateIndex == state.Index)
-                    {
-                        if (selfLoopAlreadyMatched)
-                        {
-                            // The self-loop was checked or added by the caller
-                            continue;
-                        }
-
-                        // Can't go through an existing self-loop, it will allow undesired sequences to be accepted
-                        return false;
-                    }
-
-                    if (transition.DestinationStateIndex < firstAllowedStateIndex ||
-                        element.Group != transition.Group ||
-                        !element.ElementDistribution.Equals(transition.ElementDistribution))
-                    {
-                        continue;
-                    }
-
-                    // Skip the element in the sequence, move to the destination state
-                    // Weight of the existing transition must be taken into account
-                    // This case can fail if the next element is a self-loop and the destination state already has a different one
-                    if (this.DoAddGeneralizedSequence(
-                        transition.DestinationStateIndex,
-                        false,
-                        false,
-                        firstAllowedStateIndex,
-                        currentSequencePos + 1,
-                        sequence,
-                        Weight.Product(weight, Weight.Inverse(transition.Weight))))
-                    {
-                        return true;
-                    }
-                }
-
-                // Add a new transition
-                var newChild = state.AddTransition(element.ElementDistribution, Weight.One, null, element.Group);
-                success = this.DoAddGeneralizedSequence(
-                    newChild.Index, true, false, firstAllowedStateIndex, currentSequencePos + 1, sequence, weight);
-                Debug.Assert(success, "This call must always succeed.");
-                return true;
-            }
-
-            /// <summary>
-            /// Represents an element of a generalized sequence,
-            /// i.e. a distribution over a single symbol or a weighted self-loop.
-            /// </summary>
-            public struct GeneralizedElement
-            {
-                /// <summary>
-                /// Initializes a new instance of the <see cref="GeneralizedElement"/> struct.
-                /// </summary>
-                /// <param name="elementDistribution">The element distribution associated with the generalized element.</param>
-                /// <param name="group">The group associated with the generalized element.</param>
-                /// <param name="loopWeight">
-                /// The loop weight associated with the generalized element, <see langword="null"/> if the element does not represent a self-loop.
-                /// </param>
-                public GeneralizedElement(Option<TElementDistribution> elementDistribution, int group, Weight? loopWeight)
-                    : this()
-                {
-                    Debug.Assert(
-                        elementDistribution.HasValue || loopWeight.HasValue,
-                        "Epsilon elements are only allowed in combination with self-loops.");
-
-                    this.ElementDistribution = elementDistribution;
-                    this.Group = group;
-                    this.LoopWeight = loopWeight;
-                }
-
-                /// <summary>
-                /// Gets the element distribution associated with the generalized element.
-                /// </summary>
-                public Option<TElementDistribution> ElementDistribution { get; }
-
-                /// <summary>
-                /// Gets a value indicating whether this element corresponds to an epsilon self-loop.
-                /// </summary>
-                public bool IsEpsilonSelfLoop => !this.ElementDistribution.HasValue && this.LoopWeight.HasValue;
-
-                /// <summary>
-                /// Gets the group associated with the generalized element.
-                /// </summary>
-                public int Group { get; }
-
-                /// <summary>
-                /// Gets the loop weight associated with the generalized element,
-                /// <see langword="null"/> if the element does not represent a self-loop.
-                /// </summary>
-                public Weight? LoopWeight { get; }
-
-                /// <summary>
-                /// Gets the string representation of the generalized element.
-                /// </summary>
-                /// <returns>The string representation of the generalized element.</returns>
-                public override string ToString()
-                {
-                    var elementDistributionAsString =
-                        this.ElementDistribution.Value.IsPointMass
-                            ? this.ElementDistribution.Value.Point.ToString()
-                            : this.ElementDistribution.ToString();
-                    var groupString = this.Group == 0 ? string.Empty : $"#{this.Group}";
-                    return
-                        this.LoopWeight.HasValue
-                            ? $"{groupString}{elementDistributionAsString}*({this.LoopWeight.Value})"
-                            : $"{groupString}{elementDistributionAsString}";
-                }
-            }
-
-            /// <summary>
-            /// Represents a sequence of generalized elements.
-            /// </summary>
-            public class GeneralizedSequence
-            {
-                /// <summary>
-                /// The sequence elements.
-                /// </summary>
-                private readonly List<GeneralizedElement> elements;
-
-                /// <summary>
-                /// Initializes a new instance of the <see cref="GeneralizedSequence"/> class.
-                /// </summary>
-                /// <param name="elements">The sequence elements.</param>
-                public GeneralizedSequence(IEnumerable<GeneralizedElement> elements)
-                {
-                    this.elements = new List<GeneralizedElement>(elements);
-                }
-
-                /// <summary>
-                /// Gets the number of elements in the sequence.
-                /// </summary>
-                public int Count => this.elements.Count;
-
-                /// <summary>
-                /// Gets the sequence element with the specified index.
-                /// </summary>
-                /// <param name="index">The element index.</param>
-                /// <returns>The element at the given index.</returns>
-                public GeneralizedElement this[int index] => this.elements[index];
-
-                /// <summary>
-                /// Gets the string representation of the sequence.
-                /// </summary>
-                /// <returns>The string representation of the sequence.</returns>
-                public override string ToString()
-                {
-                    var stringBuilder = new StringBuilder();
-                    foreach (var element in this.elements)
-                    {
-                        stringBuilder.Append(element);
-                    }
-
-                    return stringBuilder.ToString();
-                }
-            }
-
-            public struct WeightedSequence
-            {
-                /// <summary>
-                /// Initializes a new instance of the <see cref="WeightedSequence"/> struct.
-                /// </summary>
-                /// <param name="sequence">The <see cref="GeneralizedSequence"/></param>
-                /// <param name="weight">The <see cref="Weight"/> for the specified sequence</param>
-                public WeightedSequence(GeneralizedSequence sequence, Weight weight)
-                    : this()
-                {
-                    this.Sequence = sequence;
-                    this.Weight = weight;
-                }
-
-                /// <summary>
-                /// Gets or sets the <see cref="GeneralizedSequence"/>.
-                /// </summary>
-                public readonly GeneralizedSequence Sequence;
-
-                /// <summary>
-                /// Gets or sets the predicted probability.
-                /// </summary>
-                public readonly Weight Weight;
-
-                /// <summary>
-                /// Gets the string representation of this <see cref="WeightedSequence"/>.
-                /// </summary>
-                /// <returns>The string representation of the <see cref="WeightedSequence"/>.</returns>
-                public override string ToString() => $"[{this.Sequence},{this.Weight}]";
-
-                /// <summary>
-                /// Checks if this object is equal to <paramref name="obj"/>.
-                /// </summary>
-                /// <param name="obj">The object to compare this object with.</param>
-                /// <returns>
-                /// <see langword="true"/> if this object is equal to <paramref name="obj"/>,
-                /// <see langword="false"/> otherwise.
-                /// </returns>
-                public override bool Equals(object obj) =>
-                    obj is WeightedSequence weightedSequence &&
-                    object.Equals(this.Sequence, weightedSequence.Sequence) &&
-                    object.Equals(this.Weight, weightedSequence.Weight);
-
-                /// <summary>
-                /// Computes the hash code of this object.
-                /// </summary>
-                /// <returns>The computed hash code.</returns>
-                public override int GetHashCode()
-                {
-                    int result = Hash.Start;
-
-                    result = Hash.Combine(result, this.Sequence.GetHashCode());
-                    result = Hash.Combine(result, this.Weight.GetHashCode());
-
-                    return result;
                 }
             }
         }

--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -5,7 +5,6 @@
 
 namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
-    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
 
@@ -145,8 +144,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 {
                     this.RemoveLowWeightEndStates();
                 }
-
-                Console.WriteLine($"s:{initialStatesCount}->{builder.StatesCount}, t:{initialTransitionsCount}->{builder.TransitionsCount}");
 
                 return builder.StatesCount != initialStatesCount ||
                        builder.TransitionsCount != initialTransitionsCount;

--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -394,7 +394,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 // TODO:
                 //   - set automaton to epsilon-closure
                 //   - compute Condensation & logNormalizer
-                //   - remove all end states with EndWeight < PruneStatesWithLogEndWeightLessThan - LogNormalizer
+                //   - remove all end states with WeightFromRoot * EndWeight < PruneStatesWithLogEndWeightLessThan - LogNormalizer
                 //   - remove dead states
                 //   - write lots of unit-tests
             }

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -765,7 +765,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
             var builder = new StringBuilder();
             var visitedStates = new HashSet<int>();
-            //
             var stack = new Stack<(string prefix, Option<TElementDistribution> prefixDistribution, int state)>();
             stack.Push((string.Empty, Option.None, Start.Index));
 
@@ -803,7 +802,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 var transitions = state.Transitions.Where(t => !t.Weight.IsZero);
                 var selfTransitions = transitions.Where(t => t.DestinationStateIndex == stateIndex);
                 var selfTransitionCount = selfTransitions.Count();
-                var nonSelfTransitions = transitions.Where(t => t.DestinationStateIndex != stateIndex);
+                var nonSelfTransitions = transitions.Where(t => t.DestinationStateIndex != stateIndex).ToArray();
                 var nonSelfTransitionCount = nonSelfTransitions.Count();
 
                 if (state.CanEnd && nonSelfTransitionCount > 0)
@@ -853,12 +852,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     stack.Push(("]", Option.None, -1));
                 }
 
-                transIdx = 0;
-                foreach (var transition in nonSelfTransitions)
+                // Iterate transitions in reverse order, because after destinations are pushed to stack,
+                // order will be reversed again.
+                for (transIdx = nonSelfTransitions.Length - 1; transIdx >= 0; --transIdx)
                 {
-                    var transitionPrefix = (nonSelfTransitionCount == 1 || ++transIdx == 1)
-                        ? string.Empty
-                        : "|";
+                    var transition = nonSelfTransitions[transIdx];
+                    var transitionPrefix = transIdx == 0 ? string.Empty : "|";
                     stack.Push((transitionPrefix, transition.ElementDistribution, transition.DestinationStateIndex));
                 }
             }

--- a/src/Runtime/Distributions/Automata/Weight.cs
+++ b/src/Runtime/Distributions/Automata/Weight.cs
@@ -89,6 +89,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         }
 
         /// <summary>
+        /// Gets value indicating whether weight is infinite.
+        /// </summary>
+        public bool IsInfinity => double.IsInfinity(Value);
+
+        /// <summary>
         /// Creates a weight from the logarithm of its value.
         /// </summary>
         /// <param name="logValue">The logarithm of the weight value.</param>

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -1792,15 +1792,6 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 this.isNormalized = true;
             }
             
-            ////// todo: consider moving the following logic into the Automaton class
-            ////if (product.PruneTransitionsWithLogWeightLessThan.HasValue)
-            ////{
-            ////    if (this.isNormalized || product.TryNormalizeValues())
-            ////    {
-            ////        product.RemoveTransitionsWithSmallWeights(product.PruneTransitionsWithLogWeightLessThan.Value);
-            ////    }
-            ////}
-            
             return logNormalizer;
         }
         

--- a/test/Tests/TestUtils.cs
+++ b/test/Tests/TestUtils.cs
@@ -910,13 +910,13 @@ namespace Microsoft.ML.Probabilistic.Tests
         /// <param name="eps">Precision.</param>
         public static void Equal(double expected, double observed, double eps)
         {
-            // Infinty check
+            // Infinity check
             if (expected == observed)
             {
                 return;
             }
 
-            Assert.True(Math.Abs(expected - observed) < eps, $"Equality failure\n. Expected: {expected}\nActual:   {observed}");
+            Assert.True(Math.Abs(expected - observed) < eps, $"Equality failure.\nExpected: {expected}\nActual:   {observed}");
         }
 
         /// <summary>


### PR DESCRIPTION
We finally reached a point where automatons are big enough that recursive implementations
of algorithms fail with `StackOverflowException`.

There are 4 tests which test operations with big automatons (100k states):
* `TryComputePointLargeAutomaton`
* `SetToProductLargeAutomaton`
* `GetLogNormalizerLargeAutomaton`
* `ProjectSourceLargeAutomaton`

All four used to fail before code was rewritten to use explicit stack instead of recursive calls.
All changes except one didn't change algorithms used, code was almost mechanically changed
to use stack.

The only exception - automaton simplification. Old code used recursion in very non-trivial way.
It was rewritten from scratch, using different algorithm: instead of extraction of generalized
sequences and then reinserting them back new code merges states directly in automaton.
(There's a comment at the beginning of Simplify() method explaining all operations)