### PR TITLE
Use ulp-based constants

### DIFF
--- a/src/Runtime/Core/Maths/SpecialFunctions.cs
+++ b/src/Runtime/Core/Maths/SpecialFunctions.cs
@@ -4511,6 +4511,18 @@ rr = mpf('-0.99999824265582826');
         }
 
         /// <summary>
+        /// Returns the smallest double precision number such that when value is subtracted from it,
+        /// the result is strictly greater than zero, if one exists.  Otherwise returns value.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static double NextDoubleWithPositiveDifference(double value)
+        {
+            // This relies on denormalization being enabled in .NET.
+            return NextDouble(value);
+        }
+
+        /// <summary>
         /// Returns the largest double precision number less than value, if one exists.  Otherwise returns value.
         /// </summary>
         /// <param name="value"></param>
@@ -4522,6 +4534,18 @@ rr = mpf('-0.99999824265582826');
             if (double.IsNegativeInfinity(value)) return value;
             long bits = BitConverter.DoubleToInt64Bits(value);
             return BitConverter.Int64BitsToDouble(bits - 1);
+        }
+
+        /// <summary>
+        /// Returns the biggest double precision number such that when it is subtracted from value,
+        /// the result is strictly greater than zero, if one exists.  Otherwise returns value.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static double PreviousDoubleWithPositiveDifference(double value)
+        {
+            // This relies on denormalization being enabled in .NET.
+            return PreviousDouble(value);
         }
 
         /// <summary>
@@ -4705,16 +4729,16 @@ rr = mpf('-0.99999824265582826');
                 else return double.PositiveInfinity;
             }
             if (double.IsPositiveInfinity(sum)) return sum;
-            double lowerBound = PreviousDouble(b + sum);
+            double lowerBound = PreviousDoubleWithPositiveDifference(b + sum);
             double upperBound;
             if (Math.Abs(sum) > Math.Abs(b))
             {
                 // Cast to double to prevent upperBound from landing between double.MaxValue and infinity on a 32-bit platform.
-                upperBound = (double)(b + NextDouble(sum));
+                upperBound = (double)(b + NextDoubleWithPositiveDifference(sum));
             }
             else
             {
-                upperBound = (double)(NextDouble(b) + sum);
+                upperBound = (double)(NextDoubleWithPositiveDifference(b) + sum);
             }
             int iterCount = 0;
             while (true)

--- a/src/Runtime/Core/Maths/SpecialFunctions.cs
+++ b/src/Runtime/Core/Maths/SpecialFunctions.cs
@@ -813,12 +813,12 @@ namespace Microsoft.ML.Probabilistic.Math
             // To ensure that the result increases with n, we group terms in n.
             if (x <= 0) throw new ArgumentOutOfRangeException(nameof(x), x, "x <= 0");
             else if (n == 0) return 0;
-            else if (x < 1e-16 && x + n < 1e-16)
+            else if (x < Ulp1 && x + n < Ulp1)
             {
                 // GammaLn(x) = -log(x)
                 return -Log1Plus(n / x) / n;
             }
-            else if (Math.Abs(n / x) < 1e-6)
+            else if (Math.Abs(n / x) < CbrtUlp1)
             {
                 // x >= 1e-6 ensures that Tetragamma doesn't overflow
                 // For small x, Digamma(x) = -1/x, Trigamma(x) = 1/x^2, Tetragamma(x) = -1/x^3
@@ -828,7 +828,7 @@ namespace Microsoft.ML.Probabilistic.Math
             else if (x > GammaLnLargeX && x + n > GammaLnLargeX)
             {
                 double nOverX = n / x;
-                if (Math.Abs(nOverX) < 1e-8)
+                if (Math.Abs(nOverX) < SqrtUlp1)
                     // log(1 + x) = x - 0.5*x^2  when x^2 << 1
                     return Log1Plus(nOverX) - 0.5 * (1 - 0.5 / x) * nOverX + (GammaLnSeries(x + n) - GammaLnSeries(x)) / n - 0.5 / x + Math.Log(x);
                 else
@@ -1176,8 +1176,6 @@ namespace Microsoft.ML.Probabilistic.Math
             }
             return result;
         }
-
-        public static readonly double Ulp1 = Ulp(1.0);
 
         /// <summary>
         /// Compute the regularized upper incomplete Gamma function: int_x^inf t^(a-1) exp(-t) dt / Gamma(a)
@@ -4887,6 +4885,21 @@ rr = mpf('-0.99999824265582826');
         /// The Euler-Mascheroni Constant.
         /// </summary>
         public const double EulerGamma = 0.57721566490153286060651209;
+
+        /// <summary>
+        /// Ulp(1.0) == NextDouble(1.0) - 1.0
+        /// </summary>
+        public static readonly double Ulp1 = Ulp(1.0);
+
+        /// <summary>
+        /// Math.Sqrt(Ulp(1.0))
+        /// </summary>
+        public static readonly double SqrtUlp1 = Math.Sqrt(Ulp1);
+
+        /// <summary>
+        /// Math.Pow(Ulp(1.0), 1.0 / 3)
+        /// </summary>
+        public static readonly double CbrtUlp1 = Math.Pow(Ulp1, 1.0 / 3);
 
         /// <summary>
         /// Digamma(1)

--- a/src/Runtime/Core/Maths/SpecialFunctions.cs
+++ b/src/Runtime/Core/Maths/SpecialFunctions.cs
@@ -2086,6 +2086,8 @@ namespace Microsoft.ML.Probabilistic.Math
             });
         }
 
+        const int NormalCdfMomentRatioMaxTerms = 60;
+
         /// <summary>
         /// Computes int_0^infinity t^n N(t;x,1) dt / (n! N(x;0,1))
         /// </summary>
@@ -2094,10 +2096,9 @@ namespace Microsoft.ML.Probabilistic.Math
         /// <returns></returns>
         public static double NormalCdfMomentRatio(int n, double x)
         {
-            const int maxTerms = 60;
             if (x >= -0.5)
                 return NormalCdfMomentRatioRecurrence(n, x);
-            else if (n <= NormalCdfMomentRatioTableSize - maxTerms && x > -8)
+            else if (n <= NormalCdfMomentRatioTableSize - NormalCdfMomentRatioMaxTerms && x > -8)
             {
                 int index = (int)(-x - 1.5); // index ranges from 0 to 6
                 double x0 = -index - 2;

--- a/src/Runtime/Core/Maths/SpecialFunctions.cs
+++ b/src/Runtime/Core/Maths/SpecialFunctions.cs
@@ -1177,7 +1177,7 @@ namespace Microsoft.ML.Probabilistic.Math
             return result;
         }
 
-        private static readonly double Ulp1 = Ulp(1.0);
+        public static readonly double Ulp1 = Ulp(1.0);
 
         /// <summary>
         /// Compute the regularized upper incomplete Gamma function: int_x^inf t^(a-1) exp(-t) dt / Gamma(a)

--- a/src/Runtime/Core/Maths/SpecialFunctions.cs
+++ b/src/Runtime/Core/Maths/SpecialFunctions.cs
@@ -2742,7 +2742,6 @@ rr = mpf('-0.99999824265582826');
         }
 
         internal static bool TraceConFrac;
-        private static readonly double NormalCdfRatioConfracTolerance = Ulp1 * 1024;
 
         /// <summary>
         /// Returns NormalCdf divided by N(x;0,1) N((y-rx)/sqrt(1-r^2);0,1), multiplied by scale.
@@ -4008,14 +4007,6 @@ rr = mpf('-0.99999824265582826');
             vf = Ex2 - mf * mf;
         }
 
-        // Math.Exp(log0) == 0
-        private static readonly double log0 = Math.Log(double.Epsilon) - Ln2;
-        // 1-Math.Exp(logHalfUlpPrev1) == 1
-        private static readonly double logHalfUlpPrev1 = Math.Log((1.0 - PreviousDouble(1.0)) / 2);
-        private static readonly double logisticGaussianQuadratureRelativeTolerance = 512 * Ulp1;
-        private static readonly double logisticGaussianDerivativeQuadratureRelativeTolerance = 1024 * 512 * Ulp1;
-        private static readonly double logisticGaussianSeriesApproximmationThreshold = 1e-8;
-
         /// <summary>
         /// Calculate sigma(m,v) = \int N(x;m,v) logistic(x) dx
         /// </summary>
@@ -4990,6 +4981,16 @@ rr = mpf('-0.99999824265582826');
         // Maple command: chebyshev( subs(x=2/y-2,log(erfc(x)*(1+x/2))+x*x), y=0..1, 1e-8);
         // more accurate, but more expensive
         //{ -1.265512122, 0.9999999460, 0.3750003113, 0.08331553737, -0.0857441378, -0.142407635, -0.1269326291, 0.295066080, -0.9476268748, 2.769131338, -3.938783592, 2.943051024, -1.142311460, 0.1837542133 };
+
+        private static readonly double NormalCdfRatioConfracTolerance = Ulp1 * 1024;
+
+        // Math.Exp(log0) == 0
+        private static readonly double log0 = Math.Log(double.Epsilon) - Ln2;
+        // 1-Math.Exp(logHalfUlpPrev1) == 1
+        private static readonly double logHalfUlpPrev1 = Math.Log((1.0 - PreviousDouble(1.0)) / 2);
+        private static readonly double logisticGaussianQuadratureRelativeTolerance = 512 * Ulp1;
+        private static readonly double logisticGaussianDerivativeQuadratureRelativeTolerance = 1024 * 512 * Ulp1;
+        private static readonly double logisticGaussianSeriesApproximmationThreshold = 1e-8;
 
         #endregion
     }

--- a/src/Runtime/Core/Maths/SpecialFunctions.cs
+++ b/src/Runtime/Core/Maths/SpecialFunctions.cs
@@ -4941,6 +4941,11 @@ rr = mpf('-0.99999824265582826');
         public const double Sqrt2 = 1.41421356237309504880;
 
         /// <summary>
+        /// Math.Sqrt(3)
+        /// </summary>
+        public const double Sqrt3 = 1.7320508075688772935274463415059;
+
+        /// <summary>
         /// Math.Sqrt(0.5)
         /// </summary>
         public const double SqrtHalf = 0.70710678118654752440084436210485;

--- a/src/Runtime/Distributions/GammaPower.cs
+++ b/src/Runtime/Distributions/GammaPower.cs
@@ -577,7 +577,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 {
                     result -= rate;
                 }
-                else if (logxOverPower <= MMath.SqrtUlp1)
+                else if (Math.Abs(logxOverPower) <= MMath.SqrtUlp1)
                 {
                     // The part of the log-density that depends on x is:
                     //   (shape/power-1)*log(x) - rate*x^(1/power)

--- a/src/Runtime/Distributions/GammaPower.cs
+++ b/src/Runtime/Distributions/GammaPower.cs
@@ -577,7 +577,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 {
                     result -= rate;
                 }
-                else if (logxOverPower * logxOverPower <= MMath.Ulp1)
+                else if (logxOverPower <= MMath.SqrtUlp1)
                 {
                     // The part of the log-density that depends on x is:
                     //   (shape/power-1)*log(x) - rate*x^(1/power)

--- a/src/Runtime/Distributions/GammaPower.cs
+++ b/src/Runtime/Distributions/GammaPower.cs
@@ -577,15 +577,17 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 {
                     result -= rate;
                 }
-                else if (Math.Abs(logxOverPower) < 1e-8)
+                else if (logxOverPower * logxOverPower <= MMath.Ulp1)
                 {
                     // The part of the log-density that depends on x is:
                     //   (shape/power-1)*log(x) - rate*x^(1/power)
                     // = (shape/power-1)*log(x) - rate*exp(log(x)/power))
-                    //   (when abs(log(x)/power) < 1e-8, exp(log(x)/power) = 1 + log(x)/power + 0.5*log(x)^2/power^2)
-                    // = (shape/power-1)*log(x) - rate*(1 + log(x)/power + 0.5*log(x)^2/power^2)
-                    // = ((shape - rate)/power - 1)*log(x) - rate*(1 + 0.5*log(x)^2/power^2)
-                    result += ((shape - rate) / power - 1) * logx - rate * (1 + 0.5 * logxOverPower * logxOverPower);
+                    //   (when abs(log(x)/power)^2 < ulp(1), exp(log(x)/power) can be approximated by 1 + log(x)/power, because
+                    //    the third term of this power series 0.5*log(x)^2/power^2 (as well as all other terms) is less than
+                    //    half-ulp of the first)
+                    // = (shape/power-1)*log(x) - rate*(1 + log(x)/power)
+                    // = ((shape - rate)/power - 1)*log(x) - rate
+                    result += ((shape - rate) / power - 1) * logx - rate;
                 }
                 else
                 {

--- a/src/Runtime/Distributions/GammaPower.cs
+++ b/src/Runtime/Distributions/GammaPower.cs
@@ -577,7 +577,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 {
                     result -= rate;
                 }
-                else if (Math.Abs(logxOverPower) <= MMath.SqrtUlp1)
+                else if (Math.Abs(logxOverPower) < MMath.SqrtUlp1)
                 {
                     // The part of the log-density that depends on x is:
                     //   (shape/power-1)*log(x) - rate*x^(1/power)

--- a/src/Runtime/Factors/IsBetween.cs
+++ b/src/Runtime/Factors/IsBetween.cs
@@ -391,7 +391,7 @@ namespace Microsoft.ML.Probabilistic.Factors
                     double delta = diffs * deltaOverDiffs;
                     double deltaSqrtVx = diff * deltaOverDiffs; // delta / sqrtPrec
                     if (delta < 0) throw new Exception($"{nameof(delta)} < 0");
-                    if (delta < 1e-16 && (mx <= lowerBound || mx >= upperBound))
+                    if (delta < MMath.Ulp1 && (mx <= lowerBound || mx >= upperBound))
                     {
                         double variance = diff * diff / 12;
                         return new Gaussian(center, variance) / X;
@@ -418,13 +418,13 @@ namespace Microsoft.ML.Probabilistic.Factors
                     double rU = MMath.NormalCdfRatio(zU);
                     double r1U = MMath.NormalCdfMomentRatio(1, zU);
                     double r3U = MMath.NormalCdfMomentRatio(3, zU) * 6;
-                    if (zU < -173205080)
+                    if (zU < -(MMath.Sqrt2 * MMath.Sqrt3) / MMath.SqrtUlp1)
                     {
                         // in this regime, rU = -1/zU, r1U = rU*rU
                         // because rU = -1/zU + 1/zU^3 + ...
                         // and r1U = 1/zU^2 - 3/zU^4 + ...
                         // The second term is smaller by a factor of 3/zU^2.
-                        // The threshold satisfies 3/zU^2 == 1e-16 or zU < -sqrt(3e16)
+                        // The threshold satisfies 3/zU^2 < 0.5 * ulp(1) or zU < -sqrt(6 / ulp(1))
                         if (expMinus1 > 1e100)
                         {
                             double invzUs = 1 / (zU * sqrtPrec);

--- a/src/Tools/PythonScripts/GenerateSeries.py
+++ b/src/Tools/PythonScripts/GenerateSeries.py
@@ -91,6 +91,9 @@ def print_heading_comment(indent, header):
 def format_real_coefficient(coefficient, decimal_precision = default_decimal_precision, evalf_inner_precision = default_evalf_inner_precision):
     return format(float(coefficient.evalf(decimal_precision, maxn=evalf_inner_precision)), '.17g')
 
+def format_bigfloat_coefficient(coefficient, decimal_precision = default_decimal_precision, evalf_inner_precision = default_evalf_inner_precision):
+    return str(coefficient.evalf(decimal_precision, maxn=evalf_inner_precision))
+
 def print_polynomial_with_real_coefficients(varname, coefficients, indent):
     if len(coefficients) <= 1:
         print(f"{indent}{format_real_coefficient(coefficients[0])}")
@@ -123,9 +126,9 @@ def print_big_float_array(coefficients, decimal_precision, evalf_inner_precision
         last_non_zero_idx = last_non_zero_idx - 1
     idx = 0
     while idx < last_non_zero_idx:
-        print(f'    BigFloatFactory.Create("{format_real_coefficient(coefficients[idx], decimal_precision, evalf_inner_precision)}"),')
+        print(f'    BigFloatFactory.Create("{format_bigfloat_coefficient(coefficients[idx], decimal_precision, evalf_inner_precision)}"),')
         idx = idx + 1
-    print(f'    BigFloatFactory.Create("{format_real_coefficient(coefficients[last_non_zero_idx], decimal_precision, evalf_inner_precision)}")')
+    print(f'    BigFloatFactory.Create("{format_bigfloat_coefficient(coefficients[last_non_zero_idx], decimal_precision, evalf_inner_precision)}")')
     print("};")
 
 def format_rational_coefficient(coefficient):
@@ -382,48 +385,48 @@ def main():
         print_polynomial_with_rational_coefficients(variable_name, coefficients, indent)
 
 def big_float_main():
-    print_heading_comment(trigamma_at_1_indent, "5: Trigamma at 1")
-    trigamma_at_1_coefficients = [trigamma_at_1_coefficient(k) for k in range(0, 10)]
-    print_big_float_array(trigamma_at_1_coefficients, 50, 500)
+    #print_heading_comment(trigamma_at_1_indent, "5: Trigamma at 1")
+    #trigamma_at_1_coefficients = [trigamma_at_1_coefficient(k) for k in range(0, 10)]
+    #print_big_float_array(trigamma_at_1_coefficients, 50, 500)
 
-    print_heading_comment(trigamma_asymptotic_indent, "6: Trigamma asymptotic")
-    trigamma_asymptotic_coefficients = [trigamma_asymptotic_coefficient(k) for k in range(0, 32)]
-    print_big_float_array(trigamma_asymptotic_coefficients, 50, 500)
+    #print_heading_comment(trigamma_asymptotic_indent, "6: Trigamma asymptotic")
+    #trigamma_asymptotic_coefficients = [trigamma_asymptotic_coefficient(k) for k in range(0, 32)]
+    #print_big_float_array(trigamma_asymptotic_coefficients, 50, 500)
 
-    print_heading_comment(tetragamma_at_1_indent, "7: Tetragamma at 1")
-    tetragamma_at_1_coefficients = [tetragamma_at_1_coefficient(k) for k in range(0, 11)]
-    print_big_float_array(tetragamma_at_1_coefficients, 50, 500)
+    #print_heading_comment(tetragamma_at_1_indent, "7: Tetragamma at 1")
+    #tetragamma_at_1_coefficients = [tetragamma_at_1_coefficient(k) for k in range(0, 11)]
+    #print_big_float_array(tetragamma_at_1_coefficients, 50, 500)
 
-    print_heading_comment(tetragamma_asymptotic_indent, "8: Tetragamma asymptotic")
-    tetragamma_asymptotic_coefficients = [tetragamma_asymptotic_coefficient(k) for k in range(0, 32)]
-    print_big_float_array(tetragamma_asymptotic_coefficients, 50, 500)
+    #print_heading_comment(tetragamma_asymptotic_indent, "8: Tetragamma asymptotic")
+    #tetragamma_asymptotic_coefficients = [tetragamma_asymptotic_coefficient(k) for k in range(0, 32)]
+    #print_big_float_array(tetragamma_asymptotic_coefficients, 50, 500)
 
-    print_heading_comment(gammaln_asymptotic_indent, "9: GammaLn asymptotic")
-    gammaln_asymptotic_coefficients = [gammaln_asymptotic_coefficient(k) for k in range(0, 31)]
-    print_big_float_array(gammaln_asymptotic_coefficients, 50, 500)
+    #print_heading_comment(gammaln_asymptotic_indent, "9: GammaLn asymptotic")
+    #gammaln_asymptotic_coefficients = [gammaln_asymptotic_coefficient(k) for k in range(0, 31)]
+    #print_big_float_array(gammaln_asymptotic_coefficients, 50, 500)
 
-    print_heading_comment(log_1_minus_indent, "11: log(1 - x)")
-    log_1_minus_coefficients = [log_1_minus_coefficient(k) for k in range(0, 50)]
-    print_big_float_array(log_1_minus_coefficients, 50, 500)
+    #print_heading_comment(log_1_minus_indent, "11: log(1 - x)")
+    #log_1_minus_coefficients = [log_1_minus_coefficient(k) for k in range(0, 50)]
+    #print_big_float_array(log_1_minus_coefficients, 50, 500)
 
-    print_heading_comment(x_minus_log_1_plus_indent, "12: x - log(1 + x)")
-    x_minus_log_1_plus_coefficients = [x_minus_log_1_plus_coefficient(k) for k in range(0, 26)]
-    print_big_float_array(x_minus_log_1_plus_coefficients, 50, 500)
+    #print_heading_comment(x_minus_log_1_plus_indent, "12: x - log(1 + x)")
+    #x_minus_log_1_plus_coefficients = [x_minus_log_1_plus_coefficient(k) for k in range(0, 26)]
+    #print_big_float_array(x_minus_log_1_plus_coefficients, 50, 500)
 
     print_heading_comment(exp_minus_1_ratio_minus_1_ratio_minus_half_indent, "14: ((exp(x) - 1) / x - 1) / x - 0.5")
-    exp_minus_1_ratio_minus_1_ratio_minus_half_coefficients = [exp_minus_1_ratio_minus_1_ratio_minus_half_coefficient(k) for k in range(0, 19)]
-    print_big_float_array(exp_minus_1_ratio_minus_1_ratio_minus_half_coefficients, 50, 500)
+    exp_minus_1_ratio_minus_1_ratio_minus_half_coefficients = [exp_minus_1_ratio_minus_1_ratio_minus_half_coefficient(k) for k in range(0, 40)]
+    print_big_float_array(exp_minus_1_ratio_minus_1_ratio_minus_half_coefficients, 40, 500)
 
-    print_heading_comment(normcdfln_asymptotic_indent, "16: normcdfln asymptotic")
-    normcdfln_asymptotic_coefficients = [normcdfln_asymptotic_coefficient(k) for k in range(0, 19)]
-    print_big_float_array(normcdfln_asymptotic_coefficients, 50, 500)
+    #print_heading_comment(normcdfln_asymptotic_indent, "16: normcdfln asymptotic")
+    #normcdfln_asymptotic_coefficients = [normcdfln_asymptotic_coefficient(k) for k in range(0, 19)]
+    #print_big_float_array(normcdfln_asymptotic_coefficients, 50, 500)
     
-    print_heading_comment(reciprocal_factorial_minus_1_indent, "18: Reciprocal factorial minus 1")
-    reciprocal_factorial_minus_1_coefficients = get_reciprocal_factorial_minus_1_coefficients(22)
-    print_big_float_array(reciprocal_factorial_minus_1_coefficients, 50, 500)
+    #print_heading_comment(reciprocal_factorial_minus_1_indent, "18: Reciprocal factorial minus 1")
+    #reciprocal_factorial_minus_1_coefficients = get_reciprocal_factorial_minus_1_coefficients(22)
+    #print_big_float_array(reciprocal_factorial_minus_1_coefficients, 50, 500)
     
-    print_heading_comment(gamma_minus_reciprocal_indent, "19: Gamma(x) - 1/x")
-    gamma_minus_reciprocal_coefficients = get_gamma_minus_reciprocal_coefficients(30)
-    print_big_float_array(gamma_minus_reciprocal_coefficients, 50, 500)
+    #print_heading_comment(gamma_minus_reciprocal_indent, "19: Gamma(x) - 1/x")
+    #gamma_minus_reciprocal_coefficients = get_gamma_minus_reciprocal_coefficients(30)
+    #print_big_float_array(gamma_minus_reciprocal_coefficients, 50, 500)
 
 if __name__ == '__main__': main()

--- a/test/Tests/Operators/OperatorTests.cs
+++ b/test/Tests/Operators/OperatorTests.cs
@@ -2184,7 +2184,7 @@ zL = (L - mx)*sqrt(prec)
             yield return long.MaxValue;
             yield return 0L;
             yield return long.MinValue;
-            for (int i = 0; i < 64; i++)
+            for (int i = 0; i < 63; i++)
             {
                 double bigValue = System.Math.Pow(2, i);
                 yield return -(long)bigValue;


### PR DESCRIPTION
Replaced a number of unnamed constants with explicitly ulp(1)-related ones.

Also fixed long overflow in OperatorTests.Longs() and fixed printing extended-precision float arrays in GenerateSeries.py.