### PR TITLE
Gaussian.GetLogProb is more accurate for large precision

### DIFF
--- a/src/Runtime/Core/Maths/SpecialFunctions.cs
+++ b/src/Runtime/Core/Maths/SpecialFunctions.cs
@@ -4365,8 +4365,10 @@ else if (m < 20.0 - 60.0/11.0 * s) {
                 else upperBound = (double)Math.Min(double.MaxValue, denominator * NextDouble(ratio));
                 if (double.IsNegativeInfinity(upperBound)) return upperBound; // must have ratio < -1 and denominator > 1
             }
+            int iterCount = 0;
             while (true)
             {
+                iterCount++;
                 double value = (double)Average(lowerBound, upperBound);
                 if (value < lowerBound || value > upperBound) throw new Exception($"value={value:r}, lowerBound={lowerBound:r}, upperBound={upperBound:r}, denominator={denominator:r}, ratio={ratio:r}");
                 if ((double)(value / denominator) <= ratio)
@@ -4374,6 +4376,9 @@ else if (m < 20.0 - 60.0/11.0 * s) {
                     double value2 = NextDouble(value);
                     if (value2 == value || (double)(value2 / denominator) > ratio)
                     {
+                        // Used for performance debugging
+                        //if (iterCount > 100)
+                        //    throw new Exception();
                         return value;
                     }
                     else
@@ -4421,18 +4426,19 @@ else if (m < 20.0 - 60.0/11.0 * s) {
             {
                 upperBound = NextDouble(b) + sum;
             }
-            long iterCount = 0;
+            int iterCount = 0;
             while (true)
             {
                 iterCount++;
-                double value = Average(lowerBound, upperBound);
+                double value = (double)Average(lowerBound, upperBound);
                 //double value = RepresentationMidpoint(lowerBound, upperBound);
                 if (value < lowerBound || value > upperBound) throw new Exception($"value={value:r}, lowerBound={lowerBound:r}, upperBound={upperBound:r}, b={b:r}, sum={sum:r}");
-                if (value - b <= sum)
+                if ((double)(value - b) <= sum)
                 {
                     double value2 = NextDouble(value);
-                    if (value2 == value || value2 - b > sum)
+                    if (value2 == value || (double)(value2 - b) > sum)
                     {
+                        // Used for performance debugging
                         //if (iterCount > 100)
                         //    throw new Exception();
                         return value;

--- a/src/Runtime/Distributions/Gaussian.cs
+++ b/src/Runtime/Distributions/Gaussian.cs
@@ -415,7 +415,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 // This approach avoids rounding errors.
                 // (x - mean)^2 * Precision = (x*Precision - MeanTimesPrecision)^2/Precision
                 double diff = x * Precision - MeanTimesPrecision;
-                return 0.5 * (Math.Log(Precision) - diff * diff / Precision) - MMath.LnSqrt2PI;
+                return 0.5 * (Math.Log(Precision) - diff * (diff / Precision)) - MMath.LnSqrt2PI;
             }
             else
             {

--- a/src/Runtime/Factors/IsBetween.cs
+++ b/src/Runtime/Factors/IsBetween.cs
@@ -330,9 +330,9 @@ namespace Microsoft.ML.Probabilistic.Factors
                 double d_p = 2 * isBetween.GetProbTrue() - 1;
                 double mx = X.GetMean();
                 double center = MMath.Average(lowerBound, upperBound);
+                double diff = upperBound - lowerBound;
                 if (d_p == 1.0)
                 {
-                    double diff = upperBound - lowerBound;
                     double sqrtPrec = Math.Sqrt(X.Precision);
                     double diffs = diff * sqrtPrec;
                     // X.Prob(U) = X.Prob(L) * exp(delta)
@@ -592,7 +592,6 @@ namespace Microsoft.ML.Probabilistic.Factors
                         {
                             // The posterior is two point masses.
                             // Compute the moment-matched Gaussian and divide.
-                            double diff = upperBound - lowerBound;
                             Gaussian result = Gaussian.FromMeanAndVariance(center, diff * diff / 4);
                             result.SetToRatio(result, X, ForceProper);
                             return result;
@@ -621,7 +620,11 @@ namespace Microsoft.ML.Probabilistic.Factors
                     else betaL = (X.MeanTimesPrecision - lowerBound * X.Precision) * alphaL; // -(lowerBound - mx) / vx * alphaL;
                     if (Math.Abs(betaU) > Math.Abs(betaL)) betaX = (betaX + betaL) + betaU;
                     else betaX = (betaX + betaU) + betaL;
-                    if (betaX > double.MaxValue && d_p == -1.0) return GetPointMessage();
+                    if (Math.Abs(betaX) > double.MaxValue)
+                    {
+                        if (d_p == -1.0) return GetPointMessage();
+                        else return Gaussian.Uniform();
+                    }
                     return GaussianOp.GaussianFromAlphaBeta(X, alphaX, betaX, ForceProper);
                 }
             }

--- a/test/TestApp/TestApp.csproj
+++ b/test/TestApp/TestApp.csproj
@@ -58,6 +58,10 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseFull|AnyCPU'">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Compiler\Compiler.csproj" />
     <ProjectReference Include="..\..\src\Csoft\Csoft.csproj" />

--- a/test/Tests/Operators/OperatorTests.cs
+++ b/test/Tests/Operators/OperatorTests.cs
@@ -57,6 +57,9 @@ namespace Microsoft.ML.Probabilistic.Tests
         [Fact]
         public void LargestDoubleProductTest2()
         {
+            // This case needs 50 iterations
+            MMath.LargestDoubleProduct(1.7976931348623157E+308, 9.8813129168249309E-324);
+            MMath.LargestDoubleProduct(1.7976931348623157E+308, -4.94065645841247E-324);
             MMath.LargestDoubleProduct(1.0000000000000005E-09, 1.0000000000000166E-300);
             MMath.LargestDoubleProduct(1.0000000000000005E-09, -1.0000000000000166E-300);
             MMath.LargestDoubleProduct(0.00115249439895759, 4.9187693503017E-319);

--- a/test/Tests/Operators/OperatorTests.cs
+++ b/test/Tests/Operators/OperatorTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         private void AssertLargestDoubleSum(double b, double sum)
         {
             double a = MMath.LargestDoubleSum(b, sum);
-            Assert.True(a - b <= sum);
+            Assert.True((double)(a - b) <= sum);
             Assert.True(double.IsPositiveInfinity(a) || MMath.NextDouble(a) - b > sum);
         }
 
@@ -2174,7 +2174,7 @@ zL = (L - mx)*sqrt(prec)
                         if (double.IsNegativeInfinity(lowerBound) && double.IsPositiveInfinity(upperBound))
                             center = 0;
                         if (double.IsInfinity(center)) continue;
-                        foreach (var x in Gaussians())
+                        foreach (var x in Gaussians().Take(10000))
                         {
                             double mx = x.GetMean();
                             if (double.IsInfinity(mx)) continue;


### PR DESCRIPTION
Fixed a corner case in DoubleIsBetweenOp.
MMath.LargestDoubleSum works in 32-bit.
MMath.LargestDoubleProduct is more efficient.