### PR TITLE
Fixes for RoslynDeclarationProvider and Conversion.TryFindConversion

### DIFF
--- a/src/Csoft/ISourceProvider.cs
+++ b/src/Csoft/ISourceProvider.cs
@@ -3,22 +3,38 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Collections.Immutable;
 
 namespace Microsoft.ML.Probabilistic.Compiler
 {
-    public class SourceCode
+    public class SourceFile
     {
         public string FilePath { get; }
         public string SourceText { get; }
 
-        public SourceCode(string filePath, string sourceText)
+        public SourceFile(string filePath, string sourceText)
         {
             FilePath = filePath;
             SourceText = sourceText;
+        }
+    }
+
+    public class SourceCode
+    {
+        /// <summary>
+        /// Source file that contains the primary definition.
+        /// </summary>
+        public SourceFile PrimaryFile { get; }
+        /// <summary>
+        /// Additional files that contain the definitions of some of the types referenced in the primary file.
+        /// Should be used to build a more complete semantic model.
+        /// </summary>
+        public ImmutableArray<SourceFile> AddtionalFiles { get; }
+
+        public SourceCode(SourceFile primaryFile, ImmutableArray<SourceFile> additionalFiles)
+        {
+            PrimaryFile = primaryFile;
+            AddtionalFiles = additionalFiles;
         }
     }
 

--- a/test/Tests/Dynamic/TypeInference.cs
+++ b/test/Tests/Dynamic/TypeInference.cs
@@ -143,6 +143,14 @@ namespace Microsoft.ML.Probabilistic.Tests
             Assert.True(Conversion.TryGetConversion(typeof (Tester), typeof (int[]), out conv));
             o = conv.Converter(t);
             Console.WriteLine("{0}: {1}", o.GetType(), o);
+            Assert.True(Conversion.TryGetConversion(typeof(int), typeof(Tester), out conv));
+            Assert.True(conv.IsExplicit);
+            Assert.True(Conversion.TryGetConversion(typeof(int[]), typeof(Tester), out conv));
+            Assert.True(conv.IsExplicit);
+            Assert.True(Conversion.TryGetConversion(typeof(ImplicitlyConvertibleToTesterDefinesCast), typeof(Tester), out conv));
+            Assert.False(conv.IsExplicit);
+            Assert.True(Conversion.TryGetConversion(typeof(ImplicitlyConvertibleToTesterCastDefinedOnTester), typeof(Tester), out conv));
+            Assert.False(conv.IsExplicit);
 
             // conversion from null
             Assert.False(Conversion.TryGetConversion(typeof (Nullable), typeof (int), out conv));
@@ -842,7 +850,34 @@ namespace Microsoft.ML.Probabilistic.Tests
           {
             return t.arrayField;
           }
+
+            public static explicit operator Tester(int x)
+            {
+                var tester = new Tester
+                {
+                    intField = x
+                };
+                return tester;
+            }
+
+            public static explicit operator Tester(int[] x)
+            {
+                var tester = new Tester
+                {
+                    arrayField = x
+                };
+                return tester;
+            }
+
+            public static implicit operator Tester(ImplicitlyConvertibleToTesterCastDefinedOnTester _) => new Tester();
         }
+
+        public class ImplicitlyConvertibleToTesterDefinesCast
+        {
+            public static implicit operator Tester(ImplicitlyConvertibleToTesterDefinesCast _) => new Tester();
+        }
+
+        public class ImplicitlyConvertibleToTesterCastDefinedOnTester { }
 
         /// <summary>
         /// Help class of dynamically invoking methods.

--- a/test/Tests/MslTests.cs
+++ b/test/Tests/MslTests.cs
@@ -70,7 +70,6 @@ namespace Microsoft.ML.Probabilistic.Tests
 
         [Fact]
         [Trait("Category", "CsoftModel")]
-        [Trait("Category", "OpenBug")]
         public void MethodInAnotherFileTest()
         {
             Assert.Throws<CompilationFailedException>(() =>


### PR DESCRIPTION
- RoslynDeclarationProvider uses all available source codes (fixes MslTests.MethodInAnotherFile test)
- Conversion.TryFindConversion(fromType, toType, info) looks for casts defined on the toType as well. Used to look for casts defined on the fromType before.