### PR TITLE
CSharpWriter uses G17 to write doubles and G9 to write singles

### DIFF
--- a/src/Compiler/TransformFramework/LanguageWriters/CSharpWriter.cs
+++ b/src/Compiler/TransformFramework/LanguageWriters/CSharpWriter.cs
@@ -569,7 +569,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 }
                 else
                 {
-                    string s = d.ToString("R", CultureInfo.InvariantCulture);
+                    string s = d.ToString("G17", CultureInfo.InvariantCulture);
                     sb.Append(s);
                     if (!s.Contains(".") && !s.Contains("E") && !s.Contains("e"))
                         sb.Append(".0");
@@ -605,7 +605,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 }
                 else
                 {
-                    sb.Append(f.ToString("R", CultureInfo.InvariantCulture));
+                    sb.Append(f.ToString("G9", CultureInfo.InvariantCulture));
                     sb.Append("F");
                 }
             }

--- a/test/Tests/CodeModel/LanguageWriterTests.cs
+++ b/test/Tests/CodeModel/LanguageWriterTests.cs
@@ -229,15 +229,15 @@ namespace Microsoft.ML.Probabilistic.Tests.CodeModel
             Assert.Equal("0.0", WriteLiteralExpression(0.0));
             Assert.Equal("(-1.0 * 0.0)", WriteLiteralExpression(-1.0 * 0.0)); // some build configurations result in -0.0 producing a positive zero, hence (-1.0 * 0.0)
             Assert.Equal("42.0", WriteLiteralExpression(42.0000000));
-            Assert.Equal("3.14159265", WriteLiteralExpression(3.14159265));
-            Assert.Equal("-3.14159265", WriteLiteralExpression(-3.14159265));
+            Assert.Equal("3.1415926500000002", WriteLiteralExpression(3.14159265));
+            Assert.Equal("-3.1415926500000002", WriteLiteralExpression(-3.14159265));
             Assert.Equal("1000000.0", WriteLiteralExpression(1e6));
-            Assert.Equal("1234567.89", WriteLiteralExpression(1.23456789E6));
-            Assert.Equal("1.23456789E+42", WriteLiteralExpression(1.23456789e+42));
+            Assert.Equal("1234567.8899999999", WriteLiteralExpression(1.23456789E6));
+            Assert.Equal("1.2345678900000001E+42", WriteLiteralExpression(1.23456789e+42));
             Assert.Equal("1.23456789E-42", WriteLiteralExpression(1.23456789e-42));
             Assert.Equal("-1000000.0", WriteLiteralExpression(-1e6));
-            Assert.Equal("-1234567.89", WriteLiteralExpression(-1.23456789E6));
-            Assert.Equal("-1.23456789E+42", WriteLiteralExpression(-1.23456789e+42));
+            Assert.Equal("-1234567.8899999999", WriteLiteralExpression(-1.23456789E6));
+            Assert.Equal("-1.2345678900000001E+42", WriteLiteralExpression(-1.23456789e+42));
             Assert.Equal("-1.23456789E-42", WriteLiteralExpression(-1.23456789e-42));
             Assert.Equal("double.PositiveInfinity", WriteLiteralExpression(double.PositiveInfinity));
             Assert.Equal("double.NegativeInfinity", WriteLiteralExpression(double.NegativeInfinity));


### PR DESCRIPTION
for correct round-trip behavior in .NET framework and core.