### PR TITLE
Make ToLower() work with more char classes

### DIFF
--- a/src/Runtime/Distributions/Automata/Weight.cs
+++ b/src/Runtime/Distributions/Automata/Weight.cs
@@ -193,7 +193,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// Returns a specified weight raised to the specified power.
         /// </summary>
         public static Weight Pow(Weight weight, double power) =>
-            power == 0 && double.IsNegativeInfinity(weight.LogValue)
+            power == 0
                 ? Weight.One
                 : new Weight(weight.LogValue * power);
 

--- a/src/Runtime/Distributions/DiscreteChar.cs
+++ b/src/Runtime/Distributions/DiscreteChar.cs
@@ -1937,9 +1937,21 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 NonWordChar = WordChar.Complement();
                 Whitespace = Storage.CreateUniformInRanges("\t\r  ");
 
-                LowerOrDigit = Storage.CreateUniformInRanges(LetterOrDigitsRanges(LowerCaseCharacterRanges));
-                LowerWordCharOrDigit =Storage.CreateUniformInRanges(WordCharRanges(LowerCaseCharacterRanges));
-                UpperComplement = Upper.Complement();
+                LowerOrDigit = Storage.CreateUniformInRanges(
+                    LetterOrDigitsRanges(LowerCaseCharacterRanges),
+                    regexRepresentation: @"[\p{Ll}\d]",
+                    symbolRepresentation: "⭽");
+                LowerWordCharOrDigit = Storage.CreateUniformInRanges(
+                    WordCharRanges(LowerCaseCharacterRanges),
+                    regexRepresentation: @"[\p{Ll}\d_]",
+                    symbolRepresentation: "⧬");
+
+                var upperComplement = Upper.Complement();
+                UpperComplement = Storage.CreateUncached(
+                    upperComplement.Ranges,
+                    upperComplement.ProbabilityOutsideRanges,
+                    regexRepresentation: @"[^\p{Lu}]",
+                    symbolRepresentation: "🡻");
 
                 PointMasses = new Storage[CharRangeEndExclusive];
             }


### PR DESCRIPTION
Previously `NotSupportedException` was thrown for `WordChar` and `Uniform` char classes.
Now versions of these distributions with upper chars excluded are returned.

Note: implementation of `ToLower()` for `Unknown` char class is still somewhat broken:
- it ignores probability outside ranges.
- it can get slow if char ranges are big.