### PR TITLE
Improve support enumeration in StringAutomata

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -2517,6 +2517,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             automaton.PruneStatesWithLogEndWeightLessThan = dummy;
         }
 
+        /// <summary>
+        /// Enumerate support of this automaton
+        /// </summary>
         private IEnumerable<TSequence> EnumerateSupportInternal(bool tryDeterminize)
         {
             var isEnumerable = this.Data.IsEnumerable;
@@ -2540,6 +2543,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             return enumeration;
         }
 
+        /// <summary>
+        /// Stores information needed for backtracking during support enumeration.
+        /// </summary>
         private struct StateEnumerationState
         {
             public int StateIndex;
@@ -2550,13 +2556,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         }
 
         /// <summary>
-        /// Recursively enumerate support of this automaton
+        /// Enumerate support of this automaton without elemination of duplicate elements
         /// </summary>
         /// <returns>
         /// The sequences supporting this automaton. Sequences may be non-distinct if
         /// automaton is not determinized. A `null` value in enumeration means that
-        /// an infinite loop was reached. (public `EnumerateSupport()` / `TryEnumerateSupport()`
-        /// methods handle this differently.
+        /// an infinite loop was reached. Public `EnumerateSupport()` / `TryEnumerateSupport()`
+        /// methods handle null value differently.
         /// </returns>
         private IEnumerable<TSequence> EnumerateSupportInternalWithDuplicates()
         {

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1652,7 +1652,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 isEpsilonFree: true,
                 usesGroups: false,
                 isDeterminized: true,
-                isZero: true);
+                isZero: true,
+                isEnumerable: true);
         }
 
         /// <summary>
@@ -2016,32 +2017,21 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <returns>The sequences in the support of this automaton</returns>
         public IEnumerable<TSequence> EnumerateSupport(int maxCount = 1000000, bool tryDeterminize = true)
         {
-            if (tryDeterminize && this is StringAutomaton)
+            int idx = 0;
+            foreach (var seq in this.EnumerateSupportInternal(tryDeterminize))
             {
-                this.TryDeterminize();
-            }
-
-            // Lazily return sequences until the count is exceeded.
-            var enumeration = this.EnumerateSupport(
-                new Stack<TElement>(),
-                new ArrayDictionary<bool>(),
-                this.Start.Index);
-
-            if (!tryDeterminize) enumeration = enumeration.Distinct();
-            var result = enumeration.Select(
-                (seq, idx) =>
+                if (seq == null)
                 {
-                    if (idx < maxCount)
-                    {
-                        return seq;
-                    }
-                    else
-                    {
-                        throw new AutomatonEnumerationCountException(maxCount);
-                    }
-                });
+                    throw new NotSupportedException("Infinite loops cannot be enumerated");
+                }
 
-            return result;
+                if (++idx > maxCount)
+                {
+                    throw new AutomatonEnumerationCountException(maxCount);
+                }
+
+                yield return seq;
+            }
         }
 
         /// <summary>
@@ -2054,16 +2044,20 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <returns>True if successful, false otherwise</returns>
         public bool TryEnumerateSupport(int maxCount, out IEnumerable<TSequence> result, bool tryDeterminize = true)
         {
-            if (tryDeterminize && this is StringAutomaton)
+            var limitedResult = new List<TSequence>();
+            foreach (var seq in this.EnumerateSupportInternal(tryDeterminize))
             {
-                this.TryDeterminize();
+                if (seq == null || limitedResult.Count >= maxCount)
+                {
+                    result = null;
+                    return false;
+                }
+
+                limitedResult.Add(seq);
             }
 
-
-            result = this.EnumerateSupport(new Stack<TElement>(), new ArrayDictionary<bool>(), this.Start.Index);
-            if (!tryDeterminize) result = result.Distinct();
-            result = result.Take(maxCount + 1).ToList();
-            return result.Count() <= maxCount;
+            result = limitedResult;
+            return true;
         }
 
         /// <summary>
@@ -2523,72 +2517,190 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             automaton.PruneStatesWithLogEndWeightLessThan = dummy;
         }
 
+        private IEnumerable<TSequence> EnumerateSupportInternal(bool tryDeterminize)
+        {
+            var isEnumerable = this.Data.IsEnumerable;
+            if (isEnumerable != null && isEnumerable.Value == false)
+            {
+                // This automaton is definitely not enumerable
+                return new TSequence[] { null };
+            }
+
+            if (tryDeterminize && this is StringAutomaton)
+            {
+                this.TryDeterminize();
+            }
+
+            var enumeration = this.EnumerateSupportInternalWithDuplicates();
+            if (!tryDeterminize)
+            {
+                enumeration = enumeration.Distinct();
+            }
+
+            return enumeration;
+        }
+
+        private struct StateEnumerationState
+        {
+            public int StateIndex;
+            public int PrefixLength;
+            public int TransitionIndex;
+            public int TransitionsCount;
+            public IEnumerator<TElement> ElementEnumerator;
+        }
+
         /// <summary>
         /// Recursively enumerate support of this automaton
         /// </summary>
-        /// <param name="prefix">The prefix at this point</param>
-        /// <param name="visitedStates">The states visited at this point</param>
-        /// <param name="stateIndex">The index of the next state to process</param>
-        /// <returns>The strings supporting this automaton</returns>
-        private IEnumerable<TSequence> EnumerateSupport(Stack<TElement> prefix, ArrayDictionary<bool> visitedStates, int stateIndex)
+        /// <returns>
+        /// The sequences supporting this automaton. Sequences may be non-distinct if
+        /// automaton is not determinized. A `null` value in enumeration means that
+        /// an infinite loop was reached. (public `EnumerateSupport()` / `TryEnumerateSupport()`
+        /// methods handle this differently.
+        /// </returns>
+        private IEnumerable<TSequence> EnumerateSupportInternalWithDuplicates()
         {
-            if (visitedStates.ContainsKey(stateIndex) && visitedStates[stateIndex])
+            var visited = new bool[this.States.Count];
+            var prefix = new List<TElement>();
+            var stack = new Stack<StateEnumerationState>();
+
+            if (this.Start.CanEnd)
             {
-                throw new NotSupportedException("Infinite loops cannot be enumerated");
+                yield return SequenceManipulator.ToSequence(Enumerable.Empty<TElement>());
             }
 
-            var currentState = this.States[stateIndex];
-            if (currentState.CanEnd)
+            var startState = this.Data.States[this.Data.StartStateIndex];
+            var current = new StateEnumerationState
             {
-                yield return SequenceManipulator.ToSequence(prefix.Reverse());
-            }
+                StateIndex = this.Data.StartStateIndex,
+                TransitionIndex = startState.FirstTransitionIndex - 1,
+                TransitionsCount = startState.TransitionsCount,
+            };
 
-            visitedStates[stateIndex] = true;
-            foreach (var transition in currentState.Transitions)
+            while (true)
             {
-                if (transition.Weight.IsZero)
+                // Backtrack while needed
+                while (current.ElementEnumerator == null && current.TransitionsCount == 0)
                 {
-                    continue;
-                }
-
-                if (transition.IsEpsilon)
-                {
-                    foreach (var support in this.EnumerateSupport(prefix, visitedStates, transition.DestinationStateIndex))
+                    if (stack.Count == 0)
                     {
-                        yield return support;
-                    }
-                }
-                else if (transition.ElementDistribution.Value.IsPointMass)
-                {
-                    prefix.Push(transition.ElementDistribution.Value.Point);
-                    foreach (var support in this.EnumerateSupport(prefix, visitedStates, transition.DestinationStateIndex))
-                    {
-                        yield return support;
-                    }
-
-                    prefix.Pop();
-                }
-                else
-                {
-                    if (!(transition.ElementDistribution.Value is CanEnumerateSupport<TElement> supportEnumerator))
-                    {
-                        throw new NotImplementedException("Only point mass element distributions or distributions for which we can enumerate support are currently implemented");
-                    }
-
-                    foreach (var elt in supportEnumerator.EnumerateSupport())
-                    {
-                        prefix.Push(elt);
-                        foreach (var support in this.EnumerateSupport(prefix, visitedStates, transition.DestinationStateIndex))
+                        // Nowhere to backtrack, enumerated everything
+                        if (this.Data.IsEnumerable == null)
                         {
-                            yield return support;
+                            this.Data = this.Data.With(isEnumerable: true);
                         }
 
-                        prefix.Pop();
+                        yield break;
                     }
+
+                    visited[current.StateIndex] = false;
+                    current = stack.Pop();
+                    prefix.RemoveRange(current.PrefixLength, prefix.Count - current.PrefixLength);
+                }
+
+                if (current.ElementEnumerator != null)
+                {
+                    // Advance to next element in current transition
+                    prefix.Add(current.ElementEnumerator.Current);
+                    if (!current.ElementEnumerator.MoveNext())
+                    {
+                        // Element done, move to next transition
+                        current.ElementEnumerator = null;
+                    }
+                }
+                else if (current.TransitionsCount != 0)
+                {
+                    // Advance to next transition
+                    ++current.TransitionIndex;
+                    --current.TransitionsCount;
+
+                    var transition = this.Data.Transitions[current.TransitionIndex];
+
+                    if (!transition.IsEpsilon)
+                    {
+                        // Add next element to sequence
+                        var elementDistribution = transition.ElementDistribution.Value;
+                        if (!(transition.ElementDistribution.Value is CanEnumerateSupport<TElement> supportEnumerator))
+                        {
+                            throw new NotImplementedException(
+                                "Only point mass element distributions or distributions for which we can enumerate support are currently implemented");
+                        }
+
+                        var enumerator = supportEnumerator.EnumerateSupport().GetEnumerator();
+                        if (enumerator.MoveNext())
+                        {
+                            prefix.Add(enumerator.Current);
+                            if (enumerator.MoveNext())
+                            {
+                                current.ElementEnumerator = enumerator;
+                            }
+                        }
+                    }
+                }
+
+                if (!TryMoveTo(this.Data.Transitions[current.TransitionIndex].DestinationStateIndex))
+                {
+                    // Found a loop, signal that automaton is not enumerable
+                    this.Data = this.Data.With(isEnumerable: false);
+                    yield return null;
+                    yield break;
+                }
+
+                if (this.States[current.StateIndex].CanEnd)
+                {
+                    yield return SequenceManipulator.ToSequence(prefix);
                 }
             }
 
-            visitedStates[stateIndex] = false;
+            // Return false if loop was encountered
+            bool TryMoveTo(int index)
+            {
+                if (visited[index])
+                {
+                    // Loop encountered
+                    return false;
+                }
+
+                var state =this.Data.States[index];
+
+                // Fastpath: if we move forward and current state has 0 elements left to traverse,
+                // we can omit the backtracking logic entirely
+                if (index >= current.StateIndex &&
+                    current.ElementEnumerator == null &&
+                    current.TransitionsCount == 0)
+                {
+                    visited[current.StateIndex] = false;
+
+                    current = new StateEnumerationState
+                    {
+                        StateIndex = index,
+                        TransitionIndex = state.FirstTransitionIndex - 1,
+                        TransitionsCount = state.TransitionsCount,
+                        PrefixLength = prefix.Count,
+                    };
+
+                    return true;
+                }
+
+                stack.Push(current);
+                if (index <= current.StateIndex)
+                {
+                    // Tracking the visited states only on backward transitions is enough for
+                    // loop detection. By not setting "visited" to true for forward transitions
+                    // we can backtrack with less overhead in simple cases
+                    visited[current.StateIndex] = true;
+                }
+
+                current = new StateEnumerationState
+                {
+                    StateIndex = index,
+                    TransitionIndex = state.FirstTransitionIndex - 1,
+                    TransitionsCount = state.TransitionsCount,
+                    PrefixLength = prefix.Count,
+                };
+
+                return true;
+            }
         }
 
         /// <summary>

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -2551,12 +2551,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             public int StateIndex;
             public int PrefixLength;
             public int TransitionIndex;
-            public int TransitionsCount;
+            public int RemainingTransitionsCount;
             public IEnumerator<TElement> ElementEnumerator;
         }
 
         /// <summary>
-        /// Enumerate support of this automaton without elemination of duplicate elements
+        /// Enumerate support of this automaton without elimination of duplicate elements
         /// </summary>
         /// <returns>
         /// The sequences supporting this automaton. Sequences may be non-distinct if
@@ -2580,13 +2580,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             {
                 StateIndex = this.Data.StartStateIndex,
                 TransitionIndex = startState.FirstTransitionIndex - 1,
-                TransitionsCount = startState.TransitionsCount,
+                RemainingTransitionsCount = startState.TransitionsCount,
             };
 
             while (true)
             {
                 // Backtrack while needed
-                while (current.ElementEnumerator == null && current.TransitionsCount == 0)
+                while (current.ElementEnumerator == null && current.RemainingTransitionsCount == 0)
                 {
                     if (stack.Count == 0)
                     {
@@ -2614,11 +2614,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         current.ElementEnumerator = null;
                     }
                 }
-                else if (current.TransitionsCount != 0)
+                else if (current.RemainingTransitionsCount != 0)
                 {
                     // Advance to next transition
                     ++current.TransitionIndex;
-                    --current.TransitionsCount;
+                    --current.RemainingTransitionsCount;
 
                     var transition = this.Data.Transitions[current.TransitionIndex];
 
@@ -2673,7 +2673,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 // we can omit the backtracking logic entirely
                 if (index >= current.StateIndex &&
                     current.ElementEnumerator == null &&
-                    current.TransitionsCount == 0)
+                    current.RemainingTransitionsCount == 0)
                 {
                     visited[current.StateIndex] = false;
 
@@ -2681,7 +2681,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     {
                         StateIndex = index,
                         TransitionIndex = state.FirstTransitionIndex - 1,
-                        TransitionsCount = state.TransitionsCount,
+                        RemainingTransitionsCount = state.TransitionsCount,
                         PrefixLength = prefix.Count,
                     };
 
@@ -2701,7 +2701,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 {
                     StateIndex = index,
                     TransitionIndex = state.FirstTransitionIndex - 1,
-                    TransitionsCount = state.TransitionsCount,
+                    RemainingTransitionsCount = state.TransitionsCount,
                     PrefixLength = prefix.Count,
                 };
 

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -937,7 +937,8 @@ namespace Microsoft.ML.Probabilistic.Tests
                     isEpsilonFree: true,
                     usesGroups: false,
                     isDeterminized: null,
-                    isZero: null));
+                    isZero: null,
+                    isEnumerable: null));
 
             StringInferenceTestUtilities.TestValue(automaton1, 1.0, string.Empty, "a");
             StringInferenceTestUtilities.TestValue(automaton1, 0.0, "b");
@@ -951,7 +952,8 @@ namespace Microsoft.ML.Probabilistic.Tests
                     isEpsilonFree: true,
                     usesGroups: false,
                     isDeterminized: true,
-                    isZero: true));
+                    isZero: true,
+                    isEnumerable: true));
             Assert.True(automaton2.IsZero());
 
             // Bad start state index
@@ -964,7 +966,8 @@ namespace Microsoft.ML.Probabilistic.Tests
                         isEpsilonFree: true,
                         usesGroups: false,
                         isDeterminized: false,
-                        isZero: true)));
+                        isZero: true,
+                        isEnumerable: false)));
 
             // automaton is actually epsilon-free, but data says that it is
             Assert.Throws<ArgumentException>(
@@ -976,7 +979,8 @@ namespace Microsoft.ML.Probabilistic.Tests
                         isEpsilonFree: false,
                         usesGroups: false,
                         isDeterminized: null,
-                        isZero: null)));
+                        isZero: null,
+                        isEnumerable: null)));
 
             // automaton is not epsilon-free
             Assert.Throws<ArgumentException>(
@@ -988,7 +992,8 @@ namespace Microsoft.ML.Probabilistic.Tests
                         isEpsilonFree: false,
                         usesGroups: false,
                         isDeterminized: null,
-                        isZero: null)));
+                        isZero: null,
+                        isEnumerable: null)));
 
             // Incorrect transition index
             Assert.Throws<ArgumentException>(
@@ -1000,7 +1005,8 @@ namespace Microsoft.ML.Probabilistic.Tests
                         true,
                         false,
                         isDeterminized: null,
-                        isZero: null)));
+                        isZero: null,
+                        isEnumerable: null)));
         }
 
         #region ToString tests
@@ -2202,6 +2208,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             builder[0].AddTransition(DiscreteChar.UniformOver('c', 'd'), Weight.FromValue(1), 2);
             builder[2].AddTransition(DiscreteChar.UniformOver('e', 'f'), Weight.FromValue(1), 3);
             builder[2].AddTransition(DiscreteChar.UniformOver('g', 'h'), Weight.FromValue(1), 4);
+            builder[2].AddEpsilonTransition(Weight.FromValue(1), 4);
             builder[4].AddTransition(DiscreteChar.UniformOver('i', 'j'), Weight.FromValue(1), 5);
             builder[4].AddTransition(DiscreteChar.UniformOver('k', 'l'), Weight.FromValue(1), 5);
 
@@ -2218,14 +2225,54 @@ namespace Microsoft.ML.Probabilistic.Tests
                 "ce", "cf",
                 "cgi", "cgj", "cgk", "cgl",
                 "chi", "chj", "chk", "chl",
+                "ci", "cj", "ck", "cl",
                 "de", "df",
                 "dgi", "dgj", "dgk", "dgl",
-                "dhi", "dhj", "dhk", "dhl"
+                "dhi", "dhj", "dhk", "dhl",
+                "di", "dj", "dk", "dl"
             };
 
-            var caclulatedSupport = new HashSet<string>(automaton.EnumerateSupport());
+            var calculatedSupport1= new HashSet<string>(automaton.EnumerateSupport(tryDeterminize: false));
+            Assert.True(calculatedSupport1.SetEquals(expectedSupport));
 
-            Assert.True(caclulatedSupport.SetEquals(expectedSupport));
+            var calculatedSupport2 = new HashSet<string>(automaton.EnumerateSupport(tryDeterminize: true));
+            Assert.True(calculatedSupport2.SetEquals(expectedSupport));
+        }
+
+        /// <summary>
+        /// Tests enumeration of support.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "StringInference")]
+        public void EnumerateSupportThrowsOnLoop()
+        {
+            var builder = new StringAutomaton.Builder();
+            builder.Start
+                .AddTransition('a', Weight.One)
+                .AddTransition('a', Weight.One, 0)
+                .SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
+
+            Assert.Throws<NotSupportedException>(() => automaton.EnumerateSupport().ToList());
+        }
+
+        /// <summary>
+        /// Tests enumeration of support.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "StringInference")]
+        public void TryEnumerateSupportReturnsFalseOnLoop()
+        {
+            var builder = new StringAutomaton.Builder();
+            builder.Start
+                .AddTransition('a', Weight.One)
+                .AddTransition('a', Weight.One, 0)
+                .SetEndWeight(Weight.One);
+
+            var automaton = builder.GetAutomaton();
+
+            Assert.False(automaton.TryEnumerateSupport(Int32.MaxValue, out _));
         }
 
         [Trait("Category", "BadTest")] // Performance tests which look for exact timings are likely to fail on the build machine

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -2212,6 +2212,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             builder[4].AddTransition(DiscreteChar.UniformOver('i', 'j'), Weight.FromValue(1), 5);
             builder[4].AddTransition(DiscreteChar.UniformOver('k', 'l'), Weight.FromValue(1), 5);
 
+            builder[0].SetEndWeight(Weight.FromValue(1));
             builder[1].SetEndWeight(Weight.FromValue(1));
             builder[3].SetEndWeight(Weight.FromValue(1));
             builder[5].SetEndWeight(Weight.FromValue(1));
@@ -2221,6 +2222,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
             var expectedSupport = new HashSet<string>
             {
+                "",
                 "a", "b", 
                 "ce", "cf",
                 "cgi", "cgj", "cgk", "cgl",


### PR DESCRIPTION
Contracts has been changed: `TryEnumerateSupport()` does not throw if it encounters non-enumerable automata.

- Implementation of `TryEnumerateSupport` was changed a lot:
  - It avoids recursion (and "stacked IEnumerables")
  - An optimization has been added - traversing states with single point-mass forward transition
    (90+% of real-world cases) is cheaper, because it avoids some extra allocations

Also "is enumerable" status is cached. It is set proactively at automaton construction
in 2 common cases which are cheap to detect:
  - automaton with self-loops can not be enumerated
  - automaton with only forward transitions (and thus no loops) can always be enumerated

In all other cases this flag is calculated lazily on first enumeration try.