### PR TITLE
Add commit ID to NuGets

### DIFF
--- a/build/nuget-properties.props
+++ b/build/nuget-properties.props
@@ -26,6 +26,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/dotnet/infer/master/docs/images/infernet.png</PackageIconUrl>
     <PackageTags>Infer.NET machine learning Bayesian inference probabilistic</PackageTags>
     <RepositoryUrl>https://github.com/dotnet/infer.git</RepositoryUrl>
+    <RepositoryCommit>$(CommitId)</RepositoryCommit>
     <RepositoryType>git</RepositoryType>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/build/release.yml
+++ b/build/release.yml
@@ -170,7 +170,7 @@ jobs:
       packDirectory: '$(Build.SourcesDirectory)/bin/packages'
       nobuild: true # We must not rebuild, otherwise we overwrite the signed assemblies.
       versioningScheme: 'byBuildNumber'
-      buildProperties: 'BaseOutputPath=$(Build.SourcesDirectory)/bin/obj/packages;BuildProjectReferences=false;version=$(Build.BuildNumber)' # BaseOutputPath is set to the location the signed assemblies have been copied to. version is used for NuSpec substitution in LearnersNuGet.csproj.
+      buildProperties: 'BaseOutputPath=$(Build.SourcesDirectory)/bin/obj/packages;BuildProjectReferences=false;version=$(Build.BuildNumber);CommitId=$(Build.SourceVersion)' # BaseOutputPath is set to the location the signed assemblies have been copied to. version is used for NuSpec substitution in LearnersNuGet.csproj.
 
   - task: MSBuild@1
     displayName: Sign Packages

--- a/src/Learners/LearnersNuGet/LearnersNuGet.csproj
+++ b/src/Learners/LearnersNuGet/LearnersNuGet.csproj
@@ -35,7 +35,7 @@
     <!--
     It is necessary to forward required values through to the NuSpec since this is not automatic.
     -->
-    <NuspecProperties>minClientVersion=4.0;bin=$(OutputPath);version=$(version)</NuspecProperties>
+    <NuspecProperties>minClientVersion=4.0;bin=$(OutputPath);version=$(version);CommitId=$(CommitId)</NuspecProperties>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Learners/LearnersNuGet/LearnersNuGet.nuspec
+++ b/src/Learners/LearnersNuGet/LearnersNuGet.nuspec
@@ -21,7 +21,7 @@
     <tags>Infer.NET machine learning Bayesian inference probabilistic</tags>
     <developmentDependency>false</developmentDependency>
     <language>en-US</language>
-    <repository type="git" url="https://github.com/dotnet/infer.git" />
+    <repository type="git" url="https://github.com/dotnet/infer.git" commit="$CommitId$" />
     <dependencies>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.ML.Probabilistic" version="$version$" />


### PR DESCRIPTION
# background
It is useful to be able to backtrack from a NuGet package to the commit it was built from.

# change
The the NuSpec format supports holding the commit ID -- just populate it.