### PR TITLE
Improve .NET Core detection

### DIFF
--- a/src/Compiler/TransformFramework/CodeTransformer.cs
+++ b/src/Compiler/TransformFramework/CodeTransformer.cs
@@ -98,7 +98,9 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// The language that we'll compile
         /// </summary>
         protected string language = "C#";
-        protected bool runningOnNetCore = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase);
+        protected bool runningOnNetCore = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase)
+            || System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 5", StringComparison.OrdinalIgnoreCase)
+            || System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 6", StringComparison.OrdinalIgnoreCase);
         protected bool runningOnMono = Type.GetType("Mono.Runtime") != null;
 
         /// <summary>


### PR DESCRIPTION
I mean .NET core in very liberal sense here, since .NET 5.0 is
technically .NET Core under the hood.
Since .NET 5 change framework description string to ".NET 5.0.0"
it was incorrectly detected as .NET Framework and as such atempt
to use CodeDom which is not supported for compilation scenario anymore