### PR TITLE
Remove Owner field from Automaton.State

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.DataContainer.cs
@@ -179,7 +179,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 this.States = ((StateData[])info.GetValue(nameof(this.States), typeof(StateData[]))).ToImmutableArray();
                 this.Transitions = ((Transition[])info.GetValue(nameof(this.Transitions), typeof(Transition[]))).ToImmutableArray();
 
-                if (!IsConsistent())
+                if (!this.IsConsistent())
                 {
                     throw new Exception("Deserialized automaton is inconsistent!");
                 }

--- a/src/Runtime/Distributions/Automata/Automaton.EpsilonClosure.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.EpsilonClosure.cs
@@ -31,10 +31,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// Initializes a new instance of the <see cref="EpsilonClosure"/> class.
             /// </summary>
+            /// <param name="automaton">The automaton from to which <paramref name="state"/> belongs.</param>
             /// <param name="state">The state, which epsilon closure this instance will represent.</param>
-            internal EpsilonClosure(State state)
+            internal EpsilonClosure(
+                Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> automaton,
+                State state)
             {
-                weightedStates = new List<(State, Weight)>(DefaultStateListCapacity);
+                this.weightedStates = new List<(State, Weight)>(DefaultStateListCapacity);
 
                 // Optimize for a very common case: a single-node closure
                 bool singleNodeClosure = true;
@@ -61,7 +64,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 }
                 else
                 {
-                    Condensation condensation = state.Owner.ComputeCondensation(state, tr => tr.IsEpsilon, true);
+                    Condensation condensation = automaton.ComputeCondensation(state, tr => tr.IsEpsilon, true);
                     for (int i = 0; i < condensation.ComponentCount; ++i)
                     {
                         StronglyConnectedComponent component = condensation.GetComponent(i);

--- a/src/Runtime/Distributions/Automata/Automaton.State.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.State.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -18,9 +18,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// Represents a reference to a state of automaton for exposure in public API.
         /// </summary>
         /// <remarks>
-        /// Acts as a "fat reference" to state in automaton. In addition to reference to actual StateData it carries
-        /// 3 additional properties for convenience: <see cref="Owner"/> automaton, <see cref="Index"/> of the state
-        /// and full <see cref="transitions"/> table.
+        /// Acts as a "fat reference" to state in automaton. In addition to reference to actual
+        /// StateData it carries 2 additional properties for convenience: <see cref="Index"/>
+        /// of the state and full <see cref="transitions"/> table.
         /// </remarks>
         public struct State : IEquatable<State>
         {
@@ -33,21 +33,14 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// to wrap StateData for use in public Automaton APIs.
             /// </summary>
             internal State(
-                Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> owner,
                 ImmutableArray<StateData> states,
                 ImmutableArray<Transition> transitions,
                 int index)
             {
-                this.Owner = owner;
                 this.states = states;
                 this.transitions = transitions;
                 this.Index = index;
             }
-
-            /// <summary>
-            /// Gets automaton to which this state belongs.
-            /// </summary>
-            public Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> Owner { get; }
 
             /// <summary>
             /// Gets the index of the state.
@@ -58,7 +51,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// Gets the ending weight of the state.
             /// </summary>
             public Weight EndWeight => this.Data.EndWeight;
-            
+
             /// <summary>
             /// Gets a value indicating whether the ending weight of this state is greater than zero.
             /// </summary>
@@ -75,8 +68,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <summary>
             /// Compares 2 states for equality.
             /// </summary>
-            public static bool operator ==(State a, State b) =>
-                ReferenceEquals(a.Owner, b.Owner) && a.Index == b.Index;
+            public static bool operator ==(State a, State b) => a.Index == b.Index;
 
             /// <summary>
             /// Compares 2 states for inequality.
@@ -100,16 +92,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <returns>A string that represents the state.</returns>
             public override string ToString()
             {
-                const string StartStateMarker = "START ->";
                 const string TransitionSeparator = ",";
 
                 var sb = new StringBuilder();
-
-                var isStartState = this.Owner != null && this.Owner.Start == this;
-                if (isStartState)
-                {
-                    sb.Append(StartStateMarker);
-                }
 
                 var firstTransition = true;
                 foreach (var transition in this.Transitions)
@@ -137,34 +122,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 }
 
                 return sb.ToString();
-            }
-
-            /// <summary>
-            /// Gets the epsilon closure of this state.
-            /// </summary>
-            /// <returns>The epsilon closure of this state.</returns>
-            public EpsilonClosure GetEpsilonClosure() => new EpsilonClosure(this);
-
-            /// <summary>
-            /// Whether there are incoming transitions to this state
-            /// </summary>
-            public bool HasIncomingTransitions
-            {
-                get
-                {
-                    foreach (var state in this.Owner.States)
-                    {
-                        foreach (var transition in state.Transitions)
-                        {
-                            if (transition.DestinationStateIndex == this.Index)
-                            {
-                                return true;
-                            }
-                        }
-                    }
-
-                    return false;
-                }
             }
 
             #region Serialization

--- a/src/Runtime/Distributions/Automata/Automaton.StateCollection.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.StateCollection.cs
@@ -33,17 +33,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             internal readonly ImmutableArray<Transition> transitions;
 
             /// <summary>
-            /// Owner automaton of all states in collection.
-            /// </summary>
-            private readonly Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> owner;
-
-            /// <summary>
             /// Initializes instance of <see cref="StateCollection"/>.
             /// </summary>
             internal StateCollection(
                 Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis> owner)
             {
-                this.owner = owner;
                 this.states = owner.Data.States;
                 this.transitions = owner.Data.Transitions;
             }
@@ -51,7 +45,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             #region IReadOnlyList<State> methods
 
             /// <inheritdoc/>
-            public State this[int index] => new State(this.owner, this.states, this.transitions, index);
+            public State this[int index] => new State(this.states, this.transitions, index);
 
             /// <inheritdoc/>
             public int Count => this.states.Count;

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -65,14 +65,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <summary>
         /// Cached states representation of states for zero automaton.
         /// </summary>
-        private static readonly ImmutableArray<StateData> ZeroStates =
+        private static readonly ImmutableArray<StateData> SingleState =
             ImmutableArray.Create(new StateData(0, 0, Weight.Zero));
-
-        /// <summary>
-        /// Cached states representation of transitions for zero automaton.
-        /// </summary>
-        private static readonly ImmutableArray<Transition> ZeroTransitions =
-            ImmutableArray<Transition>.Empty;
 
         /// <summary>
         /// The maximum number of states an automaton can have.
@@ -1412,7 +1406,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 // Iterate over transitions in state1
                 foreach (var transition1 in state1.Transitions)
                 {
-                    var destState1 = state1.Owner.States[transition1.DestinationStateIndex];
+                    var destState1 = automaton1.States[transition1.DestinationStateIndex];
 
                     if (transition1.IsEpsilon)
                     {
@@ -1428,7 +1422,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         Debug.Assert(
                             !transition2.IsEpsilon,
                             "The second argument of the product operation must be epsilon-free.");
-                        var destState2 = state2.Owner.States[transition2.DestinationStateIndex];
+                        var destState2 = automaton2.States[transition2.DestinationStateIndex];
                         var productLogNormalizer = Distribution<TElement>.GetLogAverageOf(
                             transition1.ElementDistribution.Value, transition2.ElementDistribution.Value,
                             out var product);
@@ -1647,8 +1641,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         {
             this.Data = new DataContainer(
                 0,
-                ZeroStates,
-                ZeroTransitions,
+                SingleState,
+                ImmutableArray<Transition>.Empty,
                 isEpsilonFree: true,
                 usesGroups: false,
                 isDeterminized: true,
@@ -1829,7 +1823,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     }
                     else
                     {
-                        var closure = this.States[stateIndex].GetEpsilonClosure();
+                        var closure = new EpsilonClosure(this, this.States[stateIndex]);
 
                         if (sequencePos == sequenceLength)
                         {
@@ -2223,8 +2217,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             while (stack.Count > 0)
             {
                 var oldStateIndex = stack.Pop();
-                var oldState = automaton.States[oldStateIndex];
-                var closure = oldState.GetEpsilonClosure();
+                var closure = new EpsilonClosure(automaton, automaton.States[oldStateIndex]);
                 var resultState = builder[oldToNewState[oldStateIndex].Value];
 
                 resultState.SetEndWeight(closure.EndWeight);
@@ -2655,15 +2648,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             // Return false if loop was encountered
             bool TryMoveTo(int index)
             {
-                if (visited[index])
-                {
-                    // Loop encountered
-                    return false;
-                }
-
-                var state = this.Data.States[index];
-
-                
+               
                 if (index >= current.StateIndex &&
                     current.ElementEnumerator == null &&
                     current.RemainingTransitionsCount == 0)
@@ -2685,6 +2670,13 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     }
                 }
 
+                if (visited[index])
+                {
+                    // Loop encountered
+                    return false;
+                }
+
+                var state = this.Data.States[index];
                 current = new StateEnumerationState
                 {
                     StateIndex = index,

--- a/src/Runtime/Distributions/Automata/RegexpTreeBuilder.cs
+++ b/src/Runtime/Distributions/Automata/RegexpTreeBuilder.cs
@@ -199,7 +199,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         {
                             var s = currentComponent.GetStateByIndex(i);
                             var sIdx = s.Index;
-                            foreach (var s1 in s.Owner.States)
+                            foreach (var s1 in automaton.States)
                             {
                                 if (currentComponent.HasState(s1))
                                 {
@@ -381,7 +381,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     }
 
                     int destStateIndex;
-                    if ((destStateIndex = component.GetIndexByState(state.Owner.States[transition.DestinationStateIndex])) != -1)
+                    if ((destStateIndex = component.GetIndexByState(component.Automaton.States[transition.DestinationStateIndex])) != -1)
                     {
                         var destStateRegexp = transition.IsEpsilon
                                 ? RegexpTreeNode<TElement>.Empty()

--- a/src/Runtime/Distributions/Automata/TransducerBase.cs
+++ b/src/Runtime/Distributions/Automata/TransducerBase.cs
@@ -361,7 +361,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 // Iterate over transitions from mappingState
                 foreach (var mappingTransition in mappingState.Transitions)
                 {
-                    var childMappingState = mappingState.Owner.States[mappingTransition.DestinationStateIndex];
+                    var childMappingState = mappingAutomaton.States[mappingTransition.DestinationStateIndex];
 
                     // Epsilon transition case
                     if (IsSrcEpsilon(mappingTransition))
@@ -380,7 +380,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     {
                         Debug.Assert(!srcTransition.IsEpsilon, "The automaton being projected must be epsilon-free.");
                         
-                        var srcChildState = srcState.Owner.States[srcTransition.DestinationStateIndex];
+                        var srcChildState = srcAutomaton.States[srcTransition.DestinationStateIndex];
 
                         var projectionLogScale = mappingTransition.ElementDistribution.Value.ProjectFirst(
                             srcTransition.ElementDistribution.Value, out var destElementDistribution);
@@ -492,7 +492,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 // Enumerate transitions from the current mapping state
                 foreach (var mappingTransition in mappingState.Transitions)
                 {
-                    var destMappingState = mappingState.Owner.States[mappingTransition.DestinationStateIndex];
+                    var destMappingState = mappingAutomaton.States[mappingTransition.DestinationStateIndex];
 
                     // Epsilon transition case
                     if (IsSrcEpsilon(mappingTransition))

--- a/src/Runtime/Factors/SingleOp.cs
+++ b/src/Runtime/Factors/SingleOp.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Probabilistic.Factors
 
             Vector resultLogProb = PiecewiseVector.Constant(char.MaxValue + 1, double.NegativeInfinity);
             StringAutomaton probFunc = str.GetWorkspaceOrPoint();
-            StringAutomaton.EpsilonClosure startEpsilonClosure = probFunc.Start.GetEpsilonClosure();
+            StringAutomaton.EpsilonClosure startEpsilonClosure = new Automaton<string, char, DiscreteChar, StringManipulator, StringAutomaton>.EpsilonClosure(probFunc, probFunc.Start);
             for (int stateIndex = 0; stateIndex < startEpsilonClosure.Size; ++stateIndex)
             {
                 StringAutomaton.State state = startEpsilonClosure.GetStateByIndex(stateIndex);
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Probabilistic.Factors
                     if (!transition.IsEpsilon)
                     {
                         StringAutomaton.State destState = probFunc.States[transition.DestinationStateIndex];
-                        StringAutomaton.EpsilonClosure destStateClosure = destState.GetEpsilonClosure();
+                        StringAutomaton.EpsilonClosure destStateClosure = new Automaton<string, char, DiscreteChar, StringManipulator, StringAutomaton>.EpsilonClosure(probFunc, destState);
                         if (!destStateClosure.EndWeight.IsZero)
                         {
                             Weight weight = Weight.Product(stateLogWeight, transition.Weight, destStateClosure.EndWeight);

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -709,7 +709,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
                 // Make sure it doesn't contain epsilon transitions
                 Assert.True(automaton.States.All(s => s.Transitions.All(t => !t.IsEpsilon)));
-        }
+            }
         }
 
         /// <summary>
@@ -732,7 +732,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             state.SetEndWeight(Weight.One);
 
             var automaton = builder.GetAutomaton();
-            var closure = automaton.Start.GetEpsilonClosure();
+            var closure = new Automaton<string, char, DiscreteChar, StringManipulator, StringAutomaton>.EpsilonClosure(automaton, automaton.Start);
             
             Assert.Equal(ChainLength + 1, closure.Size);
             Assert.Equal(Math.Log(1 << ChainLength), closure.EndWeight.LogValue);
@@ -2295,6 +2295,10 @@ namespace Microsoft.ML.Probabilistic.Tests
             builder[3].SetEndWeight(Weight.FromValue(1));
             builder[5].SetEndWeight(Weight.FromValue(1));
             builder[6].SetEndWeight(Weight.FromValue(1));
+
+            var s = builder[5];
+            for (var i = 0; i < 100; ++i) s = s.AddTransition('a', Weight.One);
+            s.SetEndWeight(Weight.One);
 
             var automaton = builder.GetAutomaton();
 

--- a/test/Tests/Strings/LoopyAutomatonTests.cs
+++ b/test/Tests/Strings/LoopyAutomatonTests.cs
@@ -629,14 +629,15 @@ namespace Microsoft.ML.Probabilistic.Tests
 
             AssertStochastic(automaton);
 
-            StringAutomaton.EpsilonClosure startClosure = automaton.Start.GetEpsilonClosure();
+            StringAutomaton.EpsilonClosure startClosure = new Automaton<string, char, DiscreteChar, StringManipulator, StringAutomaton>.EpsilonClosure(automaton, automaton.Start);
             Assert.Equal(3, startClosure.Size);
             Assert.Equal(0.0, startClosure.EndWeight.LogValue, 1e-8);
 
             for (int i = 0; i < startClosure.Size; ++i)
             {
                 Weight weight = startClosure.GetStateWeightByIndex(i);
-                double expectedWeight = startClosure.GetStateByIndex(i) == automaton.Start ? 10 : 4;
+                var state = startClosure.GetStateByIndex(i);
+                double expectedWeight = state == automaton.Start ? 10 : 4;
                 Assert.Equal(expectedWeight, weight.Value, 1e-8);
             }
         }


### PR DESCRIPTION
It really is not required - at all points it is known with which automaton we operate right now.

Also, where only state index was needed we store now the `int` index instead of fat `State` object
which contains extra information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/infer/220)
<!-- Reviewable:end -->
