### PR TITLE
Fix performance issues after recursion elimination

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.Condensation.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Condensation.cs
@@ -300,9 +300,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                             State destState = state.Owner.States[transition.DestinationStateIndex];
                             if (this.transitionFilter(transition) && !currentComponent.HasState(destState))
                             {
-                                weightToAdd = Weight.Sum(
-                                    weightToAdd,
-                                    Weight.Product(transition.Weight, this.stateIdToInfo[transition.DestinationStateIndex].WeightToEnd));
+                                weightToAdd += transition.Weight * this.stateIdToInfo[transition.DestinationStateIndex].WeightToEnd;
                             }
                         }
 
@@ -313,9 +311,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                             {
                                 State updatedState = currentComponent.GetStateByIndex(updatedStateIndex);
                                 CondensationStateInfo updatedStateInfo = this.stateIdToInfo[updatedState.Index];
-                                updatedStateInfo.WeightToEnd = Weight.Sum(
-                                    updatedStateInfo.WeightToEnd,
-                                    Weight.Product(currentComponent.GetWeight(updatedStateIndex, stateIndex), weightToAdd));
+                                updatedStateInfo.WeightToEnd +=
+                                    currentComponent.GetWeight(updatedStateIndex, stateIndex) * weightToAdd;
                                 this.stateIdToInfo[updatedState.Index] = updatedStateInfo;
                             }
                         }
@@ -355,9 +352,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         {
                             State destState = currentComponent.GetStateByIndex(destStateIndex);
                             CondensationStateInfo destStateInfo = this.stateIdToInfo[destState.Index];
-                            destStateInfo.WeightFromRoot = Weight.Sum(
-                                destStateInfo.WeightFromRoot,
-                                Weight.Product(srcStateInfo.UpwardWeightFromRoot, currentComponent.GetWeight(srcStateIndex, destStateIndex)));
+                            destStateInfo.WeightFromRoot +=
+                                srcStateInfo.UpwardWeightFromRoot * currentComponent.GetWeight(srcStateIndex, destStateIndex);
                             this.stateIdToInfo[destState.Index] = destStateInfo;
                         }
                     }
@@ -379,9 +375,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                             if (this.transitionFilter(transition) && !currentComponent.HasState(destState))
                             {
                                 CondensationStateInfo destStateInfo = this.stateIdToInfo[destState.Index];
-                                destStateInfo.UpwardWeightFromRoot = Weight.Sum(
-                                    destStateInfo.UpwardWeightFromRoot,
-                                    Weight.Product(srcStateInfo.WeightFromRoot, transition.Weight));
+                                destStateInfo.UpwardWeightFromRoot += srcStateInfo.WeightFromRoot * transition.Weight;
                                 this.stateIdToInfo[transition.DestinationStateIndex] = destStateInfo;
                             }
                         }


### PR DESCRIPTION
* FindStronglyConnectedComponents() ncorreclty used array to store state info. When
  epsilon closure of state was constructed a very small fraction of states was traversed
  but array was created for all states in automaton. This created huge gc pressure.
* SetToEpsilonClosure() is also now recursion-free
* Automaton simplification now considers important case of eliminating epsilon-transition