### PR TITLE
Do not fail in MergeParallelTransitions when transition weights are high

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -202,12 +202,20 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                                 1.0,
                                 transition2.ElementDistribution.Value);
                         }
+                        else if (transition1.Weight > transition2.Weight)
+                        {
+                            newElementDistribution.SetToSum(
+                                1,
+                                transition1.ElementDistribution.Value,
+                                (transition2.Weight / transition1.Weight).Value,
+                                transition2.ElementDistribution.Value);
+                        }
                         else
                         {
                             newElementDistribution.SetToSum(
-                                transition1.Weight.Value,
+                                (transition1.Weight / transition2.Weight).Value,
                                 transition1.ElementDistribution.Value,
-                                transition2.Weight.Value,
+                                1,
                                 transition2.ElementDistribution.Value);
                         }
 

--- a/src/Runtime/Distributions/Automata/Weight.cs
+++ b/src/Runtime/Distributions/Automata/Weight.cs
@@ -296,6 +296,14 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public static Weight operator *(Weight weight1, Weight weight2) => Product(weight1, weight2);
 
         /// <summary>
+        /// Compute the ratio of given weights.
+        /// </summary>
+        /// <param name="weight1">The first weight.</param>
+        /// <param name="weight2">The second weight.</param>
+        /// <returns>The computed product.</returns>
+        public static Weight operator /(Weight weight1, Weight weight2) => Product(weight1, Weight.Inverse(weight2));
+
+        /// <summary>
         /// Compute the sum of given weights.
         /// </summary>
         /// <param name="weight1">The first weight.</param>

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -1597,6 +1597,21 @@ namespace Microsoft.ML.Probabilistic.Tests
             }
         }
 
+        /// <summary>
+        /// Tests that merging parallel transitions doesn't fail with high transition weights
+        /// </summary>
+        [Fact]
+        [Trait("Category", "StringInference")]
+        public void MergePrallelTransitionsWithHighTransitionsWeightsDoesNotThrow()
+        {
+            var builder = new StringAutomaton.Builder();
+            // Add 2 identical transitions from start state to second
+            builder.Start.AddTransition(DiscreteChar.Any(), Weight.FromLogValue(1e5));
+            builder.Start.AddTransition(DiscreteChar.Any(), Weight.FromLogValue(1e5), 1);
+            var automaton = builder.GetAutomaton();
+            automaton.Simplify();
+        }
+
         #endregion
 
         #region Determinization

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -1598,11 +1598,12 @@ namespace Microsoft.ML.Probabilistic.Tests
         }
 
         /// <summary>
-        /// Tests that merging parallel transitions doesn't fail with high transition weights
+        /// Tests that merging parallel transitions doesn't fail when transition weights are too large
+        /// to fit in double in non-log space.
         /// </summary>
         [Fact]
         [Trait("Category", "StringInference")]
-        public void MergePrallelTransitionsWithHighTransitionsWeightsDoesNotThrow()
+        public void MergeParallelTransitionsWithHighTransitionsWeightsDoesNotThrow()
         {
             var builder = new StringAutomaton.Builder();
             // Add 2 identical transitions from start state to second


### PR DESCRIPTION
Transition weights may become infinite when going from log space into value space. And
`SetToSum()` which is used by `MergerParallelTransitions` can't handle 2 inifnite weights at once.
To solve this, transitions weights are normalized by max weight prior to passing into `SetToSum()`