### PR TITLE
Replace custom enums with bool?

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -378,8 +378,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// Stores built automaton in pre-allocated <see cref="Automaton{TSequence,TElement,TElementDistribution,TSequenceManipulator,TThis}"/> object.
             /// </summary>
-            public DataContainer GetData(
-                DeterminizationState determinizationState = DeterminizationState.Unknown)
+            public DataContainer GetData(bool? isDeterminized = null)
             {
                 if (this.StartStateIndex < 0 || this.StartStateIndex >= this.states.Count)
                 {
@@ -425,12 +424,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
                 return new DataContainer(
                     this.StartStateIndex,
+                    resultStates,
+                    resultTransitions,
                     !hasEpsilonTransitions,
                     usesGroups,
-                    determinizationState,
-                    IsZeroState.Unknown,
-                    resultStates,
-                    resultTransitions);
+                    isDeterminized,
+                    isZero: null);
             }
 
             #endregion

--- a/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
@@ -99,11 +99,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             }
 
             public DataContainer With(
-                bool? isDetermenized = null,
+                bool? isDeterminized = null,
                 bool? isZero= null)
             {
                 // Can't overwrite known properties
-                Debug.Assert(isDetermenized.HasValue != this.IsDeterminized.HasValue || isDetermenized == this.IsDeterminized);
+                Debug.Assert(isDeterminized.HasValue != this.IsDeterminized.HasValue || isDeterminized == this.IsDeterminized);
                 Debug.Assert(isZero.HasValue != this.IsZero.HasValue || isZero == this.IsZero);
 
                 return new DataContainer(
@@ -112,7 +112,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     this.Transitions,
                     this.IsEpsilonFree,
                     this.UsesGroups,
-                    isDetermenized ?? this.IsDeterminized,
+                    isDeterminized ?? this.IsDeterminized,
                     isZero ?? this.IsZero);
             }
 

--- a/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
@@ -53,22 +53,25 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// Gets value indicating whether this automaton is determinized
             /// </summary>
-            public DeterminizationState DeterminizationState =>
-                ((this.flags & Flags.DeterminizationStateKnown) == 0)
-                    ? DeterminizationState.Unknown
-                    : ((this.flags & Flags.IsDeterminized) != 0
-                        ? DeterminizationState.IsDeterminized
-                        : DeterminizationState.IsNonDeterminizable);
+            /// <remarks>
+            /// Null value means that this property is unknown.
+            /// False value means that this automaton can not be determinized
+            /// </remarks>
+            public bool? IsDeterminized =>
+                (this.flags & Flags.DeterminizationStateKnown) != 0
+                    ? (this.flags & Flags.IsDeterminized) != 0
+                    : (bool?)null;
 
             /// <summary>
             /// Gets value indicating whether this automaton is zero
             /// </summary>
-            public IsZeroState IsZeroState =>
-                ((this.flags & Flags.IsZeroStateKnown) == 0)
-                    ? IsZeroState.Unknown
-                    : ((this.flags & Flags.IsZero) != 0
-                        ? IsZeroState.IsZero
-                        : IsZeroState.IsNonZero);
+            /// <remarks>
+            /// Null value means that this property is unknown.
+            /// </remarks>
+            public bool? IsZero =>
+                ((this.flags & Flags.IsZeroStateKnown) != 0)
+                    ? (this.flags & Flags.IsZero) != 0
+                    : (bool?)null;
 
             /// <summary>
             /// Initializes instance of <see cref="DataContainer"/>.
@@ -76,38 +79,41 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             [Construction("StartStateIndex", "IsEpsilonFree", "UsesGroups", "DeterminizationState", "IsZeroState", "States", "Transitions")]
             public DataContainer(
                 int startStateIndex,
+                ReadOnlyArray<StateData> states,
+                ReadOnlyArray<Transition> transitions,
                 bool isEpsilonFree,
                 bool usesGroups,
-                DeterminizationState determinizationState,
-                IsZeroState isZeroState,
-                ReadOnlyArray<StateData> states,
-                ReadOnlyArray<Transition> transitions)
+                bool? isDeterminized,
+                bool? isZero)
             {
                 this.flags =
                     (isEpsilonFree ? Flags.IsEpsilonFree : 0) |
                     (usesGroups ? Flags.UsesGroups : 0) |
-                    (determinizationState != DeterminizationState.Unknown ? Flags.DeterminizationStateKnown : 0) |
-                    (determinizationState == DeterminizationState.IsDeterminized ? Flags.IsDeterminized : 0) |
-                    (isZeroState != IsZeroState.Unknown ? Flags.IsZeroStateKnown : 0) |
-                    (isZeroState == IsZeroState.IsZero ? Flags.IsZero : 0);
+                    (isDeterminized.HasValue ? Flags.DeterminizationStateKnown : 0) |
+                    (isDeterminized == true ? Flags.IsDeterminized : 0) |
+                    (isZero.HasValue ? Flags.IsZeroStateKnown : 0) |
+                    (isZero == true ? Flags.IsZero : 0);
                 this.StartStateIndex = startStateIndex;
                 this.States = states;
                 this.Transitions = transitions;
             }
 
             public DataContainer With(
-                DeterminizationState? determinizationState = null,
-                IsZeroState? isZeroState = null)
+                bool? isDetermenized = null,
+                bool? isZero= null)
             {
-                Debug.Assert(this.DeterminizationState == DeterminizationState.Unknown);
+                // Can't overwrite known properties
+                Debug.Assert(isDetermenized.HasValue != this.IsDeterminized.HasValue || isDetermenized == this.IsDeterminized);
+                Debug.Assert(isZero.HasValue != this.IsZero.HasValue || isZero == this.IsZero);
+
                 return new DataContainer(
                     this.StartStateIndex,
+                    this.States,
+                    this.Transitions,
                     this.IsEpsilonFree,
                     this.UsesGroups,
-                    determinizationState ?? this.DeterminizationState,
-                    isZeroState ?? this.IsZeroState,
-                    this.States,
-                    this.Transitions);
+                    isDetermenized ?? this.IsDeterminized,
+                    isZero ?? this.IsZero);
             }
 
             /// <summary>
@@ -189,20 +195,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 IsZeroStateKnown = 0x10,
                 IsZero = 0x20,
             }
-        }
-
-        public enum DeterminizationState
-        {
-            Unknown,
-            IsDeterminized,
-            IsNonDeterminizable,
-        }
-
-        public enum IsZeroState
-        {
-            Unknown,
-            IsZero,
-            IsNonZero,
         }
     }
 }

--- a/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
@@ -76,7 +76,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// Initializes instance of <see cref="DataContainer"/>.
             /// </summary>
-            [Construction("StartStateIndex", "IsEpsilonFree", "UsesGroups", "DeterminizationState", "IsZeroState", "States", "Transitions")]
+            [Construction("StartStateIndex", "States", "Transitions", "IsEpsilonFree", "UsesGroups", "IsDeterminized", "IsZero")]
             public DataContainer(
                 int startStateIndex,
                 ReadOnlyArray<StateData> states,

--- a/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             if (this.UsesGroups)
             {
                 // Determinization will result in lost of group information, which we cannot allow
-                this.Data = this.Data.With(isDetermenized: false);
+                this.Data = this.Data.With(isDeterminized: false);
                 return false;
             }
 
@@ -87,7 +87,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
                     if (!EnqueueOutgoingTransitions(currentWeightedStateSet))
                     {
-                        this.Data = this.Data.With(isDetermenized: false);
+                        this.Data = this.Data.With(isDeterminized: false);
                         return false;
                     }
                 }
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             var simplification = new Simplification(builder, this.PruneStatesWithLogEndWeightLessThan);
             simplification.MergeParallelTransitions(); // Determinization produces a separate transition for each segment
 
-            this.Data = builder.GetData().With(isDetermenized: true);
+            this.Data = builder.GetData().With(isDeterminized: true);
             this.PruneStatesWithLogEndWeightLessThan = this.PruneStatesWithLogEndWeightLessThan;
             this.LogValueOverride = this.LogValueOverride;
 
@@ -153,8 +153,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             }
 
             // Checks that all transitions from state end up in the same destination. This is used
-            // as a very fast "is determenistic" check, that doesn't care about distributions.
-            // State can have determenistic transitions with different destinations. This case will be
+            // as a very fast "is deterministic" check, that doesn't care about distributions.
+            // State can have deterministic transitions with different destinations. This case will be
             // handled by slow path.
             bool AllDestinationsAreSame(int stateIndex)
             {

--- a/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
@@ -32,9 +32,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <remarks>See <a href="http://www.cs.nyu.edu/~mohri/pub/hwa.pdf"/> for algorithm details.</remarks>
         public bool TryDeterminize()
         {
-            if (this.Data.DeterminizationState != DeterminizationState.Unknown)
+            if (this.Data.IsDeterminized != null)
             {
-                return this.Data.DeterminizationState == DeterminizationState.IsDeterminized;
+                return this.Data.IsDeterminized == true;
             }
 
             int maxStatesBeforeStop = Math.Min(this.States.Count * 3, MaxStateCount);
@@ -44,7 +44,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             if (this.UsesGroups)
             {
                 // Determinization will result in lost of group information, which we cannot allow
-                this.Data = this.Data.With(DeterminizationState.IsNonDeterminizable);
+                this.Data = this.Data.With(isDetermenized: false);
                 return false;
             }
 
@@ -87,6 +87,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
                     if (!EnqueueOutgoingTransitions(currentWeightedStateSet))
                     {
+                        this.Data = this.Data.With(isDetermenized: false);
                         return false;
                     }
                 }
@@ -99,7 +100,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             var simplification = new Simplification(builder, this.PruneStatesWithLogEndWeightLessThan);
             simplification.MergeParallelTransitions(); // Determinization produces a separate transition for each segment
 
-            this.Data = builder.GetData().With(DeterminizationState.IsDeterminized);
+            this.Data = builder.GetData().With(isDetermenized: true);
             this.PruneStatesWithLogEndWeightLessThan = this.PruneStatesWithLogEndWeightLessThan;
             this.LogValueOverride = this.LogValueOverride;
 

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -1007,14 +1007,14 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public bool IsZero()
         {
             // Return cached value if available
-            if (this.Data.IsZeroState != IsZeroState.Unknown)
+            if (this.Data.IsZero.HasValue)
             {
-                return this.Data.IsZeroState == IsZeroState.IsZero;
+                return this.Data.IsZero.Value;
             }
 
             // Calculate and cache whether this automaton is zero
             var isZero = DoIsZero();
-            this.Data = this.Data.With(isZeroState: isZero ? IsZeroState.IsZero : IsZeroState.IsNonZero);
+            this.Data = this.Data.With(isZero: isZero);
             return isZero;
 
             bool DoIsZero()
@@ -1427,11 +1427,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             simplification.RemoveDeadStates(); // Product can potentially create dead states
             simplification.SimplifyIfNeeded();
 
-            var bothInputsDeterminized =
-                automaton1.Data.DeterminizationState == DeterminizationState.IsDeterminized &&
-                automaton2.Data.DeterminizationState == DeterminizationState.IsDeterminized;
-            var determinizationState =
-                bothInputsDeterminized ? DeterminizationState.IsDeterminized : DeterminizationState.Unknown;
+            var bothInputsDeterminized = automaton1.Data.IsDeterminized == true && automaton2.Data.IsDeterminized == true;
+            var determinizationState = bothInputsDeterminized ? (bool?)true : null;
 
             this.Data = builder.GetData(determinizationState);
             if (this is StringAutomaton && tryDeterminize)
@@ -1627,7 +1624,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public void SetToZero()
         {
             this.Data = new DataContainer(
-                0, true, false, DeterminizationState.IsDeterminized, IsZeroState.IsZero, ZeroStates, ZeroTransitions);
+                0,
+                ZeroStates,
+                ZeroTransitions,
+                isEpsilonFree: true,
+                usesGroups: false,
+                isDeterminized: true,
+                isZero: true);
         }
 
         /// <summary>

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -895,16 +895,16 @@ namespace Microsoft.ML.Probabilistic.Tests
             var automaton1 = StringAutomaton.FromData(
                 new StringAutomaton.DataContainer(
                     0,
-                    true,
-                    false,
-                    StringAutomaton.DeterminizationState.Unknown,
-                    StringAutomaton.IsZeroState.Unknown,
                     new[]
-                        {
-                            new StringAutomaton.StateData(0, 1, Weight.One),
-                            new StringAutomaton.StateData(1, 0, Weight.One),
-                        },
-                    new[] { new StringAutomaton.Transition(DiscreteChar.PointMass('a'), Weight.One, 1) }));
+                    {
+                        new StringAutomaton.StateData(0, 1, Weight.One),
+                        new StringAutomaton.StateData(1, 0, Weight.One),
+                    },
+                    new[] { new StringAutomaton.Transition(DiscreteChar.PointMass('a'), Weight.One, 1) },
+                    isEpsilonFree: true,
+                    usesGroups: false,
+                    isDeterminized: null,
+                    isZero: null));
 
             StringInferenceTestUtilities.TestValue(automaton1, 1.0, string.Empty, "a");
             StringInferenceTestUtilities.TestValue(automaton1, 0.0, "b");
@@ -913,12 +913,12 @@ namespace Microsoft.ML.Probabilistic.Tests
             var automaton2 = StringAutomaton.FromData(
                 new StringAutomaton.DataContainer(
                     0,
-                    true,
-                    false,
-                    StringAutomaton.DeterminizationState.IsDeterminized,
-                    StringAutomaton.IsZeroState.IsNonZero,
                     new[] { new StringAutomaton.StateData(0, 0, Weight.Zero) },
-                    Array.Empty<StringAutomaton.Transition>()));
+                    Array.Empty<StringAutomaton.Transition>(),
+                    isEpsilonFree: true,
+                    usesGroups: false,
+                    isDeterminized: true,
+                    isZero: true));
             Assert.True(automaton2.IsZero());
 
             // Bad start state index
@@ -926,48 +926,48 @@ namespace Microsoft.ML.Probabilistic.Tests
                 () => StringAutomaton.FromData(
                     new StringAutomaton.DataContainer(
                         0,
-                        true,
-                        false,
-                        StringAutomaton.DeterminizationState.IsNonDeterminizable,
-                        StringAutomaton.IsZeroState.IsZero,
                         Array.Empty<StringAutomaton.StateData>(),
-                        Array.Empty<StringAutomaton.Transition>())));
+                        Array.Empty<StringAutomaton.Transition>(),
+                        isEpsilonFree: true,
+                        usesGroups: false,
+                        isDeterminized: false,
+                        isZero: true)));
 
             // automaton is actually epsilon-free, but data says that it is
             Assert.Throws<ArgumentException>(
                 () => StringAutomaton.FromData(
                     new StringAutomaton.DataContainer(
                         0,
-                        false,
-                        false,
-                        StringAutomaton.DeterminizationState.Unknown,
-                        StringAutomaton.IsZeroState.Unknown,
                         new[] { new StringAutomaton.StateData(0, 0, Weight.Zero) },
-                        Array.Empty<StringAutomaton.Transition>())));
+                        Array.Empty<StringAutomaton.Transition>(),
+                        isEpsilonFree: false,
+                        usesGroups: false,
+                        isDeterminized: null,
+                        isZero: null)));
 
             // automaton is not epsilon-free
             Assert.Throws<ArgumentException>(
                 () => StringAutomaton.FromData(
                     new StringAutomaton.DataContainer(
                         0,
-                        false,
-                        false,
-                        StringAutomaton.DeterminizationState.Unknown,
-                        StringAutomaton.IsZeroState.Unknown,
                         new[] { new StringAutomaton.StateData(0, 1, Weight.Zero) },
-                        new[] { new StringAutomaton.Transition(Option.None, Weight.One, 1) })));
+                        new[] { new StringAutomaton.Transition(Option.None, Weight.One, 1) },
+                        isEpsilonFree: false,
+                        usesGroups: false,
+                        isDeterminized: null,
+                        isZero: null)));
 
             // Incorrect transition index
             Assert.Throws<ArgumentException>(
                 () => StringAutomaton.FromData(
                     new StringAutomaton.DataContainer(
                         0,
+                        new[] { new StringAutomaton.StateData(0, 1, Weight.One) },
+                        new[] { new StringAutomaton.Transition(Option.None, Weight.One, 2) },
                         true,
                         false,
-                        StringAutomaton.DeterminizationState.Unknown,
-                        StringAutomaton.IsZeroState.Unknown,
-                        new[] { new StringAutomaton.StateData(0, 1, Weight.One) },
-                        new[] { new StringAutomaton.Transition(Option.None, Weight.One, 2) })));
+                        isDeterminized: null,
+                        isZero: null)));
         }
 
         #region ToString tests


### PR DESCRIPTION
bool? can represent exactly 3 states we need for caching bool computations.

* As a byproduct, `Debug.Assert()` condition in `Automaton.DataContainer.With` was fixed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/infer/167)
<!-- Reviewable:end -->
