### PR TITLE
Make MaxStateCount overrides thread local

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -40,12 +40,20 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             private int numRemovedTransitions = 0;
 
             /// <summary>
+            /// Cached value of <see cref="MaxStateCount"/>. Getting MaxStateCount involves checking
+            /// thread static variable value and a comparison. Caching this property values is a little
+            /// faster.
+            /// </summary>
+            private readonly int maxStateCount;
+
+            /// <summary>
             /// Creates a new empty <see cref="Builder"/>.
             /// </summary>
             public Builder(int startStateCount = 1)
             {
                 this.states = new List<LinkedStateData>();
                 this.transitions = new List<LinkedTransitionNode>();
+                this.maxStateCount = MaxStateCount;
                 this.AddStates(startStateCount);
             }
 
@@ -112,9 +120,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// </summary>
             public StateBuilder AddState()
             {
-                if (this.states.Count >= maxStateCount)
+                if (this.states.Count >= this.maxStateCount)
                 {
-                    throw new AutomatonTooLargeException(MaxStateCount);
+                    throw new AutomatonTooLargeException(this.maxStateCount);
                 }
 
                 var index = this.states.Count;

--- a/src/Runtime/Distributions/Automata/TransducerBase.cs
+++ b/src/Runtime/Distributions/Automata/TransducerBase.cs
@@ -44,19 +44,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </summary>
         protected PairListAutomaton sequencePairToWeight = new PairListAutomaton();
 
-        #region Properties
-
-        /// <summary>
-        /// Gets or sets the maximum number of states a transducer can have.
-        /// </summary>
-        public static int MaxStateCount
-        {
-            get { return PairListAutomaton.MaxStateCount; }
-            set { PairListAutomaton.MaxStateCount = value; }
-        }
-        
-        #endregion
-
         #region Factory methods
 
         /// <summary>
@@ -555,6 +542,17 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         #endregion
 
         #region Nested classes
+
+        public class UnlimitedStatesComputation : IDisposable
+        {
+            private readonly PairListAutomaton.UnlimitedStatesComputation unlimitedAutomatonStatesComputation;
+
+            public UnlimitedStatesComputation() =>
+                this.unlimitedAutomatonStatesComputation = new PairListAutomaton.UnlimitedStatesComputation();
+
+            public void Dispose() =>
+                this.unlimitedAutomatonStatesComputation.Dispose();
+        }
 
         /// <summary>
         /// Represents an automaton that maps lists of element pairs to real values. Such automata are used to represent transducers internally.


### PR DESCRIPTION
UnlimitedStatesComputation() is used temporary to alter maximal size of automaton
which is defined my MaxStateCount. Using it from different threads could mess up the limit.
Now each threads gets its own limit.

Also, the default MaxStateCount limit is increased to 300k, because that is what the biggest String inference customer uses.