### PR TITLE
Fixed PR and Nightly builds so they can take as long as required

### DIFF
--- a/build/evaluator-netcore.yml
+++ b/build/evaluator-netcore.yml
@@ -9,7 +9,7 @@ parameters:
 
 steps:
 - task: Bash@3
-  displayName: 'Running Evaluator'
+  displayName: 'Running Evaluator (.NET Core)'
   condition: not(endsWith('${{ parameters.Configuration }}', 'Full'))
   inputs:
     targetType: 'inline'

--- a/build/evaluator-netframework.yml
+++ b/build/evaluator-netframework.yml
@@ -9,7 +9,7 @@ parameters:
 
 steps:
 - task: Bash@3
-  displayName: 'Running Evaluator'
+  displayName: 'Running Evaluator (.NET Framework)'
   condition: not(endsWith('${{ parameters.Configuration }}', 'Core'))
   inputs:
     targetType: 'inline'

--- a/build/nightly-netcore.yml
+++ b/build/nightly-netcore.yml
@@ -11,7 +11,7 @@ resources:
   clean: true
 
 queue:
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   
 trigger: none # disable CI build
 

--- a/build/nightly-windows.yml
+++ b/build/nightly-windows.yml
@@ -12,8 +12,8 @@ resources:
   
 trigger: none # disable CI build
 
-queue:
-  name: Hosted VS2017
+#queue:
+#  name: Hosted VS2017
 
 # Cannot use matrix strategy to create jobs for different platforms, 
 # since then the platform is given as a variable which cannot be passed as a parameter to a template,

--- a/build/nightly-windows.yml
+++ b/build/nightly-windows.yml
@@ -14,75 +14,95 @@ trigger: none # disable CI build
 
 queue:
   name: Hosted VS2017
-  timeoutInMinutes: 120
 
-steps:
-- task: Bash@3
-  displayName: 'Updating assembly versions'
-  inputs:
-    filePath: build/updateversion.sh
-    workingDirectory: build
-    arguments: $(Build.BuildNumber)
+# Cannot use matrix strategy to create jobs for different platforms, 
+# since then the platform is given as a variable which cannot be passed as a parameter to a template,
+# because templates are actualized at a very early stage when the variable has no value yet.
+jobs:
+- job: Windows Build and Test (x64)
+  timeoutInMinutes: 180
+  
+  steps:
+  - template: windows-msbuild.yml
+    parameters:
+      BuildConfiguration: '$(BuildConfiguration)'  
+      BuildNumber: '$(Build.BuildNumber)'
 
-- task: NuGetToolInstaller@0
-  inputs:
-    versionSpec: '4.7.0'
+  - template: vstest-fast.yml
+    parameters:
+      Platform: 'x64'
 
-- task: NuGetCommand@2
-  displayName: 'Restoring NuGet packages'
-  inputs:
-    command: 'restore'
-    restoreSolution: '**/*.sln'
+- job: Windows Build and Test (x86)
+  timeoutInMinutes: 180
 
-- task: MSBuild@1
-  displayName: 'Building solutions'
-  inputs:
-    solution: '**/*.sln'
-    clean: true
-    configuration: $(BuildConfiguration)
+  steps:
+  - template: windows-msbuild.yml
+    parameters:
+      BuildConfiguration: '$(BuildConfiguration)'  
+      BuildNumber: '$(Build.BuildNumber)'
 
-- template: vstest-fast.yml
-  parameters:
-    Platform: 'x64'
+  - template: vstest-fast.yml
+    parameters:
+      Platform: 'x86'
 
-- template: vstest-fast.yml
-  parameters:
-    Platform: 'x86'
 
-- template: evaluator-netcore.yml
-  parameters:
-    Configuration: '$(BuildConfiguration)'
+- job: Windows Evaluator
+  timeoutInMinutes: 180
 
-- template: evaluator-netframework.yml
-  parameters:
-    Configuration: '$(BuildConfiguration)'
+  steps:
+  - template: windows-msbuild.yml
+    parameters:
+      BuildConfiguration: '$(BuildConfiguration)'  
+      BuildNumber: '$(Build.BuildNumber)'
 
-- task: Bash@3
-  displayName: 'Gathering built assemblies'
-  condition: eq(variables['BuildConfiguration'], 'Release')
-  inputs:
-    filePath: build/copyassemblies.sh
-    arguments: ../bin $(BuildConfiguration)
-    workingDirectory: build
+  - template: evaluator-netcore.yml
+    parameters:
+      Configuration: '$(BuildConfiguration)'
 
-- task: NuGetCommand@2
-  displayName: 'Creating NuGet packages'
-  condition: eq(variables['BuildConfiguration'], 'Release')
-  inputs:
-    command: pack
-    packagesToPack: build/*.nuspec
-    includeSymbols: true
-    buildProperties: version=$(Build.BuildNumber);bin=../bin
+  - template: evaluator-netframework.yml
+    parameters:
+      Configuration: '$(BuildConfiguration)'
 
-- task: CopyFiles@2
-  displayName: 'Copying build artifacts'
-  condition: eq(variables['BuildConfiguration'], 'Release')
-  inputs:
-    sourceFolder: bin
-    targetFolder: $(Build.ArtifactStagingDirectory)
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publishing build artifacts'
-  condition: eq(variables['BuildConfiguration'], 'Release')
-  inputs:
-    artifactName: 'Everything'
+- job: Package and Publish
+  timeoutInMinutes: 30
+  dependsOn: 
+  - Windows Build and Test (x64)
+  - Windows Build and Test (x86)
+  - Windows Evaluator
+
+  steps:
+  - template: windows-msbuild.yml
+    parameters:
+      BuildConfiguration: '$(BuildConfiguration)'  
+      BuildNumber: '$(Build.BuildNumber)'
+
+  - task: Bash@3
+    displayName: 'Gathering built assemblies'
+    condition: eq(variables['BuildConfiguration'], 'Release')
+    inputs:
+      filePath: build/copyassemblies.sh
+      arguments: ../bin $(BuildConfiguration)
+      workingDirectory: build
+
+  - task: NuGetCommand@2
+    displayName: 'Creating NuGet packages'
+    condition: eq(variables['BuildConfiguration'], 'Release')
+    inputs:
+      command: pack
+      packagesToPack: build/*.nuspec
+      includeSymbols: true
+      buildProperties: version=$(Build.BuildNumber);bin=../bin
+
+  - task: CopyFiles@2
+    displayName: 'Copying build artifacts'
+    condition: eq(variables['BuildConfiguration'], 'Release')
+    inputs:
+      sourceFolder: bin
+      targetFolder: $(Build.ArtifactStagingDirectory)
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publishing build artifacts'
+    condition: eq(variables['BuildConfiguration'], 'Release')
+    inputs:
+      artifactName: 'Everything'

--- a/build/nightly-windows.yml
+++ b/build/nightly-windows.yml
@@ -64,7 +64,7 @@ jobs:
       Configuration: '$(BuildConfiguration)'
 
 
-- job: Package and Publish
+- job: Package_Publish
   timeoutInMinutes: 30
   dependsOn: 
   - Win64_Build_Test

--- a/build/nightly-windows.yml
+++ b/build/nightly-windows.yml
@@ -19,7 +19,7 @@ trigger: none # disable CI build
 # since then the platform is given as a variable which cannot be passed as a parameter to a template,
 # because templates are actualized at a very early stage when the variable has no value yet.
 jobs:
-- job: Windows Build and Test x64
+- job: Win64_Build_Test
   timeoutInMinutes: 180
   
   steps:
@@ -32,7 +32,7 @@ jobs:
     parameters:
       Platform: 'x64'
 
-- job: Windows Build and Test x86
+- job: Win32_Build_Test
   timeoutInMinutes: 180
 
   steps:
@@ -46,7 +46,7 @@ jobs:
       Platform: 'x86'
 
 
-- job: Windows Evaluator
+- job: Win_Evaluator
   timeoutInMinutes: 180
 
   steps:
@@ -67,9 +67,9 @@ jobs:
 - job: Package and Publish
   timeoutInMinutes: 30
   dependsOn: 
-  - Windows Build and Test (x64)
-  - Windows Build and Test (x86)
-  - Windows Evaluator
+  - Win64_Build_Test
+  - Win32_Build_Test
+  - Win_Evaluator
   condition: eq(variables['BuildConfiguration'], 'Release')
 
   steps:

--- a/build/nightly-windows.yml
+++ b/build/nightly-windows.yml
@@ -19,7 +19,7 @@ trigger: none # disable CI build
 # since then the platform is given as a variable which cannot be passed as a parameter to a template,
 # because templates are actualized at a very early stage when the variable has no value yet.
 jobs:
-- job: Windows Build and Test (x64)
+- job: Windows Build and Test x64
   timeoutInMinutes: 180
   
   steps:
@@ -32,7 +32,7 @@ jobs:
     parameters:
       Platform: 'x64'
 
-- job: Windows Build and Test (x86)
+- job: Windows Build and Test x86
   timeoutInMinutes: 180
 
   steps:
@@ -70,6 +70,7 @@ jobs:
   - Windows Build and Test (x64)
   - Windows Build and Test (x86)
   - Windows Evaluator
+  condition: eq(variables['BuildConfiguration'], 'Release')
 
   steps:
   - template: windows-msbuild.yml

--- a/build/nightly-windows.yml
+++ b/build/nightly-windows.yml
@@ -20,6 +20,7 @@ trigger: none # disable CI build
 # because templates are actualized at a very early stage when the variable has no value yet.
 jobs:
 - job: Win64_Build_Test
+  displayName: 'Windows: Build and Test (x64)'
   timeoutInMinutes: 180
   
   steps:
@@ -33,6 +34,7 @@ jobs:
       Platform: 'x64'
 
 - job: Win32_Build_Test
+  displayName: 'Windows: Build and Test (x86)'
   timeoutInMinutes: 180
 
   steps:
@@ -47,6 +49,7 @@ jobs:
 
 
 - job: Win_Evaluator
+  displayName: 'Windows: Running Evaluator'
   timeoutInMinutes: 180
 
   steps:
@@ -65,6 +68,7 @@ jobs:
 
 
 - job: Package_Publish
+  displayName: 'Package and Publish'
   timeoutInMinutes: 30
   dependsOn: 
   - Win64_Build_Test

--- a/build/pr-msbuild.yml
+++ b/build/pr-msbuild.yml
@@ -10,8 +10,12 @@ resources:
   
 trigger: none # disable CI build
 
+# Cannot use matrix strategy to create jobs for different platforms, 
+# since then the platform is given as a variable which cannot be passed as a parameter to a template,
+# because templates are actualized at a very early stage when the variable has no value yet.
 jobs:
 - job: Win64 # Hosted Windows agent, VS 2017, testing on x64
+  timeoutInMinutes: 120
   pool:
     vmImage: vs2017-win2016
   steps:
@@ -35,6 +39,7 @@ jobs:
       Platform: 'x64'
 
 - job: Win32 # Hosted Windows agent, VS 2017, testing on x86
+  timeoutInMinutes: 120
   pool:
     vmImage: vs2017-win2016
   steps:

--- a/build/pr-netcore.yml
+++ b/build/pr-netcore.yml
@@ -13,16 +13,20 @@ trigger: none # disable CI build
 variables:
   buildConfiguration: 'Release'
 
-steps:
-- task: DotNetCoreInstaller@0
-  inputs:
-    packageType: 'sdk' 
-    version: '2.1.403' 
+jobs:
+- job: PR_Netcore
+  timeoutInMinutes: 120
 
-- script: |
-    dotnet build /p:DisableImplicitNuGetFallbackFolder=true --configuration $(buildConfiguration)Core Infer.sln
-  displayName: Build Solution
-    
-- template: netcoretest-fast.yml
-  parameters:
-    Configuration: '$(buildConfiguration)Core'
+  steps:
+  - task: DotNetCoreInstaller@0
+    inputs:
+      packageType: 'sdk' 
+      version: '2.1.403' 
+
+  - script: |
+      dotnet build /p:DisableImplicitNuGetFallbackFolder=true --configuration $(buildConfiguration)Core Infer.sln
+    displayName: Build Solution
+      
+  - template: netcoretest-fast.yml
+    parameters:
+      Configuration: '$(buildConfiguration)Core'

--- a/build/pr-netcore.yml
+++ b/build/pr-netcore.yml
@@ -7,26 +7,25 @@
 resources:
 - repo: self
   clean: true
-  
+
+queue:
+  timeoutInMinutes: 120
+
 trigger: none # disable CI build
 
 variables:
   buildConfiguration: 'Release'
 
-jobs:
-- job: PR_Netcore
-  timeoutInMinutes: 120
+steps:
+- task: DotNetCoreInstaller@0
+  inputs:
+    packageType: 'sdk' 
+    version: '2.1.403' 
 
-  steps:
-  - task: DotNetCoreInstaller@0
-    inputs:
-      packageType: 'sdk' 
-      version: '2.1.403' 
-
-  - script: |
-      dotnet build /p:DisableImplicitNuGetFallbackFolder=true --configuration $(buildConfiguration)Core Infer.sln
-    displayName: Build Solution
-      
-  - template: netcoretest-fast.yml
-    parameters:
-      Configuration: '$(buildConfiguration)Core'
+- script: |
+    dotnet build /p:DisableImplicitNuGetFallbackFolder=true --configuration $(buildConfiguration)Core Infer.sln
+  displayName: Build Solution
+    
+- template: netcoretest-fast.yml
+  parameters:
+    Configuration: '$(buildConfiguration)Core'

--- a/build/windows-msbuild.yml
+++ b/build/windows-msbuild.yml
@@ -1,0 +1,35 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+
+# Template for building all solutions using MSBuild
+
+parameters:
+  BuildNumber: '0.0.0'
+  BuildConfiguration: 'Release'
+
+
+steps:
+- task: Bash@3
+  displayName: 'Updating assembly versions'
+  inputs:
+    filePath: build/updateversion.sh
+    workingDirectory: build
+    arguments:  ${{ parameters.BuildNumber }}
+
+- task: NuGetToolInstaller@0
+  inputs:
+    versionSpec: '4.7.0'
+
+- task: NuGetCommand@2
+  displayName: 'Restoring NuGet packages'
+  inputs:
+    command: 'restore'
+    restoreSolution: '**/*.sln'
+
+- task: MSBuild@1
+  displayName: 'Building solutions'
+  inputs:
+    solution: '**/*.sln'
+    clean: true
+    configuration: ${{ parameters.BuildConfiguration }}


### PR DESCRIPTION
1. Added or increased job timeouts.
2. Nightly Windows build split into 4 jobs.
3. Updated display names of the jobs.