### PR TITLE
Add GetElementsUntyped method to ICollectionDistribution interface

### DIFF
--- a/src/Runtime/Distributions/Distribution.cs
+++ b/src/Runtime/Distributions/Distribution.cs
@@ -49,12 +49,17 @@ namespace Microsoft.ML.Probabilistic.Distributions
     /// <summary>
     /// Interface to allow untyped access to collection distribution
     /// </summary>
-    public interface ICollectionDistribution
+    public interface ICollectionDistribution : IDistribution
     {
         /// <summary>
         /// Returns the count of known elements in collection distribution.
         /// </summary>
         int GetElementsCount();
+
+        /// <summary>
+        /// Returns the list of elements' distributions.
+        /// </summary>
+        List<IDistribution> GetElementsUntyped();
 
         /// <summary>
         /// Product of two collection distributions which also return element mapping information.


### PR DESCRIPTION
Add `GetElementsUntyped` method to `ICollectionDistribution` interface to be able to get elements for the collection without knowing of the element type.