### PR TITLE
InferenceEngine.SaveFactorGraphToFolder uses correct path on Unix

### DIFF
--- a/src/Compiler/Infer/Models/InferenceEngine.cs
+++ b/src/Compiler/Infer/Models/InferenceEngine.cs
@@ -223,7 +223,7 @@ namespace Microsoft.ML.Probabilistic.Models
                 if (SaveFactorGraphToFolder != null && Visualizer?.GraphWriter != null)
                 {
                     Directory.CreateDirectory(SaveFactorGraphToFolder);
-                    Visualizer.GraphWriter.WriteGraph(mb, SaveFactorGraphToFolder + @"\" + ModelName);
+                    Visualizer.GraphWriter.WriteGraph(mb, Path.Combine(SaveFactorGraphToFolder, ModelName));
                 }
                 if (ShowFactorGraph && Visualizer?.FactorGraphVisualizer != null)
                     Visualizer.FactorGraphVisualizer.VisualizeFactorGraph(mb);

--- a/src/Compiler/TransformFramework/TransformerChain.cs
+++ b/src/Compiler/TransformFramework/TransformerChain.cs
@@ -107,7 +107,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 if (transformer.OutputEqualsInput)
                     continue;
                 count++;
-                string filename = outputFolder + @"\" + count.ToString() + " " + transformer.Transform.Name + ".txt";
+                string filename = Path.Combine(outputFolder, count.ToString() + " " + transformer.Transform.Name + ".txt");
                 using (var writer = new StreamWriter(filename))
                 {
                     foreach (ITypeDeclaration itd in transformer.transformMap.Values)


### PR DESCRIPTION
Fixes #256 