### PR TITLE
Remove wrong Debug.Assert()

### DIFF
--- a/src/Runtime/Distributions/Automata/StringAutomaton.cs
+++ b/src/Runtime/Distributions/Automata/StringAutomaton.cs
@@ -104,7 +104,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 else
                 {
                     Debug.Assert(currentSegmentStateWeights.ContainsKey(segmentBound.DestinationStateId), "We shouldn't exit a state we didn't enter.");
-                    Debug.Assert(!segmentBound.Weight.IsInfinity);
                     currentSegmentTotal -= segmentBound.Weight;
 
                     var prevStateWeight = currentSegmentStateWeights[segmentBound.DestinationStateId];

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -1972,7 +1972,6 @@ namespace Microsoft.ML.Probabilistic.Tests
         /// </summary>
         [Fact]
         [Trait("Category", "StringInference")]
-        [Trait("Category", "OpenBug")]
         public void Determinize10()
         {
             var builder = new StringAutomaton.Builder();


### PR DESCRIPTION
String automaton determinization supports infinite weights.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/infer/168)
<!-- Reviewable:end -->
