### PR TITLE
Add configuration required to embedding pictures in the resources

### DIFF
--- a/src/Examples/ClickThroughModel/ClickThroughModel.csproj
+++ b/src/Examples/ClickThroughModel/ClickThroughModel.csproj
@@ -6,6 +6,7 @@
     <Configurations>Debug;DebugFull;DebugCore;Release;ReleaseFull;ReleaseCore</Configurations>
     <ErrorReport>prompt</ErrorReport>
     <UseWindowsForms>true</UseWindowsForms>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <Choose>
@@ -75,6 +76,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Compiler\Compiler.csproj" />
     <ProjectReference Include="..\..\Runtime\Runtime.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Resources.Extensions" Version="4.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Examples/ClickThroughModel/ClickThroughModel.csproj
+++ b/src/Examples/ClickThroughModel/ClickThroughModel.csproj
@@ -79,7 +79,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Resources.Extensions" Version="4.7.1" />
+    <PackageReference Include="System.Resources.Extensions" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Seems to be previously this code use different code paths for resource serialization
Glimps of what's going on is here https://github.com/dotnet/msbuild/issues/4704 but I still do not fully understand why it start complaining only when building using .NET 5 SDK