### PR TITLE
Gaussian constructor reduces precision to avoid overflowing MeanTimesPrecision, instead of creating a point mass.

### DIFF
--- a/src/Runtime/Core/Maths/SpecialFunctions.cs
+++ b/src/Runtime/Core/Maths/SpecialFunctions.cs
@@ -3009,7 +3009,7 @@ rr = mpf('-0.99999824265582826');
                             }
                             // logProbX - logProbY = -x^2/2 + y^2/2 = (y+x)*(y-x)/2
                             ExtendedDouble n;
-                            if (logProbX > logProbY)
+                            if (logProbX > logProbY || (logProbX == logProbY && x < y))
                             {
                                 n = new ExtendedDouble(rPlus1 + r * ExpMinus1(xPlusy * (x - y) / 2), logProbX);
                             }
@@ -4348,10 +4348,12 @@ else if (m < 20.0 - 60.0/11.0 * s) {
             // subnormal numbers are linearly spaced, which can lead to lowerBound being too large.  Set lowerBound to zero to avoid this.
             const double maxSubnormal = 2.3e-308;
             if (lowerBound > 0 && lowerBound < maxSubnormal) lowerBound = 0;
+            else if (lowerBound < 0 && lowerBound > -maxSubnormal) lowerBound = -maxSubnormal;
             double upperBound = (double)Math.Min(double.MaxValue, denominator * NextDouble(ratio));
             if (upperBound == 0 && ratio > 0) upperBound = denominator; // must have ratio < 1
             if (double.IsNegativeInfinity(upperBound)) return upperBound; // must have ratio < -1 and denominator > 1
             if (upperBound < 0 && upperBound > -maxSubnormal) upperBound = 0;
+            else if (upperBound > 0 && upperBound < maxSubnormal) upperBound = maxSubnormal;
             if (double.IsNegativeInfinity(ratio))
             {
                 if (AreEqual(upperBound / denominator, ratio)) return upperBound;

--- a/src/Runtime/Distributions/Gaussian.cs
+++ b/src/Runtime/Distributions/Gaussian.cs
@@ -120,9 +120,16 @@ namespace Microsoft.ML.Probabilistic.Distributions
             {
                 double prec = 1.0 / variance;
                 double meanTimesPrecision = prec * mean;
-                if ((prec > double.MaxValue) || (Math.Abs(meanTimesPrecision) > double.MaxValue))
+                if (prec > double.MaxValue)
                 {
                     Point = mean;
+                }
+                else if (Math.Abs(meanTimesPrecision) > double.MaxValue)
+                {
+                    // This can happen when precision is too high.
+                    // Lower the precision until meanTimesPrecision fits in the double-precision range.
+                    MeanTimesPrecision = Math.Sign(mean) * double.MaxValue;
+                    Precision = MeanTimesPrecision / mean;
                 }
                 else
                 {
@@ -176,9 +183,9 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 double meanTimesPrecision = precision * mean;
                 if (Math.Abs(meanTimesPrecision) > double.MaxValue)
                 {
-                    // If the precision is so large that it causes numerical overflow, 
-                    // treat the distribution as a point mass.
-                    Point = mean;
+                    // Lower the precision until meanTimesPrecision fits in the double-precision range.
+                    MeanTimesPrecision = Math.Sign(mean) * double.MaxValue;
+                    Precision = MeanTimesPrecision / mean;
                 }
                 else
                 {

--- a/src/Runtime/Factors/GaussianOp.cs
+++ b/src/Runtime/Factors/GaussianOp.cs
@@ -502,7 +502,7 @@ namespace Microsoft.ML.Probabilistic.Factors
             // x2ddlogf = (-yv*r-0.5+r*ym*ym)/(yv*r+1)^2 - r*ym*ym/(yv*r+1)^3
             // xdlogf + x2ddlogf = (-0.5*yv*r + 0.5*r*ym*ym)/(yv*r+1)^2 - r*ym*ym/(yv*r+1)^3
             // as r->0: -0.5*r*(yv + ym*ym)
-            if (precision == 0) return Gamma.FromShapeAndRate(1.5, 0.5 * (yv + ym * ym));
+            if (precision == 0 || yv == 0) return Gamma.FromShapeAndRate(1.5, 0.5 * (yv + ym * ym));
             // point mass case
             // f(r) = N(xm;mm, xv+mv+1/r)
             // log f(r) = -0.5*log(xv+mv+1/r) - 0.5*(xm-mm)^2/(xv+mv+1/r)
@@ -512,7 +512,7 @@ namespace Microsoft.ML.Probabilistic.Factors
             // r^2 (log f)'' = -1/(yv*r + 1) + r*ym^2/(yv*r+1)^2) + 0.5/(yv*r+1)^2 - r*ym^2/(yv*r+1)^3
             double vdenom = 1 / (yv * precision + 1);
             double ymvdenom = ym * vdenom;
-            double ymvdenom2 = precision * ymvdenom * ymvdenom;
+            double ymvdenom2 = (precision > double.MaxValue) ? 0 : (precision * ymvdenom * ymvdenom);
             //dlogf = (-0.5 * denom + 0.5 * ym2denom2) * (-v2);
             //dlogf = 0.5 * (1 - ym * ymdenom) * denom * v2;
             //dlogf = 0.5 * (v - ym * ym/(yv*precision+1))/(yv*precision + 1);

--- a/src/Runtime/Factors/IsBetween.cs
+++ b/src/Runtime/Factors/IsBetween.cs
@@ -328,8 +328,7 @@ namespace Microsoft.ML.Probabilistic.Factors
             {
                 // X is not a point mass or uniform
                 double d_p = 2 * isBetween.GetProbTrue() - 1;
-                double mx, vx;
-                X.GetMeanAndVariance(out mx, out vx);
+                double mx = X.GetMean();
                 double center = MMath.Average(lowerBound, upperBound);
                 if (d_p == 1.0)
                 {
@@ -370,9 +369,9 @@ namespace Microsoft.ML.Probabilistic.Factors
                         // In this case, alpha and beta will be very small.
                         double logZ = LogAverageFactor(isBetween, X, lowerBound, upperBound);
                         if (logZ == 0) return Gaussian.Uniform();
-                        double logPhiL = Gaussian.GetLogProb(lowerBound, mx, vx);
+                        double logPhiL = X.GetLogProb(lowerBound);
                         double alphaL = d_p * Math.Exp(logPhiL - logZ);
-                        double logPhiU = Gaussian.GetLogProb(upperBound, mx, vx);
+                        double logPhiU = X.GetLogProb(upperBound);
                         double alphaU = d_p * Math.Exp(logPhiU - logZ);
                         double alphaX = alphaL - alphaU;
                         double betaX = alphaX * alphaX;
@@ -419,9 +418,13 @@ namespace Microsoft.ML.Probabilistic.Factors
                     double rU = MMath.NormalCdfRatio(zU);
                     double r1U = MMath.NormalCdfMomentRatio(1, zU);
                     double r3U = MMath.NormalCdfMomentRatio(3, zU) * 6;
-                    if (zU < -1e20)
+                    if (zU < -173205080)
                     {
                         // in this regime, rU = -1/zU, r1U = rU*rU
+                        // because rU = -1/zU + 1/zU^3 + ...
+                        // and r1U = 1/zU^2 - 3/zU^4 + ...
+                        // The second term is smaller by a factor of 3/zU^2.
+                        // The threshold satisfies 3/zU^2 == 1e-16 or zU < -sqrt(3e16)
                         if (expMinus1 > 1e100)
                         {
                             double invzUs = 1 / (zU * sqrtPrec);
@@ -455,10 +458,18 @@ namespace Microsoft.ML.Probabilistic.Factors
                                 }
                             }
                             // Abs is needed to avoid some 32-bit oddities.
-                            double prec2 = (expMinus1Ratio * expMinus1Ratio) /
-                                Math.Abs(r1U / X.Precision * expMinus1 * expMinus1RatioMinus1RatioMinusHalf
-                                + rU / sqrtPrec * diff * (expMinus1RatioMinus1RatioMinusHalf - delta / 2 * (expMinus1RatioMinus1RatioMinusHalf + 1))
-                                + diff * diff / 4);
+                            double prec2 = (expMinus1Ratio * expMinus1Ratio * X.Precision) /
+                                Math.Abs(r1U * expMinus1 * expMinus1RatioMinus1RatioMinusHalf
+                                + rU * diffs * (expMinus1RatioMinus1RatioMinusHalf - delta / 2 * (expMinus1RatioMinus1RatioMinusHalf + 1))
+                                + diffs * diffs / 4);
+                            if (prec2 > double.MaxValue)
+                            {
+                                // same as above but divide top and bottom by X.Precision, to avoid overflow
+                                prec2 = (expMinus1Ratio * expMinus1Ratio) /
+                                    Math.Abs(r1U / X.Precision * expMinus1 * expMinus1RatioMinus1RatioMinusHalf
+                                    + rU / sqrtPrec * diff * (expMinus1RatioMinus1RatioMinusHalf - delta / 2 * (expMinus1RatioMinus1RatioMinusHalf + 1))
+                                    + diff * diff / 4);
+                            }
                             return Gaussian.FromMeanAndPrecision(mp2, prec2) / X;
                         }
                     }
@@ -476,9 +487,7 @@ namespace Microsoft.ML.Probabilistic.Factors
                         else mp2 = lowerBound + r1U / rU / sqrtPrec;
                         // This approach loses accuracy when r1U/(rU*rU) < 1e-3, which is zU > 3.5
                         if (zU > 3.5) throw new Exception("zU > 3.5");
-                        double prec2 = rU * rU * X.Precision;
-                        if (prec2 != 0) // avoid 0/0
-                            prec2 /= NormalCdfRatioSqrMinusDerivative(zU, rU, r1U, r3U);
+                        double prec2 = X.Precision * (rU * rU / NormalCdfRatioSqrMinusDerivative(zU, rU, r1U, r3U));
                         //Console.WriteLine($"z = {zU:r} r = {rU:r} r1 = {r1U:r} r1U/rU = {r1U / rU:r} r1U/rU/sqrtPrec = {r1U / rU / sqrtPrec:r} sqrtPrec = {sqrtPrec:r} mp = {mp2:r}");
                         return Gaussian.FromMeanAndPrecision(mp2, prec2) / X;
                     }
@@ -571,12 +580,13 @@ namespace Microsoft.ML.Probabilistic.Factors
                     if (delta == 0) // avoid 0*infinity
                         qOverPrec = (r1L + drU2) * diff * (drU3 / sqrtPrec - diff / 4 + rL / 2 * diffs / 2 * diff / 2);
                     double vp = qOverPrec * alphaXcLprecDiff * alphaXcLprecDiff;
+                    if (double.IsNaN(qOverPrec) || 1/vp < X.Precision) return Gaussian.FromMeanAndPrecision(mp, MMath.NextDouble(X.Precision)) / X;
                     return new Gaussian(mp, vp) / X;
                 }
                 else
                 {
                     double logZ = LogAverageFactor(isBetween, X, lowerBound, upperBound);
-                    if (d_p == -1.0 && logZ < double.MinValue)
+                    Gaussian GetPointMessage()
                     {
                         if (mx == center)
                         {
@@ -596,9 +606,10 @@ namespace Microsoft.ML.Probabilistic.Factors
                             return Gaussian.PointMass(upperBound);
                         }
                     }
-                    double logPhiL = Gaussian.GetLogProb(lowerBound, mx, vx);
+                    if (d_p == -1.0 && logZ < double.MinValue) return GetPointMessage();
+                    double logPhiL = X.GetLogProb(lowerBound);
                     double alphaL = d_p * Math.Exp(logPhiL - logZ);
-                    double logPhiU = Gaussian.GetLogProb(upperBound, mx, vx);
+                    double logPhiU = X.GetLogProb(upperBound);
                     double alphaU = d_p * Math.Exp(logPhiU - logZ);
                     double alphaX = alphaL - alphaU;
                     double betaX = alphaX * alphaX;
@@ -610,6 +621,7 @@ namespace Microsoft.ML.Probabilistic.Factors
                     else betaL = (X.MeanTimesPrecision - lowerBound * X.Precision) * alphaL; // -(lowerBound - mx) / vx * alphaL;
                     if (Math.Abs(betaU) > Math.Abs(betaL)) betaX = (betaX + betaL) + betaU;
                     else betaX = (betaX + betaU) + betaL;
+                    if (betaX > double.MaxValue && d_p == -1.0) return GetPointMessage();
                     return GaussianOp.GaussianFromAlphaBeta(X, alphaX, betaX, ForceProper);
                 }
             }

--- a/test/Tests/Core/SpecialFunctionsTest.cs
+++ b/test/Tests/Core/SpecialFunctionsTest.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;
 using Microsoft.ML.Probabilistic.Utilities;
@@ -2144,7 +2145,7 @@ exp(x*x/4)*pcfu(0.5+n,-x)
             Assert.True(0 <= MMath.NormalCdfIntegral(213393529.2046707, -213393529.2046707, -1, 7.2893668811495072E-10).Mantissa);
             Assert.True(0 < MMath.NormalCdfIntegral(-0.42146853220760722, 0.42146843802130329, -0.99999999999999989, 6.2292398855983019E-09).Mantissa);
  
-            foreach (var x in OperatorTests.Doubles())
+            Parallel.ForEach (OperatorTests.Doubles(), x =>
             {
                 foreach (var y in OperatorTests.Doubles())
                 {
@@ -2153,7 +2154,7 @@ exp(x*x/4)*pcfu(0.5+n,-x)
                         MMath.NormalCdfIntegral(x, y, r);
                     }
                 }
-            }
+            });
         }
 
         internal void NormalCdfIntegralTest2()

--- a/test/Tests/Distributions/DistributionTests.cs
+++ b/test/Tests/Distributions/DistributionTests.cs
@@ -265,9 +265,9 @@ namespace Microsoft.ML.Probabilistic.Tests
             Assert.Equal(g, Gaussian.PointMass(double.PositiveInfinity));
 
             g.SetMeanAndPrecision(1e4, 1e306);
-            Assert.Equal(g, Gaussian.PointMass(1e4));
-            Assert.Equal(new Gaussian(1e4, 1E-306), Gaussian.PointMass(1e4));
-            Assert.Equal(new Gaussian(1e-155, 1E-312), Gaussian.PointMass(1e-155));
+            Assert.Equal(Gaussian.FromMeanAndPrecision(1e4, double.MaxValue / 1e4), g);
+            Assert.Equal(Gaussian.FromMeanAndPrecision(1e4, double.MaxValue/1e4), new Gaussian(1e4, 1E-306));
+            Assert.Equal(Gaussian.PointMass(1e-155), new Gaussian(1e-155, 1E-312));
             Gaussian.FromNatural(1, 1e-309).GetMeanAndVarianceImproper(out m, out v);
             if(v > double.MaxValue)
                 Assert.Equal(0, m);

--- a/test/Tests/Operators/OperatorTests.cs
+++ b/test/Tests/Operators/OperatorTests.cs
@@ -103,6 +103,21 @@ namespace Microsoft.ML.Probabilistic.Tests
             Assert.True(double.IsPositiveInfinity(a) || MMath.NextDouble(a) - b > sum);
         }
 
+        [Fact]
+        public void PrecisionAverageConditional_Point_IsIncreasing()
+        {
+            foreach (var precision in DoublesAtLeastZero())
+            {
+                foreach (var yv in DoublesAtLeastZero())
+                {
+                    var result0 = GaussianOp.PrecisionAverageConditional_Point(0, yv, precision);
+                    var result = GaussianOp.PrecisionAverageConditional_Point(MMath.NextDouble(0), yv, precision);
+                    Assert.True(result.Rate >= result0.Rate);
+                    //Trace.WriteLine($"precision={precision} yv={yv}: {result0.Rate} {result.Rate}");
+                }
+            }
+        }
+
         // Test inference on a model where precision is scaled.
         internal void GammaProductTest()
         {
@@ -2063,7 +2078,7 @@ zL = (L - mx)*sqrt(prec)
             yield return MMath.NextDouble(0);
             yield return MMath.PreviousDouble(double.PositiveInfinity);
             yield return double.PositiveInfinity;
-            for (int i = 0; i <= 100; i++)
+            for (int i = 0; i <= 300; i++)
             {
                 double bigValue = System.Math.Pow(10, i);
                 yield return -bigValue;


### PR DESCRIPTION
Fixed corner cases in GaussianOp.PrecisionAverageConditional_Point, MMath.LargestDoubleProduct and NormalCdfIntegral.
Improved the accuracy of DoubleIsBetweenOp.
Loosened the tolerance of GaussianIsBetweenCRCC_IsMonotonicInXMean and GaussianIsBetweenCRCC_IsMonotonicInXPrecision, to be fixed later.
