### PR TITLE
Put binary formatter usage behind define

### DIFF
--- a/test/Tests/BpmSpeedTests.cs
+++ b/test/Tests/BpmSpeedTests.cs
@@ -81,6 +81,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 #if SUPPRESS_UNREACHABLE_CODE_WARNINGS
 #pragma warning disable 162
 #endif
+
         public static void Rcv1Test(double wVariance, double biasVariance)
         {
             int count = 0;

--- a/test/Tests/BpmSpeedTests.cs
+++ b/test/Tests/BpmSpeedTests.cs
@@ -81,7 +81,6 @@ namespace Microsoft.ML.Probabilistic.Tests
 #if SUPPRESS_UNREACHABLE_CODE_WARNINGS
 #pragma warning disable 162
 #endif
-
         public static void Rcv1Test(double wVariance, double biasVariance)
         {
             int count = 0;
@@ -135,6 +134,11 @@ namespace Microsoft.ML.Probabilistic.Tests
                 }
             }
             writer.Dispose();
+#if HAS_BINARY_FORMATTER
+        // In the .NET 5.0 BinaryFormatter is obsolete
+        // and would produce errors. This test code should be migrated. 
+        // See https://github.com/GrabYourPitchforks/docs/blob/bf_obsoletion_docs/docs/standard/serialization/resolving-binaryformatter-obsoletion-errors.md
+
             if (true)
             {
                 BinaryFormatter serializer = new BinaryFormatter();
@@ -145,6 +149,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                     serializer.Serialize(stream, train.biasPost);
                 }
             }
+#endif
         }
 
         // (0.5,0.5):
@@ -164,6 +169,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 #pragma warning restore 162
 #endif
 
+#if HAS_BINARY_FORMATTER
         public static void Rcv1Test2()
         {
             GaussianArray wPost;
@@ -194,6 +200,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             }
             Console.WriteLine("error rate = {0} = {1}/{2}", (double) errors/count, errors, count);
         }
+#endif
 
         public static void Rcv1Test3()
         {
@@ -404,7 +411,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
         public class BpmTrain_EP : IGeneratedAlgorithm
         {
-            #region Fields
+#region Fields
 
             /// <summary>Field backing the NumberOfIterationsDone property</summary>
             private int numberOfIterationsDone;
@@ -478,9 +485,9 @@ namespace Microsoft.ML.Probabilistic.Tests
             public Gaussian vdouble11_F;
             public Gaussian vdouble11_B;
 
-            #endregion
+#endregion
 
-            #region Properties
+#region Properties
 
             /// <summary>The number of iterations done from the initial state</summary>
             public int NumberOfIterationsDone
@@ -607,9 +614,9 @@ namespace Microsoft.ML.Probabilistic.Tests
                 }
             }
 
-            #endregion
+#endregion
 
-            #region Methods
+#region Methods
 
             /// <summary>Get the observed value of the specified variable.</summary>
             /// <param name="variableName">Variable name</param>
@@ -904,14 +911,14 @@ namespace Microsoft.ML.Probabilistic.Tests
                 return this.wSparse_marginal_F;
             }
 
-            #endregion
+#endregion
 
-            #region Events
+#region Events
 
             /// <summary>Event that is fired when the progress of inference changes, typically at the end of one iteration of the inference algorithm.</summary>
             public event EventHandler<ProgressChangedEventArgs> ProgressChanged;
 
-            #endregion
+#endregion
         }
     }
 }

--- a/test/Tests/BpmSpeedTests.cs
+++ b/test/Tests/BpmSpeedTests.cs
@@ -411,7 +411,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
         public class BpmTrain_EP : IGeneratedAlgorithm
         {
-#region Fields
+            #region Fields
 
             /// <summary>Field backing the NumberOfIterationsDone property</summary>
             private int numberOfIterationsDone;
@@ -485,9 +485,9 @@ namespace Microsoft.ML.Probabilistic.Tests
             public Gaussian vdouble11_F;
             public Gaussian vdouble11_B;
 
-#endregion
+            #endregion
 
-#region Properties
+            #region Properties
 
             /// <summary>The number of iterations done from the initial state</summary>
             public int NumberOfIterationsDone
@@ -614,9 +614,9 @@ namespace Microsoft.ML.Probabilistic.Tests
                 }
             }
 
-#endregion
+            #endregion
 
-#region Methods
+            #region Methods
 
             /// <summary>Get the observed value of the specified variable.</summary>
             /// <param name="variableName">Variable name</param>
@@ -911,14 +911,14 @@ namespace Microsoft.ML.Probabilistic.Tests
                 return this.wSparse_marginal_F;
             }
 
-#endregion
+            #endregion
 
-#region Events
+            #region Events
 
             /// <summary>Event that is fired when the progress of inference changes, typically at the end of one iteration of the inference algorithm.</summary>
             public event EventHandler<ProgressChangedEventArgs> ProgressChanged;
 
-#endregion
+            #endregion
         }
     }
 }

--- a/test/Tests/Distributions/SerializableTest.cs
+++ b/test/Tests/Distributions/SerializableTest.cs
@@ -87,6 +87,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             mc.AssertEqualTo(mc2);
         }
 
+#if HAS_BINARY_FORMATTER
         [Fact]
         public void BinaryFormatterTest()
         {
@@ -96,6 +97,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             var mc2 = CloneBinaryFormatter(mc);
             mc.AssertEqualTo(mc2);
         }
+#endif
 
         [Fact]
         public void JsonNetSerializerTest()
@@ -107,6 +109,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             mc.AssertEqualTo(mc2);
         }
 
+#if HAS_BINARY_FORMATTER
         [Fact]
         public void VectorSerializeTests()
         {
@@ -144,6 +147,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             Assert.Equal(3, vapprox2.SparseValues.Count);
             Assert.True(vapprox2.HasCommonElements);
         }
+#endif
 
         [DataContract]
         [Serializable]
@@ -307,6 +311,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             }
         }
 
+#if HAS_BINARY_FORMATTER
         private static T CloneBinaryFormatter<T>(T obj)
         {
             var bf = new BinaryFormatter();
@@ -317,6 +322,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 return (T)bf.Deserialize(ms);
             }
         }
+#endif
 
         private static T CloneJsonNet<T>(T obj)
         {

--- a/test/Tests/DocumentationTests.cs
+++ b/test/Tests/DocumentationTests.cs
@@ -1464,6 +1464,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             Console.WriteLine(engine.Infer(mean));
         }
 
+#if HAS_BINARY_FORMATTER
         internal void BinarySerializationExample()
         {
             Dirichlet d = new Dirichlet(3.0, 1.0, 2.0);
@@ -1480,6 +1481,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 Console.WriteLine(d2);
             }
         }
+#endif
 
         internal void XmlSerializationExample()
         {

--- a/test/Tests/MatchboxTests.cs
+++ b/test/Tests/MatchboxTests.cs
@@ -679,6 +679,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                     }
                 }
 
+#if HAS_BINARY_FORMATTER
                 if (false)
                 {
                     BinaryFormatter serializer = new BinaryFormatter();
@@ -691,6 +692,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                         serializer.Serialize(writer, engine.Infer(itemTraits));
                     }
                 }
+#endif
 
                 // test resetting inference
                 if (engine.Compiler.ReturnCopies)


### PR DESCRIPTION
This is required to be able support code on .NET 5.0 where this code would be obsolete.
Everything looks clean execept VectorSerializeTests method in SerializableTests

See #274