### PR TITLE
Update to .NET Core 3.1

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,23 +1,23 @@
 # Building Infer.NET from its source code
 
-- [Building with Visual Studio 2017](#building-with-visual-studio-2017)
+- [Building with Visual Studio 2019](#building-with-visual-studio-2019)
 - [Building from the command line](#building-from-the-command-line)
 
 To build from source, you must first clone the repository.
 Next decide whether you want to use a code editor like Visual Studio (recommended) or the command line.
 When building, you must select a configuration.
-All of the Infer&#46;NET libraries target .NET Standard 2.0. Projects that produce executables (including test projects) mostly target .NET Framework 4.6.1, .NET Core 2.1, or both depending on build configuration:
+All of the Infer&#46;NET libraries target .NET Standard 2.0. Projects that produce executables (including test projects) mostly target .NET Framework 4.6.1, .NET Core 3.1, or both depending on build configuration:
 
 | Configurations | Targeted Frameworks |
 |:---|---:|
-| Debug, Release | both .NET Framework 4.6.1 and .NET Core 2.1 |
+| Debug, Release | both .NET Framework 4.6.1 and .NET Core 3.1 |
 | DebugFull, ReleaseFull | .NET Framework 4.6.1 only |
-| DebugCore, ReleaseCore | .NET Core 2.1 only |
+| DebugCore, ReleaseCore | .NET Core 3.1 only |
 
 
-## Building with Visual Studio 2017
+## Building with Visual Studio 2019
 
-1. If you don't have Visual Studio 2017, you can install the free [Visual Studio 2017 Community](https://visualstudio.microsoft.com/vs/community/).
+1. If you don't have Visual Studio 2019, you can install the free [Visual Studio 2019 Community](https://visualstudio.microsoft.com/vs/community/).
 1. Start Visual Studio.
 1. Select `File -> Open -> Project/Solution` and open the `Infer.sln` solution file located in your cloned repository.
 1. Select a build configuration using `Build -> Configuration Manager...`.  When switching between configurations that change the targeted frameworks, Visual Studio currently requires you to close and re-open the solution file using `File -> Close Solution` and `File -> Open`.
@@ -57,7 +57,7 @@ When not using Windows, expect build failure messages about examples that use WP
 Unit tests are written using the [XUnit](https://xunit.github.io/) framework.
 In order to run unit tests, build the test project and execute one of the following commands:
 ```bash
-dotnet ~/.nuget/packages/xunit.runner.console/2.3.1/tools/netcoreapp2.1/xunit.console.dll <path to netcoreapp2.1 assembly with tests> <filter>
+dotnet ~/.nuget/packages/xunit.runner.console/2.3.1/tools/netcoreapp2.0/xunit.console.dll <path to netcoreapp3.1 assembly with tests> <filter>
 ```
 ```bash
 mono ~/.nuget/packages/xunit.runner.console/2.3.1/tools/net452/xunit.console.exe <path to net461 assembly with tests> <filter>
@@ -69,7 +69,7 @@ There are three test assemblies in the solution:
 - **TestPublic.dll** in the folder `test/TestPublic`.
 - **Microsoft.ML.Probabilistic.Learners.Tests.dll** in the folder `test/Learners/LearnersTests`. 
 
-Depending on the build configuration and targeted framework, the assemblies will be located in the `bin/Debug<Core|Full>/<netcoreapp2.1|net461>` or `bin/Release<Core|Full>/<netcoreapp2.1|net461>` subdirectories
+Depending on the build configuration and targeted framework, the assemblies will be located in the `bin/Debug<Core|Full>/<netcoreapp3.1|net461>` or `bin/Release<Core|Full>/<netcoreapp3.1|net461>` subdirectories
 of the test project.
 
 `<filter>` is a rule to choose what tests will be run. You can specify them
@@ -96,9 +96,9 @@ _OpenBug_ is a category of tests that can fail.
 An example of quick testing of `Microsoft.ML.Probabilistic.Tests.dll` in `Debug` configuration after changing working directory to
 the `Tests` project looks like:
 ```bash
-dotnet ~/.nuget/packages/xunit.runner.console/2.3.1/tools/netcoreapp2.1/xunit.console.dll bin/DebugCore/netcoreapp2.1/Microsoft.ML.Probabilistic.Tests.dll -notrait Category=OpenBug -notrait Category=BadTest -notrait Category=CompilerOptionsTest -notrait Category=Platform -notrait Category=CsoftModel -notrait Category=ModifiesGlobals -notrait Category=DistributedTest -notrait Category=Performance
+dotnet ~/.nuget/packages/xunit.runner.console/2.3.1/tools/netcoreapp2.0/xunit.console.dll bin/DebugCore/netcoreapp3.1/Microsoft.ML.Probabilistic.Tests.dll -notrait Category=OpenBug -notrait Category=BadTest -notrait Category=CompilerOptionsTest -notrait Category=Platform -notrait Category=CsoftModel -notrait Category=ModifiesGlobals -notrait Category=DistributedTest -notrait Category=Performance
 
-dotnet ~/.nuget/packages/xunit.runner.console/2.3.1/tools/netcoreapp2.1/xunit.console.dll bin/DebugCore/netcoreapp2.1/Microsoft.ML.Probabilistic.Tests.dll -trait Category=CsoftModel -trait Category=ModifiesGlobals -trait Category=DistributedTests -trait Category=Performance -notrait Category=OpenBug -notrait Category=BadTest -notrait Category=CompilerOptionsTest -notrait Category=Platform -parallel none
+dotnet ~/.nuget/packages/xunit.runner.console/2.3.1/tools/netcoreapp2.0/xunit.console.dll bin/DebugCore/netcoreapp3.1/Microsoft.ML.Probabilistic.Tests.dll -trait Category=CsoftModel -trait Category=ModifiesGlobals -trait Category=DistributedTests -trait Category=Performance -notrait Category=OpenBug -notrait Category=BadTest -notrait Category=CompilerOptionsTest -notrait Category=Platform -parallel none
 ```
 To run the same set of tests on Mono:
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <Company>Microsoft Research Limited</Company>
+    <Copyright>Copyright © Microsoft Research Limited 2008-2014</Copyright>
+    <Version>65534.0.0.0</Version>
+    <FileVersion>65534.0.0.0</FileVersion>
+  </PropertyGroup>
+</Project>

--- a/build/evaluator-netcore.yml
+++ b/build/evaluator-netcore.yml
@@ -14,6 +14,6 @@ steps:
   inputs:
     targetType: 'inline'
     script: dotnet Evaluator.dll InferNetRunsOnly.xml
-    workingDirectory: ${{ format('src/Learners/Runners/Evaluator/bin/{0}/netcoreapp2.1', parameters.Configuration) }}
+    workingDirectory: ${{ format('src/Learners/Runners/Evaluator/bin/{0}/netcoreapp3.1', parameters.Configuration) }}
     displayName: Running Evaluator
     continueOnError: true

--- a/build/nightly-netcore.yml
+++ b/build/nightly-netcore.yml
@@ -19,7 +19,7 @@ steps:
 - task: DotNetCoreInstaller@0
   inputs:
     packageType: 'sdk' 
-    version: '2.1.403' 
+    version: '3.1.201' 
 
 - script: |
     dotnet build /p:DisableImplicitNuGetFallbackFolder=true  --configuration $(BuildConfiguration)Core Infer.sln

--- a/build/pr-factordocs.yml
+++ b/build/pr-factordocs.yml
@@ -14,7 +14,7 @@ steps:
 - task: DotNetCoreInstaller@0
   inputs:
     packageType: 'sdk' 
-    version: '2.1.403' 
+    version: '3.1.201' 
 
 - script: |
     echo Checking $(Build.Repository.LocalPath)\src\Runtime\Factors\FactorDocs.xml...

--- a/build/pr-netcore.yml
+++ b/build/pr-netcore.yml
@@ -20,7 +20,7 @@ steps:
 - task: DotNetCoreInstaller@0
   inputs:
     packageType: 'sdk' 
-    version: '2.1.403' 
+    version: '3.1.201' 
 
 - script: |
     dotnet build /p:DisableImplicitNuGetFallbackFolder=true --configuration $(buildConfiguration)Core Infer.sln

--- a/build/release.yml
+++ b/build/release.yml
@@ -22,7 +22,7 @@ jobs:
   - task: DotNetCoreInstaller@0
     inputs:
       packageType: 'sdk' 
-      version: '2.1.403' 
+      version: '3.1.201' 
 
   - script: |
       dotnet build --configuration $(BuildConfiguration)Core Infer.sln
@@ -37,7 +37,7 @@ jobs:
   - task: DotNetCoreInstaller@0
     inputs:
       packageType: 'sdk' 
-      version: '2.1.403' 
+      version: '3.1.201' 
 
   - script: |
       dotnet build --configuration $(BuildConfiguration)Core Infer.sln

--- a/docs/_build/makeApiDocs.ps1
+++ b/docs/_build/makeApiDocs.ps1
@@ -41,7 +41,7 @@ if (!(Test-Path $projPath)) {
 & "$dotnetExe" build "$projPath" /p:Configuration=Release
 
 Write-Host "Run PrepareSource for InferNet_Copy_Temp folder"
-$prepareSourcePath = [IO.Path]::GetFullPath((join-path $sourceDirectory 'src/Tools/PrepareSource/bin/Release/netcoreapp2.1/Microsoft.ML.Probabilistic.Tools.PrepareSource.dll'))
+$prepareSourcePath = [IO.Path]::GetFullPath((join-path $sourceDirectory 'src/Tools/PrepareSource/bin/Release/netcoreapp3.1/Microsoft.ML.Probabilistic.Tools.PrepareSource.dll'))
 & "$dotnetExe" "$prepareSourcePath" "$destinationDirectory"
 
 Write-Host "Install nuget package docfx.console"

--- a/src/Examples/Crowdsourcing/BCC.cs
+++ b/src/Examples/Crowdsourcing/BCC.cs
@@ -13,6 +13,7 @@ using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Utilities;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Crowdsourcing
 {

--- a/src/Examples/Crowdsourcing/CommunityModel.cs
+++ b/src/Examples/Crowdsourcing/CommunityModel.cs
@@ -14,6 +14,7 @@ using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Utilities;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Crowdsourcing
 {

--- a/src/Examples/Crowdsourcing/Crowdsourcing.csproj
+++ b/src/Examples/Crowdsourcing/Crowdsourcing.csproj
@@ -17,17 +17,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/src/Examples/CrowdsourcingWithWords/BCCWords.cs
+++ b/src/Examples/CrowdsourcingWithWords/BCCWords.cs
@@ -9,6 +9,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Utilities;
 using System;
 using System.Linq;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace CrowdsourcingWithWords
 {

--- a/src/Examples/CrowdsourcingWithWords/CrowdsourcingWithWords.csproj
+++ b/src/Examples/CrowdsourcingWithWords/CrowdsourcingWithWords.csproj
@@ -16,17 +16,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/src/Examples/InferNET101/CyclingTime2.cs
+++ b/src/Examples/InferNET101/CyclingTime2.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Distributions;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace CyclingModels
 {

--- a/src/Examples/InferNET101/CyclingTime3.cs
+++ b/src/Examples/InferNET101/CyclingTime3.cs
@@ -6,6 +6,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Algorithms;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace CyclingModels
 {

--- a/src/Examples/InferNET101/InferNET101.csproj
+++ b/src/Examples/InferNET101/InferNET101.csproj
@@ -16,17 +16,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/src/Examples/LDA/LDA.csproj
+++ b/src/Examples/LDA/LDA.csproj
@@ -18,17 +18,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/src/Examples/LDA/LDAPredictionModel.cs
+++ b/src/Examples/LDA/LDAPredictionModel.cs
@@ -7,6 +7,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace LDAExample
 {

--- a/src/Examples/LDA/LDAShared.cs
+++ b/src/Examples/LDA/LDAShared.cs
@@ -9,6 +9,7 @@ using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace LDAExample
 {

--- a/src/Examples/LDA/LDATopicInferenceModel.cs
+++ b/src/Examples/LDA/LDATopicInferenceModel.cs
@@ -9,6 +9,7 @@ using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace LDAExample
 {

--- a/src/Examples/MotifFinder/MotifFinder.csproj
+++ b/src/Examples/MotifFinder/MotifFinder.csproj
@@ -18,17 +18,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/src/Examples/MotifFinder/Program.cs
+++ b/src/Examples/MotifFinder/Program.cs
@@ -11,6 +11,7 @@ namespace MotifFinder
     using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Models;
     using Microsoft.ML.Probabilistic.Utilities;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     /// <summary>
     /// The motif finder program.

--- a/src/Examples/ReviewerCalibration/ReviewerCalibration.cs
+++ b/src/Examples/ReviewerCalibration/ReviewerCalibration.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace ReviewerCalibration
 {

--- a/src/Examples/ReviewerCalibration/ReviewerCalibration.csproj
+++ b/src/Examples/ReviewerCalibration/ReviewerCalibration.csproj
@@ -17,17 +17,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/src/Examples/RobustGaussianProcess/GaussianProcessRegressor.cs
+++ b/src/Examples/RobustGaussianProcess/GaussianProcessRegressor.cs
@@ -5,6 +5,7 @@ using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Models;
 using System;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace RobustGaussianProcess
 {

--- a/src/Examples/RobustGaussianProcess/RobustGaussianProcess.csproj
+++ b/src/Examples/RobustGaussianProcess/RobustGaussianProcess.csproj
@@ -16,17 +16,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/src/Learners/ClassifierModels/ClassifierModels.csproj
+++ b/src/Learners/ClassifierModels/ClassifierModels.csproj
@@ -19,19 +19,19 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
         <!-- No need to generate code twice -->
         <IgnorePostBuildNetCore>true</IgnorePostBuildNetCore>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
     <RunPostBuildNetCore Condition="$(IgnorePostBuildNetCore) != 'true'">true</RunPostBuildNetCore>
   </PropertyGroup>

--- a/src/Learners/RecommenderModels/RecommenderModels.csproj
+++ b/src/Learners/RecommenderModels/RecommenderModels.csproj
@@ -19,19 +19,19 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
         <!-- No need to generate code twice -->
         <IgnorePostBuildNetCore>true</IgnorePostBuildNetCore>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
     <RunPostBuildNetCore Condition="$(IgnorePostBuildNetCore) != 'true'">true</RunPostBuildNetCore>
   </PropertyGroup>

--- a/src/Learners/Runners/CommandLine/CommandLine.csproj
+++ b/src/Learners/Runners/CommandLine/CommandLine.csproj
@@ -18,17 +18,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/src/Learners/Runners/Evaluator/Evaluator.csproj
+++ b/src/Learners/Runners/Evaluator/Evaluator.csproj
@@ -18,17 +18,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/src/Tools/BuildFactorDoc/Tools.BuildFactorDoc.csproj
+++ b/src/Tools/BuildFactorDoc/Tools.BuildFactorDoc.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Microsoft.ML.Probabilistic.Tools.BuildFactorDoc</RootNamespace>
     <AssemblyName>Microsoft.ML.Probabilistic.Tools.BuildFactorDoc</AssemblyName>
   </PropertyGroup>

--- a/src/Tools/PrepareSource/Tools.PrepareSource.csproj
+++ b/src/Tools/PrepareSource/Tools.PrepareSource.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Microsoft.ML.Probabilistic.Tools.PrepareSource</AssemblyName>
     <RootNamespace>Microsoft.ML.Probabilistic.Tools.PrepareSource</RootNamespace>
   </PropertyGroup>

--- a/src/Tutorials/BayesPointMachineExample.cs
+++ b/src/Tutorials/BayesPointMachineExample.cs
@@ -6,6 +6,7 @@ using System;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/BayesianPCA.cs
+++ b/src/Tutorials/BayesianPCA.cs
@@ -10,6 +10,7 @@ using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Utilities;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/BugsRats.cs
+++ b/src/Tutorials/BugsRats.cs
@@ -6,6 +6,7 @@ using System;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/CausalityExample.cs
+++ b/src/Tutorials/CausalityExample.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Models;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/ChessAnalysis.cs
+++ b/src/Tutorials/ChessAnalysis.cs
@@ -8,6 +8,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Utilities;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/ClickModel.cs
+++ b/src/Tutorials/ClickModel.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Distributions;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/ClinicalTrial.cs
+++ b/src/Tutorials/ClinicalTrial.cs
@@ -5,6 +5,7 @@
 using System;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Distributions;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/DifficultyAbility.cs
+++ b/src/Tutorials/DifficultyAbility.cs
@@ -8,6 +8,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Utilities;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/GaussianProcessClassifier.cs
+++ b/src/Tutorials/GaussianProcessClassifier.cs
@@ -7,6 +7,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Distributions.Kernels;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/LearningAGaussianWithRanges.cs
+++ b/src/Tutorials/LearningAGaussianWithRanges.cs
@@ -5,6 +5,7 @@
 using System;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Math;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/MixtureOfGaussians.cs
+++ b/src/Tutorials/MixtureOfGaussians.cs
@@ -7,6 +7,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Utilities;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/MultinomialRegression.cs
+++ b/src/Tutorials/MultinomialRegression.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/RecommenderSystem.cs
+++ b/src/Tutorials/RecommenderSystem.cs
@@ -10,6 +10,7 @@ using Microsoft.ML.Probabilistic.Utilities;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Factors;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/StudentSkills.cs
+++ b/src/Tutorials/StudentSkills.cs
@@ -8,6 +8,7 @@ using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Factors;
 using Microsoft.ML.Probabilistic.Math;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/src/Tutorials/Tutorials.csproj
+++ b/src/Tutorials/Tutorials.csproj
@@ -20,18 +20,18 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks> 
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks> 
         <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/src/Tutorials/WetGrassSprinklerRain.cs
+++ b/src/Tutorials/WetGrassSprinklerRain.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tutorials
 {

--- a/test/Learners/LearnersTests/LearnersTests.csproj
+++ b/test/Learners/LearnersTests/LearnersTests.csproj
@@ -15,17 +15,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
   
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/test/Learners/TestApp/TestApp.csproj
+++ b/test/Learners/TestApp/TestApp.csproj
@@ -18,17 +18,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/test/TestApp/TestApp.csproj
+++ b/test/TestApp/TestApp.csproj
@@ -20,17 +20,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
   
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/test/TestFSharp/TestFSharp.fsproj
+++ b/test/TestFSharp/TestFSharp.fsproj
@@ -17,12 +17,12 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/test/TestPublic/TestPublic.csproj
+++ b/test/TestPublic/TestPublic.csproj
@@ -17,17 +17,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/test/Tests/BPMNoiseTests.cs
+++ b/test/Tests/BPMNoiseTests.cs
@@ -13,6 +13,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Math;
 using System.IO;
 using Microsoft.ML.Probabilistic.Algorithms;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/BayesPointMachineTests.cs
+++ b/test/Tests/BayesPointMachineTests.cs
@@ -11,6 +11,7 @@ using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Factors;
 using Microsoft.ML.Probabilistic.Math;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/BioTests.cs
+++ b/test/Tests/BioTests.cs
@@ -13,6 +13,7 @@ using Microsoft.ML.Probabilistic.Utilities;
 using System.Globalization;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Serialization;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/BlogTests.cs
+++ b/test/Tests/BlogTests.cs
@@ -20,6 +20,7 @@ using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
 using Microsoft.ML.Probabilistic.Compiler;
 using Microsoft.ML.Probabilistic.Serialization;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/BpmSpeedTests.cs
+++ b/test/Tests/BpmSpeedTests.cs
@@ -12,6 +12,7 @@ using Microsoft.ML.Probabilistic.Collections;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Factors;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/ChainTests.cs
+++ b/test/Tests/ChainTests.cs
@@ -10,6 +10,7 @@ using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Factors;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Utilities;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/ClickTest.cs
+++ b/test/Tests/ClickTest.cs
@@ -13,6 +13,7 @@ using Microsoft.ML.Probabilistic.Factors;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Compiler;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/ConstrainEqualTests.cs
+++ b/test/Tests/ConstrainEqualTests.cs
@@ -12,6 +12,7 @@ using Microsoft.ML.Probabilistic.Algorithms;
 namespace Microsoft.ML.Probabilistic.Tests
 {
     using Assert = Xunit.Assert;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     /// <summary>
     /// Tests of EqualityPropagationTransform

--- a/test/Tests/Core/SparseTests.cs
+++ b/test/Tests/Core/SparseTests.cs
@@ -11,6 +11,7 @@ using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Factors;
 using Microsoft.ML.Probabilistic.Compiler.Transforms;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests.Core
 {

--- a/test/Tests/CyclistTests.cs
+++ b/test/Tests/CyclistTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Models;
 using Assert = Xunit.Assert;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/DiscreteTests.cs
+++ b/test/Tests/DiscreteTests.cs
@@ -9,6 +9,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Algorithms;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/DistributedTests.cs
+++ b/test/Tests/DistributedTests.cs
@@ -13,6 +13,7 @@ using Microsoft.ML.Probabilistic.Utilities;
 using Xunit;
 using System.IO;
 using System.Linq;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/DocumentationTests.cs
+++ b/test/Tests/DocumentationTests.cs
@@ -16,6 +16,7 @@ using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Serialization;
 using Microsoft.ML.Probabilistic.Models.Attributes;
 using Microsoft.ML.Probabilistic.Compiler;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/EnumTests.cs
+++ b/test/Tests/EnumTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Distributions;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/EpTests.cs
+++ b/test/Tests/EpTests.cs
@@ -21,6 +21,7 @@ using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
 using Microsoft.ML.Probabilistic.Serialization;
 using Microsoft.ML.Probabilistic.Compiler;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/ForumTests.cs
+++ b/test/Tests/ForumTests.cs
@@ -9,6 +9,7 @@ using Microsoft.ML.Probabilistic.Factors;
 using Microsoft.ML.Probabilistic.Models;
 using Xunit;
 using Microsoft.ML.Probabilistic.Algorithms;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/GPTests.cs
+++ b/test/Tests/GPTests.cs
@@ -10,6 +10,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Utilities;
 using Assert = Xunit.Assert;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/GateModelTests.cs
+++ b/test/Tests/GateModelTests.cs
@@ -10,6 +10,7 @@ using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Utilities;
 using Xunit;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {
@@ -24,6 +25,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using System.Diagnostics;
     using Microsoft.ML.Probabilistic.Algorithms;
     using Microsoft.ML.Probabilistic.Models.Attributes;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     public class GateModelTests
     {

--- a/test/Tests/GateTests.cs
+++ b/test/Tests/GateTests.cs
@@ -12,6 +12,7 @@ using Microsoft.ML.Probabilistic.Math;
 using Xunit;
 using Assert = Xunit.Assert;
 using Microsoft.ML.Probabilistic.Algorithms;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/GatedFactorTests.cs
+++ b/test/Tests/GatedFactorTests.cs
@@ -16,6 +16,7 @@ using Microsoft.ML.Probabilistic.Factors.Attributes;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
 using Microsoft.ML.Probabilistic.Compiler;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/GaussianFromMeanAndVarianceTests.cs
+++ b/test/Tests/GaussianFromMeanAndVarianceTests.cs
@@ -19,6 +19,7 @@ using Assert = Xunit.Assert;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
 using Microsoft.ML.Probabilistic.Serialization;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/Gibbs/BugsTests.cs
+++ b/test/Tests/Gibbs/BugsTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using Microsoft.ML.Probabilistic.Algorithms;
     using System.Diagnostics;
     using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     /// <summary>
     /// Summary description for BugsTests

--- a/test/Tests/Gibbs/GibbsTests.cs
+++ b/test/Tests/Gibbs/GibbsTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using Microsoft.ML.Probabilistic.Utilities;
     using Microsoft.ML.Probabilistic.Algorithms;
     using Microsoft.ML.Probabilistic.Compiler;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     /// <summary>
     /// Gibbs sampling tests

--- a/test/Tests/Graphs/ParallelSchedulerTests.cs
+++ b/test/Tests/Graphs/ParallelSchedulerTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using ParallelScheduler = Microsoft.ML.Probabilistic.Compiler.Graphs.ParallelScheduler;
     using Microsoft.ML.Probabilistic.Factors;
     using Microsoft.ML.Probabilistic.Models.Attributes;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     public class ParallelSchedulerTests
     {

--- a/test/Tests/IndexOfMaximumTests.cs
+++ b/test/Tests/IndexOfMaximumTests.cs
@@ -14,6 +14,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Utilities;
 using Assert = Xunit.Assert;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/IndexingTests.cs
+++ b/test/Tests/IndexingTests.cs
@@ -13,6 +13,7 @@ using Microsoft.ML.Probabilistic.Utilities;
 using System.Linq;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/InferTests.cs
+++ b/test/Tests/InferTests.cs
@@ -16,6 +16,7 @@ using Microsoft.ML.Probabilistic.Compiler;
 using Microsoft.ML.Probabilistic.Factors.Attributes;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/InnerProductArrayTests.cs
+++ b/test/Tests/InnerProductArrayTests.cs
@@ -11,6 +11,7 @@ using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Utilities;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Serialization;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/LDATests.cs
+++ b/test/Tests/LDATests.cs
@@ -15,6 +15,7 @@ using Microsoft.ML.Probabilistic.Models.Attributes;
 namespace Microsoft.ML.Probabilistic.Tests
 {
     using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     internal class LDAModel
     {

--- a/test/Tests/LaplaceTests.cs
+++ b/test/Tests/LaplaceTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using Microsoft.ML.Probabilistic.Algorithms;
     using Microsoft.ML.Probabilistic.Models.Attributes;
     using Microsoft.ML.Probabilistic.Serialization;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 #if SUPPRESS_UNREACHABLE_CODE_WARNINGS
 #pragma warning disable 162

--- a/test/Tests/MarginalPrototypeTests.cs
+++ b/test/Tests/MarginalPrototypeTests.cs
@@ -14,6 +14,7 @@ using GaussianArray2D = Microsoft.ML.Probabilistic.Distributions.DistributionStr
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Utilities;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/MatchboxTests.cs
+++ b/test/Tests/MatchboxTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using GaussianArrayArray =
         Microsoft.ML.Probabilistic.Distributions.DistributionRefArray<Microsoft.ML.Probabilistic.Distributions.DistributionStructArray<Microsoft.ML.Probabilistic.Distributions.Gaussian, double>, double[]>;
     using Microsoft.ML.Probabilistic.Models.Attributes;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     /// <summary>
     /// Matchbox recommender tests

--- a/test/Tests/MaxProductTests.cs
+++ b/test/Tests/MaxProductTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Distributions;
 using Microsoft.ML.Probabilistic.Algorithms;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/MixtureTests.cs
+++ b/test/Tests/MixtureTests.cs
@@ -13,6 +13,7 @@ using Microsoft.ML.Probabilistic.Utilities;
 using Assert = Xunit.Assert;
 using System.Linq;
 using Microsoft.ML.Probabilistic.Algorithms;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/ModelTests.cs
+++ b/test/Tests/ModelTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using BernoulliArrayArray = DistributionRefArray<DistributionStructArray<Bernoulli, bool>, bool[]>;
     using DirichletArray = DistributionRefArray<Dirichlet, Vector>;
     using GaussianArray = DistributionStructArray<Gaussian, double>;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     /// <summary>
     /// Tests for the modelling API

--- a/test/Tests/MulticlassRegressionTests.cs
+++ b/test/Tests/MulticlassRegressionTests.cs
@@ -13,6 +13,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/MultinomialRegressionTests.cs
+++ b/test/Tests/MultinomialRegressionTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Algorithms;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/NonconjugateVMP2Tests.cs
+++ b/test/Tests/NonconjugateVMP2Tests.cs
@@ -15,6 +15,7 @@ using Assert = Xunit.Assert;
 using Microsoft.ML.Probabilistic.Utilities;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/NonconjugateVMPTests.cs
+++ b/test/Tests/NonconjugateVMPTests.cs
@@ -12,6 +12,7 @@ using Assert = Xunit.Assert;
 using Microsoft.ML.Probabilistic.Utilities;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/OnlineLearning.cs
+++ b/test/Tests/OnlineLearning.cs
@@ -13,6 +13,7 @@ using Assert = Xunit.Assert;
 using System.Linq;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/PsychTests.cs
+++ b/test/Tests/PsychTests.cs
@@ -16,8 +16,9 @@ using Microsoft.ML.Probabilistic.Serialization;
 namespace Microsoft.ML.Probabilistic.Tests
 {
     using Assert = Xunit.Assert;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
-    
+
     public class PsychTests
     {
         internal void LogisticIrtTest()

--- a/test/Tests/SerialTests.cs
+++ b/test/Tests/SerialTests.cs
@@ -23,8 +23,9 @@ namespace Microsoft.ML.Probabilistic.Tests
 {
     using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;
     using GaussianArray = DistributionStructArray<Gaussian, double>;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
-    
+
     public class SerialTests
     {
 #if SUPPRESS_UNREACHABLE_CODE_WARNINGS

--- a/test/Tests/SharedVariableTests.cs
+++ b/test/Tests/SharedVariableTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using DirichletArray = DistributionRefArray<Dirichlet, Vector>;
     using GaussianArrayArrayArray = DistributionRefArray<DistributionRefArray<DistributionStructArray<Gaussian, double>, double[]>, double[][]>;
     using Microsoft.ML.Probabilistic.Algorithms;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     /// <summary>
     /// Provides test routines for shared variables on Gaussian and Discrete.

--- a/test/Tests/SpeedTests.cs
+++ b/test/Tests/SpeedTests.cs
@@ -19,6 +19,7 @@ using Microsoft.ML.Probabilistic.Compiler.CodeModel;
 using Assert = Xunit.Assert;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/Strings/StringInferencePerformanceTests.cs
+++ b/test/Tests/Strings/StringInferencePerformanceTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using System.Threading.Tasks;
     using Microsoft.ML.Probabilistic.Utilities;
     using Microsoft.ML.Probabilistic.Factors.Attributes;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     /// <summary>
     /// These tests don't check for correctness, just print timings to the console.

--- a/test/Tests/Tests.csproj
+++ b/test/Tests/Tests.csproj
@@ -18,17 +18,17 @@
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
       <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
   
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);NETCORE;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 

--- a/test/Tests/TransformTests.cs
+++ b/test/Tests/TransformTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using Microsoft.ML.Probabilistic.Compiler;
     using Microsoft.ML.Probabilistic.Algorithms;
     using Microsoft.ML.Probabilistic.Models.Attributes;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     public class TransformTests
     {

--- a/test/Tests/VmpArrayTests.cs
+++ b/test/Tests/VmpArrayTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using Microsoft.ML.Probabilistic.Algorithms;
     using Microsoft.ML.Probabilistic.Compiler;
     using Microsoft.ML.Probabilistic.Serialization;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 #if SUPPRESS_UNREACHABLE_CODE_WARNINGS
 #pragma warning disable 162

--- a/test/Tests/VmpGateArrayTests.cs
+++ b/test/Tests/VmpGateArrayTests.cs
@@ -9,6 +9,7 @@ using Microsoft.ML.Probabilistic.Models;
 using Microsoft.ML.Probabilistic.Factors;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Algorithms;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/VmpGateTests.cs
+++ b/test/Tests/VmpGateTests.cs
@@ -13,6 +13,7 @@ using Assert = Xunit.Assert;
 using Microsoft.ML.Probabilistic.Compiler;
 using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/Tests/VmpTests.cs
+++ b/test/Tests/VmpTests.cs
@@ -19,6 +19,7 @@ using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Models.Attributes;
 using Microsoft.ML.Probabilistic.Compiler;
 using Microsoft.ML.Probabilistic.Serialization;
+using Range = Microsoft.ML.Probabilistic.Models.Range;
 
 namespace Microsoft.ML.Probabilistic.Tests
 {

--- a/test/netcoretest.sh
+++ b/test/netcoretest.sh
@@ -15,11 +15,11 @@ then
     configuration=Release
 fi
 
-compath=/bin/${configuration}/netcoreapp2.1/
+compath=/bin/${configuration}/netcoreapp3.1/
 dlls="Learners/LearnersTests${compath}Microsoft.ML.Probabilistic.Learners.Tests.dll Tests${compath}Microsoft.ML.Probabilistic.Tests.dll TestPublic${compath}TestPublic.dll"
 
 # dotnet command
-dotnet='dotnet --fx-version 2.1.5'
+dotnet='dotnet --fx-version 3.1.3'
 
 # path to the xunit runner
 runner=~/.nuget/packages/xunit.runner.console/2.3.1/tools/netcoreapp2.0/xunit.console.dll


### PR DESCRIPTION
This update was faily trivial change of project properties with only one caveat
```
error CS0104: 'Range' is an ambiguous reference between 'Microsoft.ML.Probabilistic.Models.Range' and 'System.Range'
```

which require sprinkling everywhere following line of code
```
using Range = Microsoft.ML.Probabilistic.Models.Range;
```