### PR TITLE
Fix AssemblyNamePrefix usage

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -16,5 +16,29 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <SharedVersionOutputDirectory>$(MSBuildThisFileDirectory)\src\Shared</SharedVersionOutputDirectory>
+
+    <!--
+      Generate assembly info so that IntervalsVisibleTo
+      can be specified in ProjectFile, where we have access to
+      AssemblyNamePrefix
+    -->
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    
+    <!--
+      Disable generation of assembly properties where their values
+      differ for NuGet packages and assemblies. For these
+      properties are defined in AssemblyInfo files.
+    -->
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+
+    <!--
+      We currently generate versions manually using SharedAssemblyInfo.cs
+      and a tool that updates it.
+    -->
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
   </PropertyGroup>
 </Project>

--- a/src/Csoft/Properties/AssemblyInfo.cs
+++ b/src/Csoft/Properties/AssemblyInfo.cs
@@ -10,9 +10,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Csoft")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Csoft")]
 [assembly: AssemblyCopyright("Copyright ©  2013")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/src/Runtime/Properties/AssemblyInfo.cs
+++ b/src/Runtime/Properties/AssemblyInfo.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly: AssemblyTitle("Microsoft.ML.Probabilistic")]
 [assembly: AssemblyDescription("Run-time library for Infer.NET")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -22,16 +21,8 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("b35ca8e5-42b7-4dc6-9c75-8b94393d4c1d")]
 
-// Compiler and Tests need to be friend assemblies
+// Tests need to be friend assemblies
 
-[assembly:
-    InternalsVisibleTo(
-        "Microsoft.ML.Probabilistic.Compiler,PublicKey=0024000004800000940000000602000000240000525341310004000001000100551f07a755a3e3f2901fa321ab631d13d6192b4e6ac9c87279500f49d6635cde6902587752eff20402f46f6ea9c3d80e827580a799840aaab9a49b1d2597e4c1798ee93c5cb66851e9d22f4d6e8110571f4a2e59f1d760f7be04fb10e7dc43ee7ed2831907731427b9815c5fe7f4888f9933ee7a1ad5d1f293fd8ab834fac1be"
-        )]
-[assembly:
-    InternalsVisibleTo(
-        "AzureML.Microsoft.ML.Probabilistic.Compiler,PublicKey=0024000004800000940000000602000000240000525341310004000001000100551f07a755a3e3f2901fa321ab631d13d6192b4e6ac9c87279500f49d6635cde6902587752eff20402f46f6ea9c3d80e827580a799840aaab9a49b1d2597e4c1798ee93c5cb66851e9d22f4d6e8110571f4a2e59f1d760f7be04fb10e7dc43ee7ed2831907731427b9815c5fe7f4888f9933ee7a1ad5d1f293fd8ab834fac1be"
-        )]
 [assembly:
     InternalsVisibleTo(
         "Microsoft.ML.Probabilistic.Tests,PublicKey=0024000004800000940000000602000000240000525341310004000001000100551f07a755a3e3f2901fa321ab631d13d6192b4e6ac9c87279500f49d6635cde6902587752eff20402f46f6ea9c3d80e827580a799840aaab9a49b1d2597e4c1798ee93c5cb66851e9d22f4d6e8110571f4a2e59f1d760f7be04fb10e7dc43ee7ed2831907731427b9815c5fe7f4888f9933ee7a1ad5d1f293fd8ab834fac1be"

--- a/src/Runtime/Runtime.csproj
+++ b/src/Runtime/Runtime.csproj
@@ -34,4 +34,10 @@
     <Compile Include="..\Shared\SharedAssemblyFileVersion.cs" />
     <Compile Include="..\Shared\SharedAssemblyInfo.cs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>$(AssemblyNamePrefix)Microsoft.ML.Probabilistic.Compiler,PublicKey=0024000004800000940000000602000000240000525341310004000001000100551f07a755a3e3f2901fa321ab631d13d6192b4e6ac9c87279500f49d6635cde6902587752eff20402f46f6ea9c3d80e827580a799840aaab9a49b1d2597e4c1798ee93c5cb66851e9d22f4d6e8110571f4a2e59f1d760f7be04fb10e7dc43ee7ed2831907731427b9815c5fe7f4888f9933ee7a1ad5d1f293fd8ab834fac1be</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/Shared/SharedAssemblyInfo.cs
+++ b/src/Shared/SharedAssemblyInfo.cs
@@ -4,13 +4,7 @@
 
 using System.Reflection;
 
-#if DEBUG
-[assembly: AssemblyConfiguration("Debug")]
-#else
-[assembly: AssemblyConfiguration("Release")]
-#endif
 [assembly: AssemblyCompany("Microsoft Research Limited")]
-[assembly: AssemblyProduct("Microsoft.ML.Probabilistic")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Research Limited 2008-2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/test/Learners/LearnersTests/Properties/AssemblyInfo.cs
+++ b/test/Learners/LearnersTests/Properties/AssemblyInfo.cs
@@ -10,9 +10,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.ML.Probabilistic.Learners.Tests")]
 [assembly: AssemblyDescription("Learner module tests for Infer.NET")]
-[assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Research Limited")]
-[assembly: AssemblyProduct("Microsoft.ML.Probabilistic")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Research Limited 2013")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/test/Learners/TestApp/Properties/AssemblyInfo.cs
+++ b/test/Learners/TestApp/Properties/AssemblyInfo.cs
@@ -10,9 +10,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.ML.Probabilistic.Learners.TestApp")]
 [assembly: AssemblyDescription("Learner module test application for Infer.NET")]
-[assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Research Limited")]
-[assembly: AssemblyProduct("Microsoft.ML.Probabilistic")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Research Limited 2013")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/test/TestApp/Properties/AssemblyInfo.cs
+++ b/test/TestApp/Properties/AssemblyInfo.cs
@@ -10,9 +10,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("TestApp")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Research Limited")]
-[assembly: AssemblyProduct("Microsoft.ML.Probabilistic")]
 [assembly: AssemblyCopyright("Copyright � Microsoft Research Limited 2008")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/test/Tests/Properties/AssemblyInfo.cs
+++ b/test/Tests/Properties/AssemblyInfo.cs
@@ -9,11 +9,8 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly: AssemblyTitle("Microsoft.ML.Probabilistic.Tests")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Research Limited")]
-[assembly: AssemblyProduct("Microsoft.ML.Probabilistic")]
 [assembly: AssemblyCopyright("Copyright � Microsoft Research Limited 2008")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]


### PR DESCRIPTION
# problem
It is not possible to use the AssemblyNamePrefix property currently, when building the solution, because the InternalsVisibleTo from Runtime to Compiler will have the wrong name.

# solution
Move the InternalsVisibleTo into the project file where it can use AssemblyNamePrefix directly; and then turn on assembly property generation so it is effective.