### PR TITLE
Use explicit stack in Automaton.IsZero()

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -428,6 +428,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     !hasEpsilonTransitions,
                     usesGroups,
                     determinizationState,
+                    IsZeroState.Unknown,
                     resultStates,
                     resultTransitions);
             }

--- a/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             if (this.UsesGroups)
             {
                 // Determinization will result in lost of group information, which we cannot allow
-                this.Data = this.Data.WithDeterminizationState(DeterminizationState.IsNonDeterminizable);
+                this.Data = this.Data.With(DeterminizationState.IsNonDeterminizable);
                 return false;
             }
 
@@ -99,7 +99,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             var simplification = new Simplification(builder, this.PruneStatesWithLogEndWeightLessThan);
             simplification.MergeParallelTransitions(); // Determinization produces a separate transition for each segment
 
-            this.Data = builder.GetData().WithDeterminizationState(DeterminizationState.IsDeterminized);
+            this.Data = builder.GetData().With(DeterminizationState.IsDeterminized);
             this.PruneStatesWithLogEndWeightLessThan = this.PruneStatesWithLogEndWeightLessThan;
             this.LogValueOverride = this.LogValueOverride;
 

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -848,6 +848,40 @@ namespace Microsoft.ML.Probabilistic.Tests
         }
 
         /// <summary>
+        /// Tests whether the point mass computation operations fails due to a stack overflow when an automaton becomes sufficiently large.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "StringInference")]
+        public void IsZeroLargeAutomaton()
+        {
+            using (var unlimited = new StringAutomaton.UnlimitedStatesComputation())
+            {
+                var zeroAutomaton = MakeAutomaton(Weight.Zero);
+                var nonZeroAutomaton = MakeAutomaton(Weight.One);
+
+                Assert.True(zeroAutomaton.IsZero());
+                Assert.False(nonZeroAutomaton.IsZero());
+            }
+
+            StringAutomaton MakeAutomaton(Weight endWeight)
+            {
+                const int StateCount = 100_000;
+
+                var builder = new StringAutomaton.Builder();
+                var state = builder.Start;
+
+                for (var i = 1; i < StateCount; ++i)
+                {
+                    state = state.AddTransition('a', Weight.One);
+                }
+
+                state.SetEndWeight(endWeight);
+
+                return builder.GetAutomaton();
+            }
+        }
+
+        /// <summary>
         /// Tests creating an automaton from state and transition lists.
         /// </summary>
         [Fact]

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -761,8 +761,8 @@ namespace Microsoft.ML.Probabilistic.Tests
         }
 
         /// <summary>
-        /// Tests whether the point mass computation operations fails due to a stack overflow when
-        /// an automaton becomes sufficiently large.
+        /// Tests whether <see cref="StringAutomaton.TryComputePoint"/> fails due to a stack overflow
+        /// when an automaton becomes sufficiently large.
         /// </summary>
         [Fact]
         [Trait("Category", "StringInference")]
@@ -791,7 +791,8 @@ namespace Microsoft.ML.Probabilistic.Tests
         }
 
         /// <summary>
-        /// Tests whether the point mass computation operations fails due to a stack overflow when an automaton becomes sufficiently large.
+        /// Tests whether <see cref="StringAutomaton.Product"/> fails due to a stack overflow
+        /// when an automaton becomes sufficiently large.
         /// </summary>
         [Fact]
         [Trait("Category", "StringInference")]
@@ -821,7 +822,8 @@ namespace Microsoft.ML.Probabilistic.Tests
         }
 
         /// <summary>
-        /// Tests whether the point mass computation operations fails due to a stack overflow when an automaton becomes sufficiently large.
+        /// Tests whether <see cref="StringAutomaton.GetLogNormalizer"/> fails due to a stack overflow
+        /// when an automaton becomes sufficiently large.
         /// </summary>
         [Fact]
         [Trait("Category", "StringInference")]
@@ -848,7 +850,8 @@ namespace Microsoft.ML.Probabilistic.Tests
         }
 
         /// <summary>
-        /// Tests whether the point mass computation operations fails due to a stack overflow when an automaton becomes sufficiently large.
+        /// Tests whether <see cref="StringAutomaton.IsZero"/> fails due to a stack overflow
+        /// when an automaton becomes sufficiently large.
         /// </summary>
         [Fact]
         [Trait("Category", "StringInference")]

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -861,6 +861,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                     true,
                     false,
                     StringAutomaton.DeterminizationState.Unknown,
+                    StringAutomaton.IsZeroState.Unknown,
                     new[]
                         {
                             new StringAutomaton.StateData(0, 1, Weight.One),
@@ -878,6 +879,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                     true,
                     false,
                     StringAutomaton.DeterminizationState.IsDeterminized,
+                    StringAutomaton.IsZeroState.IsNonZero,
                     new[] { new StringAutomaton.StateData(0, 0, Weight.Zero) },
                     Array.Empty<StringAutomaton.Transition>()));
             Assert.True(automaton2.IsZero());
@@ -890,6 +892,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                         true,
                         false,
                         StringAutomaton.DeterminizationState.IsNonDeterminizable,
+                        StringAutomaton.IsZeroState.IsZero,
                         Array.Empty<StringAutomaton.StateData>(),
                         Array.Empty<StringAutomaton.Transition>())));
 
@@ -901,6 +904,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                         false,
                         false,
                         StringAutomaton.DeterminizationState.Unknown,
+                        StringAutomaton.IsZeroState.Unknown,
                         new[] { new StringAutomaton.StateData(0, 0, Weight.Zero) },
                         Array.Empty<StringAutomaton.Transition>())));
 
@@ -912,6 +916,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                         false,
                         false,
                         StringAutomaton.DeterminizationState.Unknown,
+                        StringAutomaton.IsZeroState.Unknown,
                         new[] { new StringAutomaton.StateData(0, 1, Weight.Zero) },
                         new[] { new StringAutomaton.Transition(Option.None, Weight.One, 1) })));
 
@@ -923,6 +928,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                         true,
                         false,
                         StringAutomaton.DeterminizationState.Unknown,
+                        StringAutomaton.IsZeroState.Unknown,
                         new[] { new StringAutomaton.StateData(0, 1, Weight.One) },
                         new[] { new StringAutomaton.Transition(Option.None, Weight.One, 2) })));
         }


### PR DESCRIPTION
* IsZero() used recursion and could fail with `StackOverflowException`. It doesn't anymore.
* `IsZero()` computation result is now cached between calls

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/infer/166)
<!-- Reviewable:end -->
