### PR TITLE
Gaussian.GetMean throws if Precision == 0, instead of returning 0.

### DIFF
--- a/src/Runtime/Distributions/Gaussian.cs
+++ b/src/Runtime/Distributions/Gaussian.cs
@@ -545,10 +545,15 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 MeanTimesPrecision = a.MeanTimesPrecision + b.MeanTimesPrecision;
                 if (Precision > double.MaxValue || Math.Abs(MeanTimesPrecision) > double.MaxValue)
                 {
-                    // (am*ap + bm*bp)/(ap + bp) = am*w + bm*(1-w)
-                    // w = 1/(1 + bp/ap)
-                    double w = 1 / (1 + b.Precision / a.Precision);
-                    Point = a.GetMean() * w + b.GetMean() * (1 - w);
+                    if (a.IsUniform()) SetTo(b);
+                    else if (b.IsUniform()) SetTo(a);
+                    else
+                    {
+                        // (am*ap + bm*bp)/(ap + bp) = am*w + bm*(1-w)
+                        // w = 1/(1 + bp/ap)
+                        double w = 1 / (1 + b.Precision / a.Precision);
+                        Point = a.GetMean() * w + b.GetMean() * (1 - w);
+                    }
                 }
             }
         }
@@ -600,8 +605,15 @@ namespace Microsoft.ML.Probabilistic.Distributions
             {
                 if (forceProper && numerator.Precision < denominator.Precision)
                 {
-                    // must not modify this before computing numerator.GetMean()
-                    MeanTimesPrecision = numerator.GetMean() * denominator.Precision - denominator.MeanTimesPrecision;
+                    if (numerator.IsUniform())
+                    {
+                        MeanTimesPrecision = -denominator.MeanTimesPrecision;
+                    }
+                    else
+                    {
+                        // must not modify this before computing numerator.GetMean()
+                        MeanTimesPrecision = numerator.GetMean() * denominator.Precision - denominator.MeanTimesPrecision;
+                    }
                     Precision = 0;
                 }
                 else

--- a/src/Runtime/Distributions/Gaussian.cs
+++ b/src/Runtime/Distributions/Gaussian.cs
@@ -233,8 +233,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         public double GetMean()
         {
             if (IsPointMass) return Point;
-            else if (Precision == 0.0) return 0.0;
-            else if (Precision < 0.0) throw new ImproperDistributionException(this);
+            else if (Precision <= 0.0) throw new ImproperDistributionException(this);
             else return MeanTimesPrecision / Precision;
         }
 

--- a/src/Runtime/Distributions/InnerQuantiles.cs
+++ b/src/Runtime/Distributions/InnerQuantiles.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
     public class InnerQuantiles : CanGetQuantile, CanGetProbLessThan
     {
         /// <summary>
-        /// Numbers in increasing order.
+        /// Numbers in increasing order.  Cannot be empty.
         /// </summary>
         [DataMember] private readonly double[] quantiles;
         /// <summary>
@@ -120,6 +120,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         {
             if (double.IsNaN(x)) throw new ArgumentOutOfRangeException("x is NaN");
             int n = quantiles.Length;
+            if (n == 0) throw new ArgumentOutOfRangeException(nameof(quantiles) + ".Count", n, "quantiles array is empty");
             if (x < quantiles[0])
             {
                 return GetProbLessThan(x, (IReadOnlyList<double>)quantiles);
@@ -148,6 +149,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         private static Gaussian GetLowerGaussian(IReadOnlyList<double> quantiles)
         {
             int n = quantiles.Count;
+            if (n == 0) throw new ArgumentOutOfRangeException(nameof(quantiles) + ".Count", n, "quantiles array is empty");
             // find the next quantile
             int i = 1;
             while (i < n && quantiles[i] == quantiles[0])
@@ -177,6 +179,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         private static Gaussian GetUpperGaussian(IReadOnlyList<double> quantiles)
         {
             int n = quantiles.Count;
+            if (n == 0) throw new ArgumentOutOfRangeException(nameof(quantiles) + ".Count", n, "quantiles array is empty");
             // find the previous quantile
             int i = n - 2;
             while (i >= 0 && quantiles[i] == quantiles[n - 1])
@@ -216,6 +219,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         public static double GetProbLessThan(double x, IReadOnlyList<double> quantiles)
         {
             int n = quantiles.Count;
+            if (n == 0) throw new ArgumentOutOfRangeException(nameof(quantiles) + ".Count", n, "quantiles array is empty");
             if (x < quantiles[0])
             {
                 return GetLowerGaussian(quantiles).GetProbLessThan(x);

--- a/src/Runtime/Distributions/OuterQuantiles.cs
+++ b/src/Runtime/Distributions/OuterQuantiles.cs
@@ -28,6 +28,8 @@ namespace Microsoft.ML.Probabilistic.Distributions
 
         public OuterQuantiles(double[] quantiles)
         {
+            if (quantiles == null) throw new ArgumentNullException(nameof(quantiles));
+            if (quantiles.Length == 0) throw new ArgumentException("quantiles array is empty", nameof(quantiles));
             AssertNondecreasing(quantiles, nameof(quantiles));
             AssertFinite(quantiles, nameof(quantiles));
             this.quantiles = quantiles;
@@ -101,6 +103,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         public static double GetProbLessThan(double x, double[] quantiles)
         {
             int n = quantiles.Length;
+            if (n == 0) throw new ArgumentException("quantiles array is empty", nameof(quantiles));
             // The index of the specified value in the specified array, if value is found; otherwise, a negative number. 
             // If value is not found and value is less than one or more elements in array, the negative number returned 
             // is the bitwise complement of the index of the first element that is larger than value. 

--- a/src/Runtime/Distributions/TruncatedGaussian.cs
+++ b/src/Runtime/Distributions/TruncatedGaussian.cs
@@ -474,7 +474,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
             }
             else
             {
-                return Sample(Gaussian.GetMean(), Gaussian.Precision, LowerBound, UpperBound);
+                return Sample(Gaussian.IsUniform() ? 0.0 : Gaussian.GetMean(), Gaussian.Precision, LowerBound, UpperBound);
             }
         }
 

--- a/src/Runtime/Factors/Exp.cs
+++ b/src/Runtime/Factors/Exp.cs
@@ -162,7 +162,9 @@ namespace Microsoft.ML.Probabilistic.Factors
                 // dlogGa/dx = (a-1)/x - b
                 // d2logGa/dx2 = -(a-1)/x^2
                 // match derivatives and solve for (a,b)
-                double shape = (1 + d.GetMean() - Math.Log(exp.Point)) * d.Precision;
+                // a = 1 - d2logZ/dx2*x^2 = 1 + dlogZ/dx*x + 1/vy = -1/vy*(log(x)-my) + 1/vy
+                // b = -d2logZ/dx2*x - dlogZ/dx = 1/vy/x
+                double shape = d.MeanTimesPrecision + (1 - Math.Log(exp.Point)) * d.Precision;
                 double rate = d.Precision / exp.Point;
                 return Gamma.FromShapeAndRate(shape, rate);
             }

--- a/src/Runtime/Factors/VariablePointOp.cs
+++ b/src/Runtime/Factors/VariablePointOp.cs
@@ -374,6 +374,7 @@ namespace Microsoft.ML.Probabilistic.Factors
                 bufferTGa.lowerBound = Math.Log(currDist.LowerBound);
                 bufferTGa.upperBound = Math.Log(currDist.UpperBound);
                 currDeriv = currDist.Gamma.Shape - currDist.Gamma.Rate * currPoint;
+                //Trace.WriteLine($"use deriv = {(use.Gamma.Shape-1) - use.Gamma.Rate*currPoint} def deriv = {def.Gamma.Shape - def.Gamma.Rate*currPoint} total deriv = {currDeriv}");
                 if (currPoint <= 0)
                     throw new ArgumentException($"currPoint ({currPoint}) <= 0");
                 bufferTGa.SetNextPoint(Math.Log(currPoint), currDeriv);

--- a/test/Tests/Distributions/DistributionTests.cs
+++ b/test/Tests/Distributions/DistributionTests.cs
@@ -284,7 +284,8 @@ namespace Microsoft.ML.Probabilistic.Tests
             PointMassMomentTest(g, 7.7, 4.4, 5.5);
             SamplingTest(g, 7.7);
             g.SetToUniform();
-            GetAndSetMomentTest(g, 0.0, Double.PositiveInfinity);
+            Assert.True(g.GetVariance() == double.PositiveInfinity);
+            Assert.Throws<ImproperDistributionException>(() => g.GetMean());
 
             Gaussian g3 = new Gaussian();
             g3.SetToSum(1.0, g, System.Math.Exp(800), g2);

--- a/test/Tests/Operators/OperatorTests.cs
+++ b/test/Tests/Operators/OperatorTests.cs
@@ -2732,7 +2732,7 @@ zL = (L - mx)*sqrt(prec)
                 if (i > 0)
                 {
                     Assert.True(toUpper.GetVariance() >= previousToUpper.GetVariance() - 1e-20);
-                    Assert.True(toUpper.GetMean() <= previousToUpper.GetMean());
+                    Assert.True(toUpper.IsUniform() || toUpper.GetMean() <= previousToUpper.GetMean());
                 }
                 previousToUpper = toUpper;
 


### PR DESCRIPTION
ExpOp.ExpAverageConditional correctly handles improper d.
InnerQuantiles/OuterQuantiles check for an empty quantiles array.