### PR TITLE
Automaton determinization improvements

### DIFF
--- a/src/Runtime/Core/Collections/ReadOnlyArray.cs
+++ b/src/Runtime/Core/Collections/ReadOnlyArray.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-
 namespace Microsoft.ML.Probabilistic.Collections
 {
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Runtime.Serialization;
 
     using Microsoft.ML.Probabilistic.Serialization;

--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -500,11 +500,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 /// <summary>
                 /// Sets a new end weight for this state.
                 /// </summary>
-                public void SetEndWeight(Weight weight)
+                public StateBuilder SetEndWeight(Weight weight)
                 {
                     var state = this.builder.states[this.Index];
                     state.EndWeight = weight;
                     this.builder.states[this.Index] = state;
+                    return this;
                 }
 
                 #region AddTransition variants

--- a/src/Runtime/Distributions/Automata/ListAutomaton.cs
+++ b/src/Runtime/Distributions/Automata/ListAutomaton.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// The first two elements of a tuple define the element distribution and the weight of a transition.
         /// The third element defines the outgoing state.
         /// </returns>
-        protected override IEnumerable<(TElementDistribution, Weight, Determinization.WeightedStateSet)> GetOutgoingTransitionsForDeterminization(
+        protected override IEnumerable<Determinization.OutgoingTransition> GetOutgoingTransitionsForDeterminization(
             Determinization.WeightedStateSet sourceState)
         {
             throw new NotImplementedException("Determinization is not yet supported for this type of automata.");
@@ -84,7 +84,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// The first two elements of a tuple define the element distribution and the weight of a transition.
         /// The third element defines the outgoing state.
         /// </returns>
-        protected override IEnumerable<(TElementDistribution, Weight, Determinization.WeightedStateSet)> GetOutgoingTransitionsForDeterminization(
+        protected override IEnumerable<Determinization.OutgoingTransition> GetOutgoingTransitionsForDeterminization(
             Determinization.WeightedStateSet sourceState)
         {
             throw new NotImplementedException();

--- a/src/Runtime/Distributions/Automata/StringAutomaton.cs
+++ b/src/Runtime/Distributions/Automata/StringAutomaton.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// The first two elements of a tuple define the element distribution and the weight of a transition.
         /// The third element defines the outgoing state.
         /// </returns>
-        protected override IEnumerable<(DiscreteChar, Weight, Determinization.WeightedStateSet)> GetOutgoingTransitionsForDeterminization(
+        protected override IEnumerable<Determinization.OutgoingTransition> GetOutgoingTransitionsForDeterminization(
             Determinization.WeightedStateSet sourceStateSet)
         {
             // Build a list of numbered non-zero probability character segment bounds (they are numbered here due to perf. reasons)
@@ -81,7 +81,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         Weight.FromValue(segmentLength),
                         currentSegmentTotal.Sum,
                         destinationStateSetWeight);
-                    yield return (elementDist, transitionWeight, destinationStateSet);
+                    yield return new Determinization.OutgoingTransition(
+                        elementDist, transitionWeight, destinationStateSet);
                 }
 
                 // Update current segment

--- a/src/Runtime/Distributions/Automata/TransducerBase.cs
+++ b/src/Runtime/Distributions/Automata/TransducerBase.cs
@@ -572,7 +572,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// The first two elements of a tuple define the element distribution and the weight of a transition.
             /// The third element defines the outgoing state.
             /// </returns>
-            protected override List<(TPairDistribution, Weight, Determinization.WeightedStateSet)> GetOutgoingTransitionsForDeterminization(
+            protected override IEnumerable<(TPairDistribution, Weight, Determinization.WeightedStateSet)> GetOutgoingTransitionsForDeterminization(
                 Determinization.WeightedStateSet sourceState)
             {
                 throw new NotImplementedException("Determinization is not yet supported for this type of automata.");

--- a/src/Runtime/Distributions/Automata/TransducerBase.cs
+++ b/src/Runtime/Distributions/Automata/TransducerBase.cs
@@ -572,7 +572,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// The first two elements of a tuple define the element distribution and the weight of a transition.
             /// The third element defines the outgoing state.
             /// </returns>
-            protected override IEnumerable<(TPairDistribution, Weight, Determinization.WeightedStateSet)> GetOutgoingTransitionsForDeterminization(
+            protected override IEnumerable<Determinization.OutgoingTransition> GetOutgoingTransitionsForDeterminization(
                 Determinization.WeightedStateSet sourceState)
             {
                 throw new NotImplementedException("Determinization is not yet supported for this type of automata.");

--- a/src/Runtime/Distributions/Automata/Weight.cs
+++ b/src/Runtime/Distributions/Automata/Weight.cs
@@ -73,7 +73,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <summary>
         /// Gets value indicating whether weight is infinite.
         /// </summary>
-        public bool IsInfinity => double.IsPositiveInfinity(Value);
+        public bool IsInfinity => double.IsPositiveInfinity(this.LogValue);
 
         /// <summary>
         /// Creates a weight from the logarithm of its value.

--- a/src/Runtime/Distributions/Automata/WeightSum.cs
+++ b/src/Runtime/Distributions/Automata/WeightSum.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Distributions.Automata
+{
+    /// <summary>
+    /// Helper class for calculating sum of multiple <see cref="Weight"/>. It supports adding
+    /// and then substracting infinite values. Only values which were added into sum can be substracted from it.
+    /// </summary>
+    public struct WeightSum
+    {
+        /// <summary>
+        /// Number of non-infinite weights participating in the sum
+        /// </summary>
+        private readonly int count;
+
+        /// <summary>
+        /// Number of infinite weights participating in the sum
+        /// </summary>
+        private readonly int infCount;
+
+        /// <summary>
+        /// Sum of all non-infinite weights
+        /// </summary>
+        private readonly Weight sum;
+
+        public WeightSum(int count, int infCount, Weight sum)
+        {
+            this.count = count;
+            this.infCount = infCount;
+            this.sum = sum;
+        }
+
+        public WeightSum(Weight init)
+        {
+            this.count = 1;
+            if (init.IsInfinity)
+            {
+                this.infCount = 1;
+                this.sum = Weight.Zero;
+            }
+            else
+            {
+                this.infCount = 0;
+                this.sum = init;
+            }
+        }
+
+        /// <summary>
+        /// Constructs new empty accumulator instance
+        /// </summary>
+        public static WeightSum Zero() => new WeightSum(0, 0, Weight.Zero);
+
+        public static WeightSum operator +(WeightSum a, Weight b) =>
+            b.IsInfinity
+                ? new WeightSum(a.count + 1, a.infCount + 1, a.sum)
+                : new WeightSum(a.count + 1, a.infCount, a.sum + b);
+
+        public static WeightSum operator -(WeightSum a, Weight b) =>
+            a.count == 1
+                ? WeightSum.Zero()
+                : (b.IsInfinity
+                    ? new WeightSum(a.count - 1, a.infCount - 1, a.sum)
+                    : new WeightSum(a.count - 1, a.infCount, Weight.AbsoluteDifference(a.sum, b)));
+
+        public int Count => this.count;
+
+        public Weight Sum =>
+            this.infCount != 0
+                ? Weight.Infinity
+                : this.sum;
+    }
+}

--- a/test/Tests/Strings/StringAutomatonTests.cs
+++ b/test/Tests/Strings/StringAutomatonTests.cs
@@ -36,11 +36,13 @@ namespace Microsoft.ML.Probabilistic.Tests
             var wrapper = new StringAutomatonWrapper(builder);
             
             var outgoingTransitions =
-                wrapper.GetOutgoingTransitionsForDeterminization(new Dictionary<int, Weight> { { 0, Weight.FromValue(3) } });
+                wrapper.GetOutgoingTransitionsForDeterminization(0, Weight.FromValue(3));
             var expectedOutgoingTransitions = new[]
             {
-                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
-                    DiscreteChar.Uniform(), Weight.FromValue(6), new Dictionary<int, Weight> { { 1, Weight.FromValue(1) } })
+                ValueTuple.Create(
+                    DiscreteChar.Uniform(),
+                    Weight.FromValue(2),
+                    new[] {(1, Weight.FromValue(1))})
             };
 
             AssertCollectionsEqual(expectedOutgoingTransitions, outgoingTransitions, TransitionInfoEqualityComparer.Instance);
@@ -61,13 +63,17 @@ namespace Microsoft.ML.Probabilistic.Tests
             var wrapper = new StringAutomatonWrapper(builder);
             
             var outgoingTransitions =
-                wrapper.GetOutgoingTransitionsForDeterminization(new Dictionary<int, Weight> { { 0, Weight.FromValue(5) } });
+                wrapper.GetOutgoingTransitionsForDeterminization(0, Weight.FromValue(5));
             var expectedOutgoingTransitions = new[]
             {
-                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
-                    DiscreteChar.UniformInRange('A', 'Z'), Weight.FromValue(7.5), new Dictionary<int, Weight> { { 2, Weight.FromValue(1) } }),
-                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
-                    DiscreteChar.UniformInRange('a', 'z'), Weight.FromValue(17.5), new Dictionary<int, Weight> { { 1, Weight.FromValue(10 / 17.5) }, { 2, Weight.FromValue(7.5 / 17.5) } }),
+                ValueTuple.Create(
+                    DiscreteChar.UniformInRange('A', 'Z'),
+                    Weight.FromValue(1.5),
+                    new[] {(2, Weight.FromValue(1))}),
+                ValueTuple.Create(
+                    DiscreteChar.UniformInRange('a', 'z'),
+                    Weight.FromValue(3.5),
+                    new[] {(1, Weight.FromValue(1)), (2, Weight.FromValue(0.75))}),
             };
 
             AssertCollectionsEqual(expectedOutgoingTransitions, outgoingTransitions, TransitionInfoEqualityComparer.Instance);
@@ -91,29 +97,33 @@ namespace Microsoft.ML.Probabilistic.Tests
             var wrapper = new StringAutomatonWrapper(builder);
 
             var outgoingTransitions =
-                wrapper.GetOutgoingTransitionsForDeterminization(new Dictionary<int, Weight> { { 0, Weight.FromValue(6) } });
+                wrapper.GetOutgoingTransitionsForDeterminization(0, Weight.FromValue(6));
             var expectedOutgoingTransitions = new[]
             {
-                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
-                    DiscreteChar.UniformInRange(char.MinValue, (char)('a' - 1)),
-                    Weight.FromValue(30.0 * 97.0 / 98.0),
-                    new Dictionary<int, Weight> { { 4, Weight.FromValue(1) } }),
-                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                ValueTuple.Create(
+                    DiscreteChar.UniformInRange(char.MinValue, (char) ('a' - 1)),
+                    Weight.FromValue(5.0 * 97.0 / 98.0),
+                    new[] {(4, Weight.FromValue(1))}),
+                ValueTuple.Create(
                     DiscreteChar.PointMass('a'),
-                    Weight.FromValue((30.0 / 98.0) + 6.0),
-                    new Dictionary<int, Weight> { { 1, Weight.FromValue(6.0 / ((30.0 / 98.0) + 6.0)) }, { 4, Weight.FromValue((30.0 / 98.0) / ((30.0 / 98.0) + 6.0)) } }),
-                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                    Weight.FromValue((5.0 / 98.0) + 1.0),
+                    new[]
+                    {
+                        (1, Weight.FromValue(1.0 / ((30.0 / 98.0) + 1.0))),
+                        (4, Weight.FromValue((5.0 / 98.0) / ((30.0 / 98.0) + 1.0)))
+                    }),
+                ValueTuple.Create(
                     DiscreteChar.PointMass('b'),
-                    Weight.FromValue(12.0),
-                    new Dictionary<int, Weight> { { 1, Weight.FromValue(0.5) }, { 2, Weight.FromValue(0.5)} }),
-                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                    Weight.FromValue(2.0),
+                    new[] {(1, Weight.FromValue(0.5)), (2, Weight.FromValue(0.5))}),
+                ValueTuple.Create(
                     DiscreteChar.UniformInRange('c', 'd'),
-                    Weight.FromValue(12.0),
-                    new Dictionary<int, Weight> { { 2, Weight.FromValue(1.0) } }),
-                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                    Weight.FromValue(2.0),
+                    new[] {(2, Weight.FromValue(1.0))}),
+                ValueTuple.Create(
                     DiscreteChar.UniformInRange('e', 'g'),
-                    Weight.FromValue(24.0),
-                    new Dictionary<int, Weight> { { 3, Weight.FromValue(1.0) } }),
+                    Weight.FromValue(4.0),
+                    new[] {(3, Weight.FromValue(1.0))}),
             };
 
             AssertCollectionsEqual(expectedOutgoingTransitions, outgoingTransitions, TransitionInfoEqualityComparer.Instance);
@@ -133,39 +143,39 @@ namespace Microsoft.ML.Probabilistic.Tests
             builder.Start.AddTransition(DiscreteChar.UniformInRanges('z', char.MaxValue), Weight.FromValue(4));
 
             var wrapper = new StringAutomatonWrapper(builder);
-            
-            var outgoingTransitions =
-                wrapper.GetOutgoingTransitionsForDeterminization(new Dictionary<int, Weight> { { 0, Weight.FromValue(5) } });
 
-            double transition1Segment1Weight = 10.0 * 'a' / (char.MaxValue + 1.0);
-            double transition1Segment2Weight = 10.0 * ('z' - 'a') / (char.MaxValue + 1.0);
-            double transition1Segment3Weight = 10.0 * (char.MaxValue - 'z' + 1.0) / (char.MaxValue + 1.0);
-            double transition2Segment1Weight = 15.0 * ('z' - 'a') / (char.MaxValue - 'a' + 1.0);
-            double transition2Segment2Weight = 15.0 * (char.MaxValue - 'z' + 1.0) / (char.MaxValue - 'a' + 1.0);
-            double transition3Segment1Weight = 20.0;
+            var outgoingTransitions =
+                wrapper.GetOutgoingTransitionsForDeterminization(0, Weight.FromValue(5));
+
+            double transition1Segment1Weight = 2.0 * 'a' / (char.MaxValue + 1.0);
+            double transition1Segment2Weight = 2.0 * ('z' - 'a') / (char.MaxValue + 1.0);
+            double transition1Segment3Weight = 2.0 * (char.MaxValue - 'z' + 1.0) / (char.MaxValue + 1.0);
+            double transition2Segment1Weight = 3.0 * ('z' - 'a') / (char.MaxValue - 'a' + 1.0);
+            double transition2Segment2Weight = 3.0 * (char.MaxValue - 'z' + 1.0) / (char.MaxValue - 'a' + 1.0);
+            double transition3Segment1Weight = 4.0;
             var expectedOutgoingTransitions = new[]
             {
-                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                ValueTuple.Create(
                     DiscreteChar.UniformInRange(char.MinValue, (char)('a' - 1)),
                     Weight.FromValue(transition1Segment1Weight),
-                    new Dictionary<int, Weight> { { 1, Weight.FromValue(1) } }),
-                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                    new[] {(1, Weight.FromValue(1))}),
+                ValueTuple.Create(
                     DiscreteChar.UniformInRange('a', (char)('z' - 1)),
                     Weight.FromValue(transition1Segment2Weight + transition2Segment1Weight),
-                    new Dictionary<int, Weight>
-                        {
-                            { 1, Weight.FromValue(transition1Segment2Weight / (transition1Segment2Weight + transition2Segment1Weight)) },
-                            { 2, Weight.FromValue(transition2Segment1Weight / (transition1Segment2Weight + transition2Segment1Weight)) }
-                        }),
-                new ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>(
+                    new[]
+                    {
+                        (1, Weight.FromValue(transition1Segment2Weight / (transition1Segment2Weight + transition2Segment1Weight))),
+                        (2, Weight.FromValue(transition2Segment1Weight / (transition1Segment2Weight + transition2Segment1Weight))),
+                    }),
+                ValueTuple.Create(
                     DiscreteChar.UniformInRange('z', char.MaxValue),
                     Weight.FromValue(transition1Segment3Weight + transition2Segment2Weight + transition3Segment1Weight),
-                    new Dictionary<int, Weight>
-                        {
-                            { 1, Weight.FromValue(transition1Segment3Weight / (transition1Segment3Weight + transition2Segment2Weight + transition3Segment1Weight)) },
-                            { 2, Weight.FromValue(transition2Segment2Weight / (transition1Segment3Weight + transition2Segment2Weight + transition3Segment1Weight)) },
-                            { 3, Weight.FromValue(transition3Segment1Weight / (transition1Segment3Weight + transition2Segment2Weight + transition3Segment1Weight)) }
-                        }),
+                    new[]
+                    {
+                        (1, Weight.FromValue(transition1Segment3Weight / (transition1Segment3Weight + transition2Segment2Weight + transition3Segment1Weight))),
+                        (2, Weight.FromValue(transition2Segment2Weight / (transition1Segment3Weight + transition2Segment2Weight + transition3Segment1Weight))),
+                        (3, Weight.FromValue(transition3Segment1Weight / (transition1Segment3Weight + transition2Segment2Weight + transition3Segment1Weight))),
+                    }),
             };
 
             AssertCollectionsEqual(expectedOutgoingTransitions, outgoingTransitions, TransitionInfoEqualityComparer.Instance);
@@ -188,8 +198,8 @@ namespace Microsoft.ML.Probabilistic.Tests
 
             var wrapper = new StringAutomatonWrapper(builder);
 
-            var outgoingTransitions = wrapper.GetOutgoingTransitionsForDeterminization(
-                new Dictionary<int, Weight> { { 0, Weight.FromValue(1) } }).ToArray();
+            var outgoingTransitions =
+                wrapper.GetOutgoingTransitionsForDeterminization(0, Weight.FromValue(1)).ToArray();
 
             Assert.Equal(5, outgoingTransitions.Length);
             Assert.True(outgoingTransitions.All(ot => ot.Item1.IsPointMass));
@@ -277,7 +287,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         /// A comparer for weighted states that allows for some tolerance when comparing weights.
         /// </summary>
         private class WeightedStateEqualityComparer :
-            EqualityComparerBase<KeyValuePair<int, Weight>, WeightedStateEqualityComparer>
+            EqualityComparerBase<(int, Weight), WeightedStateEqualityComparer>
         {
             /// <summary>
             /// Checks whether two objects are equal.
@@ -288,9 +298,9 @@ namespace Microsoft.ML.Probabilistic.Tests
             /// <see langword="true"/> if the objects are equal,
             /// <see langword="false"/> otherwise.
             /// </returns>
-            public override bool Equals(KeyValuePair<int, Weight> x, KeyValuePair<int, Weight> y)
+            public override bool Equals((int, Weight) x, (int, Weight) y)
             {
-                return x.Key == y.Key && WeightEqualityComparer.Instance.Equals(x.Value, y.Value);
+                return x.Item1 == y.Item1 && WeightEqualityComparer.Instance.Equals(x.Item2, y.Item2);
             }
         }
 
@@ -298,7 +308,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         /// A comparer for transition information that allows for some tolerance when comparing weights.
         /// </summary>
         private class TransitionInfoEqualityComparer :
-            EqualityComparerBase<ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>>, TransitionInfoEqualityComparer>
+            EqualityComparerBase<ValueTuple<DiscreteChar, Weight, (int, Weight)[]>, TransitionInfoEqualityComparer>
         {
             /// <summary>
             /// Checks whether two objects are equal.
@@ -310,13 +320,13 @@ namespace Microsoft.ML.Probabilistic.Tests
             /// <see langword="false"/> otherwise.
             /// </returns>
             public override bool Equals(
-                ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>> x,
-                ValueTuple<DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>> y)
+                ValueTuple<DiscreteChar, Weight, (int, Weight)[]> x,
+                ValueTuple<DiscreteChar, Weight, (int, Weight)[]> y)
             {
                 return
                     object.Equals(x.Item1, y.Item1) &&
                     WeightEqualityComparer.Instance.Equals(x.Item2, y.Item2) &&
-                    Enumerable.SequenceEqual(x.Item3, y.Item3, WeightedStateEqualityComparer.Instance);
+                    x.Item3.SequenceEqual(y.Item3, WeightedStateEqualityComparer.Instance);
             }
         }
 
@@ -338,14 +348,20 @@ namespace Microsoft.ML.Probabilistic.Tests
             /// <param name="sourceState">The source state.</param>
             /// <returns>The produced transitions.</returns>
             /// <remarks>See the doc of the original method.</remarks>
-            public IEnumerable<(DiscreteChar, Weight, IEnumerable<KeyValuePair<int, Weight>>)>
-                GetOutgoingTransitionsForDeterminization(IEnumerable<KeyValuePair<int, Weight>> sourceState)
+            public IEnumerable<(DiscreteChar, Weight, (int, Weight)[])>
+                GetOutgoingTransitionsForDeterminization(int sourceState, Weight sourceWeight)
             {
-                var result = base.GetOutgoingTransitionsForDeterminization(new Determinization.WeightedStateSet(sourceState));
-                return result.Select(t => (t.Item1, t.Item2, (IEnumerable<KeyValuePair<int, Weight>>)t.Item3));
+                var weightedStateSetBuilder = Determinization.WeightedStateSetBuilder.Create();
+                weightedStateSetBuilder.Add(sourceState, sourceWeight);
+
+                var (weightedStateSet, weight) = weightedStateSetBuilder.Get();
+                var result = base.GetOutgoingTransitionsForDeterminization(weightedStateSet);
+                return result.Select(t => (
+                    t.Item1,
+                    t.Item2 * weight,
+                    t.Item3.ToArray().Select(state => (state.Index, state.Weight)).ToArray()));
             }
         }
-
         #endregion
     }
 }

--- a/test/Tests/Strings/StringAutomatonTests.cs
+++ b/test/Tests/Strings/StringAutomatonTests.cs
@@ -367,9 +367,9 @@ namespace Microsoft.ML.Probabilistic.Tests
                 var (weightedStateSet, weight) = weightedStateSetBuilder.Get();
                 var result = base.GetOutgoingTransitionsForDeterminization(weightedStateSet);
                 return result.Select(t => (
-                    t.Item1,
-                    t.Item2 * weight,
-                    t.Item3.ToArray().Select(state => (state.Index, state.Weight)).ToArray()));
+                    t.ElementDistribution,
+                    t.Weight * weight,
+                    t.Destinations.ToArray().Select(state => (state.Index, state.Weight)).ToArray()));
             }
         }
         #endregion

--- a/test/Tests/Strings/StringInferencePerformanceTests.cs
+++ b/test/Tests/Strings/StringInferencePerformanceTests.cs
@@ -257,7 +257,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
                 action(); // To exclude the compilation time from the profile
                 ProfileAction(action, 100);
-            }, 10000);
+            }, 10001);
         }
 
         /// <summary>

--- a/test/Tests/Strings/StringInferencePerformanceTests.cs
+++ b/test/Tests/Strings/StringInferencePerformanceTests.cs
@@ -257,7 +257,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
                 action(); // To exclude the compilation time from the profile
                 ProfileAction(action, 100);
-            }, 10001);
+            }, 10000);
         }
 
         /// <summary>


### PR DESCRIPTION
* Determinization doesn't change language of the automaton anymore.
  2 new tests were added which check that it doesn't happen.
  Previously all very low probability transitions (with probability of less than e^-35) were removed.
  That was done because of 2 reasons:
  - some probabilities were represented in linear space. And e^-35 is as low resolution
    as you can get with regular doubles. (That is, if one probability = 1 and another is e^-35,
    then when you add them together, second one is indistinguishable from zero).
    This was fixed when discrete charprobabilities
  - Trying to determinize some non-determinizable automata lead to explosion of low-probability
    states and transitions which led to a very poor performance.
    (E.g. `AutomatonNormalizationPerformance3` test). Now a smarter strategy for detecting
    these non-determinizable automata is used - during traversal all sets of states from root
    are remembered. If automaton comes to the same set of states but with different weights
    than it stops immediately, because otherwise it will be caught in infinite loop
* `Equals()` and `GetHashCode()` for `WeightedStateSet` take into account only high 32 bits of weight.
  This coupled with normalization of weights allows to reuse already added states with
  very close weights. This speeds up the "PropertyInferencePerformanceTest" 2.5x due to
  smaller intermediate automata.
* Weighted sets of size one are handled specially in `TryDeterminize` - they don't need to be
  determinized and can be copied into result almost as is. (Unless they have non-deterministic
  transitions. Simple heuristic of "has different destination states" is used to detect that
  and fallback to slow general path).
* Representation for `WeightedStateSet` is changed from (int -> float) dictionary to
  sorted array of (int, float) pairs. As an optimization, a common case of single-element
  set does not allocate any arrays.
* Determinization code for `ListAutomaton` was removed, because it has never worked