### PR TITLE
Fix automaton simplification code

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -164,6 +164,10 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// </summary>
             public void RemoveState(int stateIndex)
             {
+                // Caller must ensure that it doesn't try to delete start state. Because it will lead to
+                // invalid automaton.
+                Debug.Assert(stateIndex != StartStateIndex);
+
                 // After state is removed, all its transitions will be dead
                 for (var iterator = this[stateIndex].TransitionIterator; iterator.Ok; iterator.Next())
                 {
@@ -219,8 +223,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     return 0;
                 }
 
-                // may invalidate automaton
                 this.StartStateIndex = oldToNewStateIdMapping[this.StartStateIndex];
+
+                // Caller must ensure that it doesn't try to delete start state. Because it will lead to
+                // invalid automaton.
+                Debug.Assert(StartStateIndex != -1);
 
                 for (var i = 0; i < this.states.Count; ++i)
                 {

--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -257,8 +257,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                                 "Parallel transitions must be merged earlier by MergeParallelTransitions()");
 
                             // ignore non-tree nodes and self-loops
-                            if (isTreeNode[transition1.DestinationStateIndex] &&
-                                transition1.DestinationStateIndex != stateIndex &&
+                            if (isTreeNode[transition2.DestinationStateIndex] &&
+                                transition2.DestinationStateIndex != stateIndex &&
                                 CanMerge(transition1, transition2))
                             {
                                 MergeStates(
@@ -269,6 +269,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                                 iterator2.Remove();
                             }
                         }
+
+                        stack.Push(transition1.DestinationStateIndex);
                     }
                 }
 

--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -235,13 +235,17 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 {
                     var stateIndex = stack.Pop();
                     var state = builder[stateIndex];
+
+                    // Transitions to non-tree nodes and self-loops should be ignored
+                    bool IsMergeableTransition(Transition t) =>
+                        isTreeNode[t.DestinationStateIndex] && t.DestinationStateIndex != stateIndex;
+
                     for (var iterator1 = state.TransitionIterator; iterator1.Ok; iterator1.Next())
                     {
                         var transition1 = iterator1.Value;
 
                         // ignore non-tree nodes and self-loops
-                        if (!isTreeNode[transition1.DestinationStateIndex] ||
-                            transition1.DestinationStateIndex == stateIndex)
+                        if (!IsMergeableTransition(transition1))
                         {
                             continue;
                         }
@@ -257,9 +261,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                                 "Parallel transitions must be merged earlier by MergeParallelTransitions()");
 
                             // ignore non-tree nodes and self-loops
-                            if (isTreeNode[transition2.DestinationStateIndex] &&
-                                transition2.DestinationStateIndex != stateIndex &&
-                                CanMerge(transition1, transition2))
+                            if (IsMergeableTransition(transition2) && CanMerge(transition1, transition2))
                             {
                                 MergeStates(
                                     transition1.DestinationStateIndex,


### PR DESCRIPTION
* It didn't recurse past first state
* transition2 was not checked if it is valid for merging. Because of subscript error, transition1 was checked twice.