### PR TITLE
Move Nightly build on to VS2019 machines

### DIFF
--- a/build/nightly-windows.yml
+++ b/build/nightly-windows.yml
@@ -12,8 +12,8 @@ resources:
   
 trigger: none # disable CI build
 
-#queue:
-#  name: Hosted VS2017
+pool:
+  vmImage: 'windows-2019'
 
 # Cannot use matrix strategy to create jobs for different platforms, 
 # since then the platform is given as a variable which cannot be passed as a parameter to a template,
@@ -22,7 +22,7 @@ jobs:
 - job: Win64_Build_Test
   displayName: 'Windows: Build and Test (x64)'
   timeoutInMinutes: 180
-  
+
   steps:
   - template: windows-msbuild.yml
     parameters:


### PR DESCRIPTION
The Nightly build has been failing because it uses VS2017 hosted machines that can not target the desired version of .NET Core.

Switching to VS2019 machines fixes this issue.