### PR TITLE
Faithful SetTo for SequenceDistribution

### DIFF
--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -1106,15 +1106,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
             }
 
             this.point = that.point;
-            if (this.point == null)
-            {
-                this.SetWeightFunction(that.sequenceToWeight);
-            }
-            else
-            {
-                this.sequenceToWeight = null;
-            }
-
+            this.sequenceToWeight = that.sequenceToWeight;
             this.isNormalized = that.isNormalized;
         }
 

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -1106,7 +1106,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
             }
 
             this.point = that.point;
-            this.sequenceToWeight = that.sequenceToWeight.Clone();
+            this.sequenceToWeight = that.sequenceToWeight?.Clone();
             this.isNormalized = that.isNormalized;
         }
 

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -1106,7 +1106,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
             }
 
             this.point = that.point;
-            this.sequenceToWeight = that.sequenceToWeight;
+            this.sequenceToWeight = that.sequenceToWeight.Clone();
             this.isNormalized = that.isNormalized;
         }
 


### PR DESCRIPTION
`SequenceDistribution.SetTo()` called `SetWorkspace` that tried to normalize weight function.
This is not necessary if sequence distribution is set to another valid sequence distribution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/infer/240)
<!-- Reviewable:end -->
