### PR TITLE
Irrelevant exception while setting TraitCount to 0 is fixed

### DIFF
--- a/src/Learners/Recommender/MatchboxRecommenderTrainingSettings.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderTrainingSettings.cs
@@ -205,7 +205,7 @@ namespace Microsoft.ML.Probabilistic.Learners
             set
             {
                 this.trainingSettingsGuard.OnSettingChanging();
-                Argument.CheckIfInRange(value > 0, "value", "The number of traits must be non-negative.");
+                Argument.CheckIfInRange(value >= 0, "value", "The number of traits must be non-negative.");
                 this.traitCount = value;
             }
         }


### PR DESCRIPTION
Recommender doesn't allow to set trait count to zero but it should by design.
This PR fixes it. 