### PR TITLE
Replace ReadOnlyArray with ImmutableArray look-alike

### DIFF
--- a/src/Runtime/Core/Collections/ImmutableArray.cs
+++ b/src/Runtime/Core/Collections/ImmutableArray.cs
@@ -94,14 +94,10 @@ namespace Microsoft.ML.Probabilistic.Collections
 
         public struct Builder
         {
-            private bool dirty;
             private T[] array;
 
-            public Builder(int size)
-            {
-                this.dirty = false;
+            public Builder(int size) =>
                 this.array = new T[size];
-            }
 
             public T this[int index]
             {
@@ -111,15 +107,11 @@ namespace Microsoft.ML.Probabilistic.Collections
 
             public int Count => this.array.Length;
 
-            public ImmutableArray<T> ToImmutable()
+            public ImmutableArray<T> MoveToImmutable()
             {
-                if (dirty)
-                {
-                    throw new NotImplementedException("ToImmutable() can be called only once at the moment");
-                }
-
-                dirty = true;
-                return new ImmutableArray<T>(this.array);
+                var result = new ImmutableArray<T>(this.array);
+                this.array = Array.Empty<T>();
+                return result;
             }
         }
     }
@@ -259,13 +251,13 @@ namespace Microsoft.ML.Probabilistic.Collections
         public static ImmutableArray<T> Create<T>(T elem)
         {
             var builder = new ImmutableArray<T>.Builder(1) {[0] = elem};
-            return builder.ToImmutable();
+            return builder.MoveToImmutable();
         }
 
         public static ImmutableArray<T> Create<T>(T elem1, T elem2)
         {
             var builder = new ImmutableArray<T>.Builder(1) {[0] = elem1, [1] = elem2};
-            return builder.ToImmutable();
+            return builder.MoveToImmutable();
         }
 
         /// <summary>

--- a/src/Runtime/Core/Collections/ImmutableArray.cs
+++ b/src/Runtime/Core/Collections/ImmutableArray.cs
@@ -2,17 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
-using System.Data.Common;
-using System.Linq;
-using System.Runtime.CompilerServices;
-
 namespace Microsoft.ML.Probabilistic.Collections
 {
     using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
     using System.Runtime.Serialization;
 
     using Microsoft.ML.Probabilistic.Serialization;

--- a/src/Runtime/Core/Collections/ImmutableArray.cs
+++ b/src/Runtime/Core/Collections/ImmutableArray.cs
@@ -88,7 +88,7 @@ namespace Microsoft.ML.Probabilistic.Collections
         public static bool operator !=(ImmutableArray<T> left, ImmutableArray<T> right) =>
             left.array != right.array;
 
-        public struct Builder
+        public class Builder
         {
             private T[] array;
 

--- a/src/Runtime/Core/Collections/ImmutableArray.cs
+++ b/src/Runtime/Core/Collections/ImmutableArray.cs
@@ -252,7 +252,7 @@ namespace Microsoft.ML.Probabilistic.Collections
 
         public static ImmutableArray<T> Create<T>(T elem1, T elem2)
         {
-            var builder = new ImmutableArray<T>.Builder(1) {[0] = elem1, [1] = elem2};
+            var builder = new ImmutableArray<T>.Builder(2) {[0] = elem1, [1] = elem2};
             return builder.MoveToImmutable();
         }
 

--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -397,11 +397,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
                 var hasEpsilonTransitions = false;
                 var usesGroups = false;
-                var resultStates = new StateData[this.states.Count];
-                var resultTransitions = new Transition[this.transitions.Count - this.numRemovedTransitions];
+                var resultStates = ImmutableArray.CreateBuilder<StateData>(this.states.Count);
+                var resultTransitions = ImmutableArray.CreateBuilder<Transition>(this.transitions.Count - this.numRemovedTransitions);
                 var nextResultTransitionIndex = 0;
 
-                for (var i = 0; i < resultStates.Length; ++i)
+                for (var i = 0; i < resultStates.Count; ++i)
                 {
                     var firstResultTransitionIndex = nextResultTransitionIndex;
                     var transitionIndex = this.states[i].FirstTransitionIndex;
@@ -410,7 +410,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         var node = this.transitions[transitionIndex];
                         var transition = node.Transition;
                         Debug.Assert(
-                            transition.DestinationStateIndex < resultStates.Length,
+                            transition.DestinationStateIndex < resultStates.Count,
                             "Destination indexes must be in valid range");
                         resultTransitions[nextResultTransitionIndex] = transition;
                         ++nextResultTransitionIndex;
@@ -427,13 +427,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 }
 
                 Debug.Assert(
-                    nextResultTransitionIndex == resultTransitions.Length,
+                    nextResultTransitionIndex == resultTransitions.Count,
                     "number of copied transitions must match result array size");
 
                 return new DataContainer(
                     this.StartStateIndex,
-                    resultStates,
-                    resultTransitions,
+                    resultStates.ToImmutable(),
+                    resultTransitions.ToImmutable(),
                     !hasEpsilonTransitions,
                     usesGroups,
                     isDeterminized,

--- a/src/Runtime/Distributions/Automata/Automaton.Builder.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Builder.cs
@@ -432,8 +432,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
                 return new DataContainer(
                     this.StartStateIndex,
-                    resultStates.ToImmutable(),
-                    resultTransitions.ToImmutable(),
+                    resultStates.MoveToImmutable(),
+                    resultTransitions.MoveToImmutable(),
                     !hasEpsilonTransitions,
                     usesGroups,
                     isDeterminized,

--- a/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
@@ -32,13 +32,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// All automaton states.
             /// </summary>
-            public readonly ReadOnlyArray<StateData> States;
+            public readonly ImmutableArray<StateData> States;
 
             /// <summary>
             /// All automaton transitions. Transitions for the same state are stored as a contiguous block
             /// inside this array.
             /// </summary>
-            public readonly ReadOnlyArray<Transition> Transitions;
+            public readonly ImmutableArray<Transition> Transitions;
 
             /// <summary>
             /// Gets value indicating whether this automaton is epsilon-free.
@@ -79,8 +79,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             [Construction("StartStateIndex", "States", "Transitions", "IsEpsilonFree", "UsesGroups", "IsDeterminized", "IsZero")]
             public DataContainer(
                 int startStateIndex,
-                ReadOnlyArray<StateData> states,
-                ReadOnlyArray<Transition> transitions,
+                ImmutableArray<StateData> states,
+                ImmutableArray<Transition> transitions,
                 bool isEpsilonFree,
                 bool usesGroups,
                 bool? isDeterminized,
@@ -165,8 +165,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             {
                 this.flags = (Flags)info.GetValue(nameof(this.flags), typeof(Flags));
                 this.StartStateIndex = (int)info.GetValue(nameof(this.StartStateIndex), typeof(int));
-                this.States = (StateData[])info.GetValue(nameof(this.States), typeof(StateData[]));
-                this.Transitions = (Transition[])info.GetValue(nameof(this.Transitions), typeof(Transition[]));
+                this.States = ((StateData[])info.GetValue(nameof(this.States), typeof(StateData[]))).ToImmutableArray();
+                this.Transitions = ((Transition[])info.GetValue(nameof(this.Transitions), typeof(Transition[]))).ToImmutableArray();
 
                 if (!IsConsistent())
                 {

--- a/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
@@ -329,24 +329,24 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 /// <summary>
                 /// A mapping from state ids to weights. This array is sorted by state Id.
                 /// </summary>
-                private readonly ReadOnlyArray<WeightedState> weightedStates;
+                private readonly ImmutableArray<WeightedState> weightedStates;
 
                 private readonly int singleStateIndex;
 
                 public WeightedStateSet(int stateIndex)
                 {
-                    this.weightedStates = null;
+                    this.weightedStates = default;
                     this.singleStateIndex = stateIndex;
                 }
 
-                public WeightedStateSet(ReadOnlyArray<WeightedState> weightedStates)
+                public WeightedStateSet(ImmutableArray<WeightedState> weightedStates)
                 {
                     Debug.Assert(weightedStates.Count > 0);
                     Debug.Assert(IsSorted(weightedStates));
                     if (weightedStates.Count == 1)
                     {
                         Debug.Assert(weightedStates[0].Weight == Weight.One);
-                        this.weightedStates = null;
+                        this.weightedStates = default;
                         this.singleStateIndex = weightedStates[0].Index;
                     }
                     else
@@ -357,12 +357,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 }
 
                 public int Count =>
-                    this.weightedStates.IsNull
+                    (this.weightedStates == default)
                         ? 1
                         : this.weightedStates.Count;
 
                 public WeightedState this[int index] =>
-                    this.weightedStates.IsNull
+                    (this.weightedStates == default)
                         ? new WeightedState(this.singleStateIndex, Weight.One)
                         : this.weightedStates[index];
 
@@ -444,7 +444,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 /// <summary>
                 /// Checks weather states array is sorted in ascending order by Index.
                 /// </summary>
-                private static bool IsSorted(ReadOnlyArray<WeightedState> array)
+                private static bool IsSorted(ImmutableArray<WeightedState> array)
                 {
                     for (var i = 1; i < array.Count; ++i)
                     {
@@ -520,7 +520,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     MergeRepeatedEntries(weightsClone);
                     var maxWeight = NormalizeWeights(weightsClone);
 
-                    return (new WeightedStateSet(weightsClone.ToArray()), maxWeight);
+                    return (new WeightedStateSet(weightsClone.ToImmutableArray()), maxWeight);
                 }
 
                 private static void MergeRepeatedEntries(List<WeightedState> weightedStates)

--- a/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
@@ -335,7 +335,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
                 public WeightedStateSet(int stateIndex)
                 {
-                    this.weightedStates = default;
+                    this.weightedStates = default(ImmutableArray<WeightedState>);
                     this.singleStateIndex = stateIndex;
                 }
 
@@ -346,7 +346,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     if (weightedStates.Count == 1)
                     {
                         Debug.Assert(weightedStates[0].Weight == Weight.One);
-                        this.weightedStates = default;
+                        this.weightedStates = default(ImmutableArray<WeightedState>);
                         this.singleStateIndex = weightedStates[0].Index;
                     }
                     else
@@ -357,12 +357,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 }
 
                 public int Count =>
-                    (this.weightedStates == default)
+                    (this.weightedStates == default(ImmutableArray<WeightedState>))
                         ? 1
                         : this.weightedStates.Count;
 
                 public WeightedState this[int index] =>
-                    (this.weightedStates == default)
+                    (this.weightedStates == default(ImmutableArray<WeightedState>))
                         ? new WeightedState(this.singleStateIndex, Weight.One)
                         : this.weightedStates[index];
 

--- a/src/Runtime/Distributions/Automata/Automaton.State.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.State.cs
@@ -24,9 +24,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </remarks>
         public struct State : IEquatable<State>
         {
-            private readonly ReadOnlyArray<StateData> states;
+            private readonly ImmutableArray<StateData> states;
 
-            private readonly ReadOnlyArray<Transition> transitions;
+            private readonly ImmutableArray<Transition> transitions;
 
             /// <summary>
             /// Initializes a new instance of <see cref="State"/> class. Used internally by automaton implementation
@@ -34,8 +34,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// </summary>
             internal State(
                 Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> owner,
-                ReadOnlyArray<StateData> states,
-                ReadOnlyArray<Transition> transitions,
+                ImmutableArray<StateData> states,
+                ImmutableArray<Transition> transitions,
                 int index)
             {
                 this.Owner = owner;
@@ -64,8 +64,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// </summary>
             public bool CanEnd => this.Data.CanEnd;
 
-            public ReadOnlyArraySegment<Transition> Transitions =>
-                new ReadOnlyArraySegment<Transition>(
+            public ImmutableArraySegment<Transition> Transitions =>
+                new ImmutableArraySegment<Transition>(
                     this.transitions,
                     this.Data.FirstTransitionIndex,
                     this.Data.TransitionsCount);

--- a/src/Runtime/Distributions/Automata/Automaton.StateCollection.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.StateCollection.cs
@@ -25,12 +25,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// Cached value of this.owner.Data.states. Cached for performance.
             /// </summary>
-            internal readonly ReadOnlyArray<StateData> states;
+            internal readonly ImmutableArray<StateData> states;
 
             /// <summary>
             /// Cached value of this.owner.Data.states. Cached for performance.
             /// </summary>
-            internal readonly ReadOnlyArray<Transition> transitions;
+            internal readonly ImmutableArray<Transition> transitions;
 
             /// <summary>
             /// Owner automaton of all states in collection.

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -65,12 +65,14 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <summary>
         /// Cached states representation of states for zero automaton.
         /// </summary>
-        private static readonly ReadOnlyArray<StateData> ZeroStates = new[] { new StateData(0, 0, Weight.Zero) };
+        private static readonly ImmutableArray<StateData> ZeroStates =
+            ImmutableArray.Create(new StateData(0, 0, Weight.Zero));
 
         /// <summary>
         /// Cached states representation of transitions for zero automaton.
         /// </summary>
-        private static readonly ReadOnlyArray<Transition> ZeroTransitions = new Transition[] { };
+        private static readonly ImmutableArray<Transition> ZeroTransitions =
+            ImmutableArray<Transition>.Empty;
 
         /// <summary>
         /// The maximum number of states an automaton can have.

--- a/src/Runtime/Distributions/DiscreteChar.cs
+++ b/src/Runtime/Distributions/DiscreteChar.cs
@@ -211,7 +211,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         public char Point
         {
             get => this.Data.Point ?? throw new InvalidOperationException();
-            set => this.Data = StorageCache.GetPointMass(value, default);
+            set => this.Data = StorageCache.GetPointMass(value, null);
         }
 
         /// <summary>
@@ -1543,7 +1543,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 StorageCache.GetPointMass(point, ranges);
 
             public static Storage CreatePoint(char point) =>
-                StorageCache.GetPointMass(point, default);
+                StorageCache.GetPointMass(point, null);
 
             public static Storage CreateUniformInRanges(
                 IEnumerable<char> startEndPairs,
@@ -1906,14 +1906,14 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 PointMasses = new Storage[CharRangeEndExclusive];
             }
 
-            public static Storage GetPointMass(char point, ImmutableArray<CharRange> ranges)
+            public static Storage GetPointMass(char point, ImmutableArray<CharRange>? ranges)
             {
                 if (PointMasses[point] == null)
                 {
                     PointMasses[point] = Storage.CreateUncached(
-                        ranges == default
-                            ? ImmutableArray.Create(new CharRange(point, point + 1, Weight.One))
-                            : ranges,
+                        ranges.HasValue
+                            ? ranges.Value
+                            : ImmutableArray.Create(new CharRange(point, point + 1, Weight.One)),
                         point);
                 }
 

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -929,12 +929,11 @@ namespace Microsoft.ML.Probabilistic.Tests
             var automaton1 = StringAutomaton.FromData(
                 new StringAutomaton.DataContainer(
                     0,
-                    new[]
-                    {
+                    ImmutableArray.Create(
                         new StringAutomaton.StateData(0, 1, Weight.One),
-                        new StringAutomaton.StateData(1, 0, Weight.One),
-                    },
-                    new[] { new StringAutomaton.Transition(DiscreteChar.PointMass('a'), Weight.One, 1) },
+                        new StringAutomaton.StateData(1, 0, Weight.One)),
+                    ImmutableArray.Create(
+                        new StringAutomaton.Transition(DiscreteChar.PointMass('a'), Weight.One, 1)),
                     isEpsilonFree: true,
                     usesGroups: false,
                     isDeterminized: null,
@@ -947,8 +946,8 @@ namespace Microsoft.ML.Probabilistic.Tests
             var automaton2 = StringAutomaton.FromData(
                 new StringAutomaton.DataContainer(
                     0,
-                    new[] { new StringAutomaton.StateData(0, 0, Weight.Zero) },
-                    Array.Empty<StringAutomaton.Transition>(),
+                    ImmutableArray.Create(new StringAutomaton.StateData(0, 0, Weight.Zero)),
+                    ImmutableArray<StringAutomaton.Transition>.Empty,
                     isEpsilonFree: true,
                     usesGroups: false,
                     isDeterminized: true,
@@ -960,8 +959,8 @@ namespace Microsoft.ML.Probabilistic.Tests
                 () => StringAutomaton.FromData(
                     new StringAutomaton.DataContainer(
                         0,
-                        Array.Empty<StringAutomaton.StateData>(),
-                        Array.Empty<StringAutomaton.Transition>(),
+                        ImmutableArray<StringAutomaton.StateData>.Empty,
+                        ImmutableArray<StringAutomaton.Transition>.Empty,
                         isEpsilonFree: true,
                         usesGroups: false,
                         isDeterminized: false,
@@ -972,8 +971,8 @@ namespace Microsoft.ML.Probabilistic.Tests
                 () => StringAutomaton.FromData(
                     new StringAutomaton.DataContainer(
                         0,
-                        new[] { new StringAutomaton.StateData(0, 0, Weight.Zero) },
-                        Array.Empty<StringAutomaton.Transition>(),
+                        ImmutableArray.Create(new StringAutomaton.StateData(0, 0, Weight.Zero)),
+                        ImmutableArray<StringAutomaton.Transition>.Empty,
                         isEpsilonFree: false,
                         usesGroups: false,
                         isDeterminized: null,
@@ -984,8 +983,8 @@ namespace Microsoft.ML.Probabilistic.Tests
                 () => StringAutomaton.FromData(
                     new StringAutomaton.DataContainer(
                         0,
-                        new[] { new StringAutomaton.StateData(0, 1, Weight.Zero) },
-                        new[] { new StringAutomaton.Transition(Option.None, Weight.One, 1) },
+                        ImmutableArray.Create(new StringAutomaton.StateData(0, 1, Weight.Zero)),
+                        ImmutableArray.Create(new StringAutomaton.Transition(Option.None, Weight.One, 1)),
                         isEpsilonFree: false,
                         usesGroups: false,
                         isDeterminized: null,
@@ -996,8 +995,8 @@ namespace Microsoft.ML.Probabilistic.Tests
                 () => StringAutomaton.FromData(
                     new StringAutomaton.DataContainer(
                         0,
-                        new[] { new StringAutomaton.StateData(0, 1, Weight.One) },
-                        new[] { new StringAutomaton.Transition(Option.None, Weight.One, 2) },
+                        ImmutableArray.Create(new StringAutomaton.StateData(0, 1, Weight.One)),
+                        ImmutableArray.Create(new StringAutomaton.Transition(Option.None, Weight.One, 2)),
                         true,
                         false,
                         isDeterminized: null,


### PR DESCRIPTION
`System.Collections.Immutable` has `ImmutableArray` that serves the same purpose as
`ReadOnlyArray` but has different API. This type is available only in netcore, so can't be used
in Infer.NET which has to support netframework. Until netframework support can be dropped
reimplement a subset of `ImmutableArray` in Infer.NET codebase.