### PR TITLE
Add non-generic IDistribution interface

### DIFF
--- a/src/Runtime/Distributions/Distribution.cs
+++ b/src/Runtime/Distributions/Distribution.cs
@@ -13,6 +13,19 @@ namespace Microsoft.ML.Probabilistic.Distributions
     using Utilities;
     using Factors.Attributes;
 
+    /// <summary>
+    /// Base type for all distributions that doesn't specify over which domain distribution is defined.
+    /// </summary>
+    /// <remarks>
+    /// This interface is useful in generic code where distributions of different types have to be stored
+    /// in single container. Container of <see cref="IDistribution"/> is a more specific type than
+    /// container of <see cref="object"/> and adds some type-safety in these cases.
+    /// </remarks>
+    [Quality(QualityBand.Mature)]
+    public interface IDistribution : ICloneable, Diffable, SettableToUniform
+    {
+    }
+
     /// <summary>Distribution interface</summary>
     /// <typeparam name="T">The type of objects in the domain, e.g. Vector or Matrix.</typeparam>
     /// <remarks><para>
@@ -29,8 +42,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
     /// CanGetLogAverageOf, CanGetAverageLog</c>
     /// </para></remarks>
     [Quality(QualityBand.Mature)]
-    public interface IDistribution<T> : ICloneable,
-                                        HasPoint<T>, Diffable, SettableToUniform, CanGetLogProb<T>
+    public interface IDistribution<T> : IDistribution, HasPoint<T>, CanGetLogProb<T>
     {
     }
 


### PR DESCRIPTION
This interface is useful for generic code that stores distributions of different types in single container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/infer/215)
<!-- Reviewable:end -->
