### PR TITLE
InnerProduct supports fixed output when B vector has zero or one nonzero element.

### DIFF
--- a/src/Runtime/Distributions/GammaPower.cs
+++ b/src/Runtime/Distributions/GammaPower.cs
@@ -725,6 +725,18 @@ namespace Microsoft.ML.Probabilistic.Distributions
         }
 
         /// <summary>
+        /// Creates a new GammaPower distribution corresponding to dividing every sample by a positive constant.
+        /// </summary>
+        /// <param name="numerator">The numerator distribution</param>
+        /// <param name="denominator">The denominator constant.</param>
+        /// <returns>Result. May not be proper.</returns>
+        public static GammaPower operator /(GammaPower numerator, double denominator)
+        {
+            if (denominator <= 0) throw new ArgumentOutOfRangeException(nameof(denominator), denominator, "<= 0");
+            return GammaPower.FromShapeAndRate(numerator.Shape, numerator.Rate / denominator, numerator.Power);
+        }
+
+        /// <summary>
         /// Sets the parameters to represent the power of a source distribution to some exponent.
         /// </summary>
         /// <param name="dist">The source distribution</param>

--- a/src/Runtime/Factors/Exp.cs
+++ b/src/Runtime/Factors/Exp.cs
@@ -548,6 +548,15 @@ namespace Microsoft.ML.Probabilistic.Factors
     {
         public static int QuadratureNodeCount = 1000;
 
+        public static Gaussian DAverageConditional([SkipIfUniform] GammaPower exp, [Proper] Gaussian d)
+        {
+            double scale = 1 / exp.Power;
+            Gaussian forward = GaussianProductOp.ProductAverageConditional(scale, d);
+            Gaussian message = DAverageConditional(Gamma.FromNatural(exp.Shape - exp.Power, exp.Rate), forward);
+            Gaussian backward = GaussianProductOp.BAverageConditional(message, scale);
+            return backward;
+        }
+
         public static Gaussian DAverageConditional([SkipIfUniform] Gamma exp, [Proper] Gaussian d)
         {
             // as a function of d, the factor is Ga(exp(d); shape, rate) = exp(d*(shape-1) -rate*exp(d))


### PR DESCRIPTION
ExpOp_Slow handles GammaPower messages.
GammaPower implements division by constant.