### PR TITLE
Revert change to name of Visualizers package

### DIFF
--- a/src/Visualizers/Windows/Visualizers.Windows.csproj
+++ b/src/Visualizers/Windows/Visualizers.Windows.csproj
@@ -5,6 +5,7 @@
     <Description>Infer.NET is a framework for running Bayesian inference in graphical models. It can also be used for probabilistic programming. This package contains visualization tools for exploring and analyzing models on Windows platform.</Description>
     <TargetFramework>net461</TargetFramework>
     <AssemblyName>Microsoft.ML.Probabilistic.Compiler.Visualizers.Windows</AssemblyName>
+    <PackageId>Microsoft.ML.Probabilistic.Visualizers.Windows</PackageId>
     <DefineConstants>TRACE;SUPPRESS_XMLDOC_WARNINGS, SUPPRESS_UNREACHABLE_CODE_WARNINGS, SUPPRESS_AMBIGUOUS_REFERENCE_WARNINGS</DefineConstants>
     <NoWarn>1591</NoWarn>
     <RootNamespace>Microsoft.ML.Probabilistic.Compiler.Visualizers</RootNamespace>


### PR DESCRIPTION
In https://github.com/dotnet/infer/commit/daa1058627dafe32f0fff13a2454d7e8ae82a43c#diff-5ac97f13a1c20ca94402ec1e8382444b the name of the Visualizers package was accidentally changed to include "Compiler" -- this reverts that change.