### PR TITLE
Implement concatenation operation for automata and transudcers

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -600,6 +600,36 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         }
 
         /// <summary>
+        /// Creates an automaton which is the concatenation of given automata.
+        /// </summary>
+        /// <param name="automata">The automata to multiply.</param>
+        /// <returns>The created automaton.</returns>
+        public static TThis Concatenate(params TThis[] automata)
+        {
+            return Concatenate((IEnumerable<TThis>)automata);
+        }
+
+        /// <summary>
+        /// Creates an automaton which is the concatenation of given automata.
+        /// </summary>
+        /// <param name="automata">The automata to multiply.</param>
+        /// <returns>The created automaton.</returns>
+        public static TThis Concatenate(IEnumerable<TThis> automata)
+        {
+            Argument.CheckIfNotNull(automata, "automata");
+
+            var builder = new Builder(1);
+            builder.Start.SetEndWeight(Weight.One);
+
+            foreach (var automaton in automata)
+            {
+                builder.Append(automaton);
+            }
+
+            return builder.GetAutomaton();
+        }
+
+        /// <summary>
         /// Creates an automaton which has given values on given sequences and is zero everywhere else.
         /// </summary>
         /// <param name="sequenceToValue">The collection of pairs of a sequence and the automaton value on that sequence.</param>

--- a/src/Runtime/Distributions/Automata/TransducerBase.cs
+++ b/src/Runtime/Distributions/Automata/TransducerBase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -206,6 +206,28 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             Argument.CheckIfNotNull(transducers, "transducers");
 
             return new TThis { sequencePairToWeight = PairListAutomaton.Sum(transducers.Select(t => t.sequencePairToWeight)) };
+        }
+
+        /// <summary>
+        /// Creates an automaton which is the concatenation of given transducers.
+        /// </summary>
+        /// <param name="transducers">The transducers to concatenate.</param>
+        /// <returns>The created transucer.</returns>
+        public static TThis Concatenate(params TThis[] transducers)
+        {
+            return Concatenate((IEnumerable<TThis>)transducers);
+        }
+
+        /// <summary>
+        /// Creates an automaton which is the concatenation of given transducers.
+        /// </summary>
+        /// <param name="transducers">The transducers to concatenate.</param>
+        /// <returns>The created transucer.</returns>
+        public static TThis Concatenate(IEnumerable<TThis> transducers)
+        {
+            Argument.CheckIfNotNull(transducers, "transducers");
+
+            return new TThis { sequencePairToWeight = PairListAutomaton.Concatenate(transducers.Select(t => t.sequencePairToWeight)) };
         }
 
         /// <summary>


### PR DESCRIPTION
`AppendInplace()` is not inplace anymore, it creates a copy of automata under the hood.
This makes calling it repeatedly quite expensive, because runtime will grow quadratically
with the number of calls. This method should be removed in future.

As a replacement a new method is introduced - `Concatenate()` which concatenates multiple
automata/transducers at once. It is significantly faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/infer/223)
<!-- Reviewable:end -->
