### PR TITLE
Simplification improvements

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -401,22 +401,10 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         var transition = iterator.Value;
                         if (transition.DestinationStateIndex != state2Index)
                         {
+                            // Self-loop is not copied: it is already present in state1 and is absolutely
+                            // compatible: it has the same distribution and weight
                             transition.Weight *= state2WeightMultiplier;
                             state1.AddTransition(transition);
-                        }
-                        else
-                        {
-                            // Self-loop gets special treatment - it's not copied, instead destination self-loop weight is updated
-                            for (var iterator2 = state1.TransitionIterator; iterator2.Ok; iterator.Next())
-                            {
-                                var transition2 = iterator2.Value;
-                                if (transition2.DestinationStateIndex == state1Index)
-                                {
-                                    transition2.Weight += transition.Weight * state2WeightMultiplier;
-                                    iterator2.Value = transition2;
-                                    break;
-                                }
-                            }
                         }
                     }
 

--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -406,7 +406,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         }
                         else
                         {
-                            // Self-loop get special treatment - it's not copied but destination self-loop weight is updated
+                            // Self-loop gets special treatment - it's not copied, instead destination self-loop weight is updated
                             for (var iterator2 = state1.TransitionIterator; iterator2.Ok; iterator.Next())
                             {
                                 var transition2 = iterator2.Value;

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -1902,12 +1902,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         {
                             return null;
                         }
-
-                        continue;
                     }
-                    
-                    // Now we know the length of the sequence
-                    pointLength = sequencePos;
+                    else
+                    {
+                        // Now we know the length of the sequence
+                        pointLength = sequencePos;
+                    }
                 }
 
                 foreach (var transition in state.Transitions)


### PR DESCRIPTION
1. Actually remove merged states in MergeTrees(). Not doing this led to slightly worse performance
2. TryComputePoint() contained a bug when it didn't traverse some transitions in automaton