### PR TITLE
Added TruncatedPoisson

### DIFF
--- a/src/Compiler/Dynamic/Binding.cs
+++ b/src/Compiler/Dynamic/Binding.cs
@@ -14,10 +14,6 @@ using Microsoft.ML.Probabilistic.Collections;
 
 namespace Microsoft.ML.Probabilistic.Compiler.Reflection
 {
-#if SUPPRESS_XMLDOC_WARNINGS
-#pragma warning disable 1591
-#endif
-
     /// <summary>
     /// Represents the type parameters and argument conversions needed to invoke a method.
     /// </summary>
@@ -38,12 +34,12 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
         /// The type inferred for each type parameter.
         /// </summary>
         /// <remarks>All entries are non-null.  A missing entry indicates an unconstrained parameter.</remarks>
-        public IDictionary<Type, Type> Types;
+        public readonly Dictionary<Type, Type> Types;
 
         /// <summary>
         /// The conversion inferred for each method parameter position.
         /// </summary>
-        public Conversion[] Conversions;
+        public readonly Conversion[] Conversions;
 
         /// <summary>
         /// Array indexing depth needed to obtain a match.
@@ -551,12 +547,11 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
             if (isReplaced || !formal.ContainsGenericParameters || actual == typeof(Nullable) || GenericParameterFactory.IsConstructedParameter(actual))
             {
                 // no more substitutions are possible in formal.
-                Conversion conv;
                 if (formal.Equals(actual) || GenericParameterFactory.IsConstructedParameter(actual))
                 {
                     yield return binding;
                 }
-                else if (allowSubtype && conversionOptions.TryGetConversion(actual, formal, out conv))
+                else if (allowSubtype && conversionOptions.TryGetConversion(actual, formal, position, out Conversion conv))
                 {
                     Conversion oldConversion = new Conversion();
                     if (position >= 0)
@@ -632,7 +627,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
                     choices = new Type[] { actual };
                 }
                 Type[] formalDefArgs = formalGenericTypeDefinition.GetGenericArguments();
-                Func<int, bool> parameterIsCovariant = i => (formalDefArgs[i].GenericParameterAttributes & GenericParameterAttributes.Covariant) != 0;
+                bool parameterIsCovariant(int i) => (formalDefArgs[i].GenericParameterAttributes & GenericParameterAttributes.Covariant) != 0;
                 int subclassCount = 0;
                 bool anyMatch = false;
                 List<Exception> innerErrors = new List<Exception>();
@@ -763,14 +758,13 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
         /// <param name="type">A type which may have generic parameters.</param>
         /// <param name="typeMap">A dictionary for mapping types</param>
         /// <returns>A type with possibly fewer generic parameters.</returns>
-        public static Type ReplaceTypeParameters(Type type, IDictionary<Type, Type> typeMap)
+        public static Type ReplaceTypeParameters(Type type, IReadOnlyDictionary<Type, Type> typeMap)
         {
             if (type == null) return null;
             else if (!type.ContainsGenericParameters) return type;
             else if (type.IsGenericParameter)
             {
-                Type actual;
-                if (typeMap.TryGetValue(type, out actual)) return actual;
+                if (typeMap.TryGetValue(type, out Type actual)) return actual;
                 else return type;
             }
             else if (type.IsArray)
@@ -842,10 +836,9 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
                 if (!arg.IsGenericParameter) return arg;
                 else
                 {
-                    Type bound;
                     // if the actuals contain constructed type parameters, then these may also be bound, so
                     // we need to call Bind(bound)
-                    if (Types.TryGetValue(arg, out bound)) return Bind(bound);
+                    if (Types.TryGetValue(arg, out Type bound)) return Bind(bound);
                     else
                     {
                         Type[] constraints = arg.GetGenericParameterConstraints();
@@ -863,7 +856,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
 
         public override string ToString()
         {
-            return $"Binding({StringUtil.DictionaryToString(Types, Environment.NewLine)}, Conversions={StringUtil.ArrayToString(Conversions)}, Depth={Depth})";
+            return $"Binding({StringUtil.DictionaryToString<Type,Type>(Types, Environment.NewLine)}, Conversions={StringUtil.ArrayToString(Conversions)}, Depth={Depth})";
         }
 
         /// <summary>
@@ -944,19 +937,21 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
 
         public bool AllowImplicitConversions;
         public bool AllowExplicitConversions;
-        public Func<Type, Type, bool> IsImplicitConversion;
+        public Func<Type, Type, int, bool> IsImplicitConversion;
 
-        public bool TryGetConversion(Type fromType, Type toType, out Conversion conv)
+        public bool TryGetConversion(Type fromType, Type toType, int position, out Conversion conv)
         {
-            if (IsImplicitConversion != null && IsImplicitConversion(fromType, toType))
+            if (IsImplicitConversion != null && IsImplicitConversion(fromType, toType, position))
             {
-                conv = new Conversion();
-                conv.SubclassCount = 1000;
+                conv = new Conversion
+                {
+                    SubclassCount = Conversion.SpecialImplicitSubclassCount
+                };
                 return true;
             }
             return Conversion.TryGetConversion(fromType, toType, out conv) &&
                    (conv.Converter == null ||
-                    (AllowExplicitConversions) ||
+                    AllowExplicitConversions ||
                     (AllowImplicitConversions && !conv.IsExplicit));
         }
     }
@@ -986,15 +981,17 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
 
             public static Constraints FromTypeParameter(Type typeParam)
             {
-                Dictionary<Type, Type> typeMap = new Dictionary<Type, Type>();
-                typeMap[typeParam] = ThisType;
+                Dictionary<Type, Type> typeMap = new Dictionary<Type, Type>
+                {
+                    [typeParam] = ThisType
+                };
                 return FromTypeParameter(typeParam, typeMap);
             }
 
-            public static Constraints FromTypeParameter(Type typeParam, IDictionary<Type, Type> typeMap)
+            public static Constraints FromTypeParameter(Type typeParam, IReadOnlyDictionary<Type, Type> typeMap)
             {
                 Type[] constraints = typeParam.GetGenericParameterConstraints();
-                constraints = Array.ConvertAll<Type, Type>(constraints, delegate (Type tt) { return Binding.ReplaceTypeParameters(tt, typeMap); });
+                constraints = Array.ConvertAll(constraints, delegate (Type tt) { return Binding.ReplaceTypeParameters(tt, typeMap); });
                 Constraints result = new Constraints();
                 result.attributes = typeParam.GenericParameterAttributes;
                 foreach (Type c in constraints)
@@ -1005,15 +1002,12 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
                 return result;
             }
 
-#if SUPPRESS_UNREACHABLE_CODE_WARNINGS
-#pragma warning disable 162
-#endif
-
             public Constraints Intersect(Constraints that)
             {
                 Constraints result = new Constraints();
                 result.attributes = attributes | that.attributes;
-                if (false)
+                bool intersectConstraints = false;
+                if (intersectConstraints)
                 {
                     if (baseTypeConstraint == null) result.baseTypeConstraint = that.baseTypeConstraint;
                     else if (that.baseTypeConstraint == null) result.baseTypeConstraint = baseTypeConstraint;
@@ -1047,10 +1041,6 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
                 return result;
             }
 
-#if SUPPRESS_UNREACHABLE_CODE_WARNINGS
-#pragma warning restore 162
-#endif
-
             public static T[] ArrayJoin<T>(T[] array1, T[] array2)
             {
                 T[] result = new T[array1.Length + array2.Length];
@@ -1083,11 +1073,10 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
 
             public override bool Equals(object obj)
             {
-                Constraints that = obj as Constraints;
-                if (that == null) return false;
-                if (attributes != that.attributes) return false;
-                if (baseTypeConstraint != that.baseTypeConstraint) return false;
-                return (interfaceConstraints == that.interfaceConstraints);
+                return (obj is Constraints that) && 
+                    (attributes == that.attributes) &&
+                    (baseTypeConstraint == that.baseTypeConstraint) &&
+                    (interfaceConstraints == that.interfaceConstraints);
             }
 
             public override int GetHashCode()
@@ -1182,9 +1171,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
         {
             lock (GenericParameterCache)
             {
-                Type result;
                 KeyValuePair<string, Constraints> key = new KeyValuePair<string, Constraints>(name, constraints);
-                if (GenericParameterCache.TryGetValue(key, out result)) return result;
+                if (GenericParameterCache.TryGetValue(key, out Type result)) return result;
                 AssemblyName myAsmName = new AssemblyName("GenericParameterFactory");
                 AssemblyBuilder myAssembly = AssemblyBuilder.DefineDynamicAssembly(myAsmName, AssemblyBuilderAccess.Run);
                 ModuleBuilder myModule = myAssembly.DefineDynamicModule(myAsmName.Name);
@@ -1259,8 +1247,4 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
             return typeParam.IsGenericParameter && (typeParam.DeclaringType.Name == "MakeGenericParameter");
         }
     }
-
-#if SUPPRESS_XMLDOC_WARNINGS
-#pragma warning restore 1591
-#endif
 }

--- a/src/Compiler/Dynamic/Conversion.cs
+++ b/src/Compiler/Dynamic/Conversion.cs
@@ -20,6 +20,11 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
 
     public struct Conversion
     {
+        public const int SameTypeCodeSubclassCount = 1000;
+        public const int OpImplicitSubclassCount = 2000;
+        public const int ChangeRankSubclassCount = 3000;
+        public const int SpecialImplicitSubclassCount = 10000;
+
         public Converter Converter;
 
         /// <summary>
@@ -132,7 +137,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
             if (fromTypeCode == toTypeCode)
             {
                 // fromType has the same TypeCode but is not assignable to toType.
-                info.SubclassCount = 1000;
+                info.SubclassCount = SameTypeCodeSubclassCount;
                 return true;
             }
             info.Converter = GetPrimitiveConverter(fromType, toType);
@@ -381,8 +386,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
             {
                 Type fromElementType = fromType.GetElementType();
                 Type toElementType = toType.GetGenericArguments()[0];
-                int elementSubclassCount;
-                bool ok = IsAssignableFrom(toElementType, fromElementType, out elementSubclassCount);
+                bool ok = IsAssignableFrom(toElementType, fromElementType, out int elementSubclassCount);
                 subclassCount += elementSubclassCount;
                 return ok;
             }
@@ -401,8 +405,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
         {
             info = new Conversion();
             if (fromType == typeof (Nullable)) return IsNullable(toType);
-            int subclassCount;
-            if (IsAssignableFrom(toType, fromType, out subclassCount))
+            if (IsAssignableFrom(toType, fromType, out int subclassCount))
             {
                 //(toType.IsAssignableFrom(fromType)) {
                 // toType is a superclass or an interface of fromType
@@ -481,7 +484,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
                 MethodInfo method = (MethodInfo) member;
                 if (method.ReturnType == toType)
                 {
-                    info.SubclassCount = 1000;
+                    info.SubclassCount = OpImplicitSubclassCount;
                     info.Converter = delegate (object value)
                     {
                         return Util.Invoke(method, null, value);
@@ -497,7 +500,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
                 ParameterInfo[] parameters = method.GetParameters();
                 if (parameters.Length == 1 && parameters[0].ParameterType == fromType)
                 {
-                    info.SubclassCount = 1000;
+                    info.SubclassCount = OpImplicitSubclassCount;
                     info.Converter = delegate (object value)
                     {
                         return Util.Invoke(method, null, value);
@@ -573,7 +576,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
                 int[] lengths = new int[toRank];
                 for (int i = 0; i < toRank; i++) lengths[i] = 1;
                 int[] index = new int[toRank];
-                info.SubclassCount = 1000;
+                info.SubclassCount = ChangeRankSubclassCount;
                 info.Converter = delegate(object item)
                     {
                         object value = item;
@@ -592,7 +595,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
             }
             else if (toRank == 1 || fromRank == 1)
             {
-                info.SubclassCount = 1000;
+                info.SubclassCount = ChangeRankSubclassCount;
                 info.Converter = delegate(object fromArray) { return ChangeRank((Array) fromArray, toRank, toElementType, conv); };
                 return true;
             }
@@ -631,7 +634,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
             Type returnType = signature.ReturnType;
             Type innerReturnType = inner.Method.ReturnType;
             Conversion conv;
-            if (!Conversion.TryGetConversion(innerReturnType, returnType, out conv))
+            if (!TryGetConversion(innerReturnType, returnType, out conv))
             {
                 throw new ArgumentException("Return type of the innerMethod (" + innerReturnType.Name + ") cannot be converted to the delegate return type (" + returnType.Name +
                                             ")");

--- a/src/Compiler/Infer/CompilerAttributes/DependencyInformation.cs
+++ b/src/Compiler/Infer/CompilerAttributes/DependencyInformation.cs
@@ -25,13 +25,13 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
         /// <summary>
         /// Stores the dependency type of all dependent statements.
         /// </summary>
-        public Dictionary<IStatement, DependencyType> dependencyTypeOf = new Dictionary<IStatement, DependencyType>(new IdentityComparer<IStatement>());
+        public Dictionary<IStatement, DependencyType> dependencyTypeOf = new Dictionary<IStatement, DependencyType>(ReferenceEqualityComparer<IStatement>.Instance);
 
         //public SortedDictionary<IStatement,DependencyType> dependencyTypeOf = new SortedDictionary<IStatement, DependencyType>(new StatementComparer());
         /// <summary>
         /// Stores the offsets of all dependent statements that have an offset.
         /// </summary>
-        public Dictionary<IStatement, IOffsetInfo> offsetIndexOf = new Dictionary<IStatement, IOffsetInfo>(new IdentityComparer<IStatement>());
+        public Dictionary<IStatement, IOffsetInfo> offsetIndexOf = new Dictionary<IStatement, IOffsetInfo>(ReferenceEqualityComparer<IStatement>.Instance);
 
         /// <summary>
         /// True if this statement assigns to an output variable of the inference.
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
         /// <summary>
         /// List of method arguments that the statement depends on.
         /// </summary>
-        public Set<IParameterDeclaration> ParameterDependencies = new Set<IParameterDeclaration>(new IdentityComparer<IParameterDeclaration>());
+        public Set<IParameterDeclaration> ParameterDependencies = new Set<IParameterDeclaration>(ReferenceEqualityComparer<IParameterDeclaration>.Instance);
 
         public void AddOffsetIndices(IOffsetInfo offsetIndex, IStatement ist)
         {
@@ -230,8 +230,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
         public void Replace(Converter<IStatement, IStatement> converter)
         {
             List<IStatement> toRemove = new List<IStatement>();
-            Dictionary<IStatement, DependencyType> toAdd = new Dictionary<IStatement, DependencyType>(new IdentityComparer<IStatement>());
-            Dictionary<IStatement, IOffsetInfo> toAddOffset = new Dictionary<IStatement, IOffsetInfo>(new IdentityComparer<IStatement>());
+            Dictionary<IStatement, DependencyType> toAdd = new Dictionary<IStatement, DependencyType>(ReferenceEqualityComparer<IStatement>.Instance);
+            Dictionary<IStatement, IOffsetInfo> toAddOffset = new Dictionary<IStatement, IOffsetInfo>(ReferenceEqualityComparer<IStatement>.Instance);
             foreach (KeyValuePair<IStatement, DependencyType> entry in dependencyTypeOf)
             {
                 IStatement stmt = entry.Key;
@@ -338,8 +338,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
         public void AddClones(Converter<IStatement, IEnumerable<IStatement>> getClones)
         {
             List<IStatement> toRemove = new List<IStatement>();
-            Dictionary<IStatement, DependencyType> toAdd = new Dictionary<IStatement, DependencyType>(new IdentityComparer<IStatement>());
-            Dictionary<IStatement, IOffsetInfo> toAddOffset = new Dictionary<IStatement, IOffsetInfo>(new IdentityComparer<IStatement>());
+            Dictionary<IStatement, DependencyType> toAdd = new Dictionary<IStatement, DependencyType>(ReferenceEqualityComparer<IStatement>.Instance);
+            Dictionary<IStatement, IOffsetInfo> toAddOffset = new Dictionary<IStatement, IOffsetInfo>(ReferenceEqualityComparer<IStatement>.Instance);
             foreach (KeyValuePair<IStatement, DependencyType> entry in dependencyTypeOf)
             {
                 IStatement stmt = entry.Key;

--- a/src/Compiler/Infer/CompilerAttributes/DependencyInformation.cs
+++ b/src/Compiler/Infer/CompilerAttributes/DependencyInformation.cs
@@ -115,9 +115,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
         {
             if (ReferenceEquals(dependencySt, ist))
                 return true;
-            if (dependencySt is AnyStatement)
+            if (dependencySt is AnyStatement anySt)
             {
-                AnyStatement anySt = (AnyStatement)dependencySt;
                 bool found = false;
                 ForEachStatement(anySt, st =>
                 {
@@ -126,10 +125,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
                 });
                 return found;
             }
-            if (dependencySt is IExpressionStatement && ist is IExpressionStatement)
+            if (dependencySt is IExpressionStatement es && ist is IExpressionStatement ies)
             {
-                IExpressionStatement es = (IExpressionStatement)dependencySt;
-                IExpressionStatement ies = (IExpressionStatement)ist;
                 return CodeBuilder.Instance.ContainsExpression(es.Expression, ies.Expression);
             }
             return false;
@@ -172,8 +169,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
 
         public void Remove(DependencyType type, IStatement stmt)
         {
-            DependencyType depType;
-            if (dependencyTypeOf.TryGetValue(stmt, out depType))
+            if (dependencyTypeOf.TryGetValue(stmt, out DependencyType depType))
             {
                 depType = depType & (~type);
                 if (depType == 0)
@@ -223,13 +219,12 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
         public void Replace(IDictionary<IStatement, IStatement> replacements)
         {
             Replace(delegate (IStatement ist)
-                {
-                    IStatement newStmt;
-                    if (replacements.TryGetValue(ist, out newStmt))
-                        return newStmt;
-                    else
-                        return ist;
-                });
+            {
+                if (replacements.TryGetValue(ist, out IStatement newStmt))
+                    return newStmt;
+                else
+                    return ist;
+            });
         }
 
         public void Replace(Converter<IStatement, IStatement> converter)
@@ -247,11 +242,9 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
                     if (newStmt != null)
                     {
                         DependencyType type = entry.Value;
-                        IOffsetInfo offsetIndices;
-                        offsetIndexOf.TryGetValue(stmt, out offsetIndices);
-                        if (newStmt is AnyStatement)
+                        offsetIndexOf.TryGetValue(stmt, out IOffsetInfo offsetIndices);
+                        if (newStmt is AnyStatement anySt)
                         {
-                            AnyStatement anySt = (AnyStatement)newStmt;
                             DependencyType anyTypes = DependencyType.Requirement | DependencyType.SkipIfUniform;
                             DependencyType otherType = type & ~anyTypes;
                             if (otherType > 0)
@@ -295,9 +288,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
             IStatement newStmt = converter(stmt);
             if (!ReferenceEquals(newStmt, stmt))
                 return newStmt;
-            else if (stmt is AnyStatement)
+            else if (stmt is AnyStatement anySt)
             {
-                AnyStatement anySt = (AnyStatement)stmt;
                 AnyStatement newAnySt = new AnyStatement();
                 bool replaced = false;
                 foreach (IStatement ist in anySt.Statements)
@@ -308,8 +300,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
                     if (newStmt != null)
                     {
                         // flatten nested Any statements
-                        if (newStmt is AnyStatement)
-                            newAnySt.Statements.AddRange(((AnyStatement)newStmt).Statements);
+                        if (newStmt is AnyStatement nestedAnySt)
+                            newAnySt.Statements.AddRange(nestedAnySt.Statements);
                         else
                             newAnySt.Statements.Add(newStmt);
                     }
@@ -336,8 +328,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
         {
             AddClones(delegate (IStatement ist)
             {
-                IEnumerable<IStatement> clones;
-                if (clonesOfStatement.TryGetValue(ist, out clones))
+                if (clonesOfStatement.TryGetValue(ist, out IEnumerable<IStatement> clones))
                     return clones;
                 else
                     return null;
@@ -352,9 +343,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
             foreach (KeyValuePair<IStatement, DependencyType> entry in dependencyTypeOf)
             {
                 IStatement stmt = entry.Key;
-                if (stmt is AnyStatement)
+                if (stmt is AnyStatement anySt)
                 {
-                    AnyStatement anySt = (AnyStatement)stmt;
                     AnyStatement newAnySt = new AnyStatement();
                     bool changed = false;
                     foreach (IStatement ist in anySt.Statements)
@@ -380,8 +370,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
                     if (clones != null)
                     {
                         DependencyType type = entry.Value;
-                        IOffsetInfo offsetIndices;
-                        offsetIndexOf.TryGetValue(stmt, out offsetIndices);
+                        offsetIndexOf.TryGetValue(stmt, out IOffsetInfo offsetIndices);
                         if (type > 0)
                         {
                             foreach (var clone in clones)
@@ -413,8 +402,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
         {
             foreach (IStatement ist in anySt.Statements)
             {
-                if (ist is AnyStatement)
-                    ForEachStatement((AnyStatement)ist, action);
+                if (ist is AnyStatement nestedAny)
+                    ForEachStatement(nestedAny, action);
                 else
                     action(ist);
             }
@@ -519,15 +508,16 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
 
         public object Clone()
         {
-            DependencyInformation that = new DependencyInformation();
-            that.dependencyTypeOf = Clone(dependencyTypeOf);
-            // the OffsetInfo values inside the offsetIndexOf dictionary are not cloned.
-            that.offsetIndexOf = Clone(offsetIndexOf);
-            that.IsOutput = IsOutput;
-            that.IsUniform = IsUniform;
-            that.IsFresh = IsFresh;
-            that.ParameterDependencies = Clone(ParameterDependencies);
-            return that;
+            return new DependencyInformation
+            {
+                dependencyTypeOf = Clone(dependencyTypeOf),
+                // the OffsetInfo values inside the offsetIndexOf dictionary are not cloned.
+                offsetIndexOf = Clone(offsetIndexOf),
+                IsOutput = IsOutput,
+                IsUniform = IsUniform,
+                IsFresh = IsFresh,
+                ParameterDependencies = Clone(ParameterDependencies)
+            };
         }
 
         private List<T> Clone<T>(List<T> list)

--- a/src/Compiler/Infer/CompilerAttributes/LoopMergingInfo.cs
+++ b/src/Compiler/Infer/CompilerAttributes/LoopMergingInfo.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
         /// <summary>
         /// Maps statements into graph node numbers
         /// </summary>
-        private Dictionary<IStatement, NodeIndex> indexOf = new Dictionary<IStatement, NodeIndex>(new IdentityComparer<IStatement>());
+        private Dictionary<IStatement, NodeIndex> indexOf = new Dictionary<IStatement, NodeIndex>(ReferenceEqualityComparer<IStatement>.Instance);
 
         /// <summary>
         /// A graph where nodes are statements and edges indicate that loop merging is prohibited between them.
@@ -169,7 +169,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Attributes
                 ICollection<IVariableDeclaration> list = prohibitedLoopVars[edge];
                 if (list == null)
                 {
-                    list = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+                    list = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
                     prohibitedLoopVars[edge] = list;
                 }
                 list.AddRange(loopVars);

--- a/src/Compiler/Infer/Models/ModelBuilder.cs
+++ b/src/Compiler/Infer/Models/ModelBuilder.cs
@@ -30,16 +30,16 @@ namespace Microsoft.ML.Probabilistic.Models
         public ITypeDeclaration modelType;
         public AttributeRegistry<object, ICompilerAttribute> Attributes;
         private Stack<IModelExpression> toSearch = new Stack<IModelExpression>();
-        private Set<IModelExpression> searched = new Set<IModelExpression>(new IdentityComparer<IModelExpression>());
+        private Set<IModelExpression> searched = new Set<IModelExpression>(ReferenceEqualityComparer<IModelExpression>.Instance);
 
         /// <summary>
         /// The set of condition variables used in 'IfNot' blocks.  Filled in during search.
         /// </summary>
-        private Set<Variable> negatedConditionVariables = new Set<Variable>(new IdentityComparer<Variable>());
+        private Set<Variable> negatedConditionVariables = new Set<Variable>(ReferenceEqualityComparer<Variable>.Instance);
 
         // optimizes ModelBuilder.Compile
         internal List<Variable> observedVars = new List<Variable>();
-        internal Set<IVariable> variablesToInfer = new Set<IVariable>(new IdentityComparer<IVariable>());
+        internal Set<IVariable> variablesToInfer = new Set<IVariable>(ReferenceEqualityComparer<IVariable>.Instance);
 
         protected IMethodDeclaration modelMethod;
         protected Stack<IList<IStatement>> blockStack;
@@ -912,7 +912,7 @@ namespace Microsoft.ML.Probabilistic.Models
 
         protected void GetJaggedArrayIndicesAndSizes(IVariableArray array, out IList<IVariableDeclaration[]> jaggedIndexVars, out IList<IExpression[]> jaggedSizes)
         {
-            Set<IVariableDeclaration> allVars = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+            Set<IVariableDeclaration> allVars = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
             jaggedIndexVars = new List<IVariableDeclaration[]>();
             jaggedSizes = new List<IExpression[]>();
             while (true)

--- a/src/Compiler/Infer/Transforms/Channel2Transform.cs
+++ b/src/Compiler/Infer/Transforms/Channel2Transform.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         private ChannelAnalysisTransform analysis;
 
         private readonly Dictionary<IVariableDeclaration, VariableToChannelInformation> usesOfVariable =
-            new Dictionary<IVariableDeclaration, VariableToChannelInformation>(new IdentityComparer<IVariableDeclaration>());
+            new Dictionary<IVariableDeclaration, VariableToChannelInformation>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
 
         public override ITypeDeclaration Transform(ITypeDeclaration itd)
         {

--- a/src/Compiler/Infer/Transforms/ChannelAnalysisTransform.cs
+++ b/src/Compiler/Infer/Transforms/ChannelAnalysisTransform.cs
@@ -214,7 +214,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             /// </summary>
             protected Dictionary<IExpression, Dictionary<object, List<GroupKey>>> invertedIndex;
             protected static IVariableDeclaration tempDecl = Builder.VarDecl("_EmptyBinding", typeof(int));
-            public Dictionary<IStatement, Queue<int>> useNumberOfStatement = new Dictionary<IStatement, Queue<int>>(new IdentityComparer<IStatement>());
+            public Dictionary<IStatement, Queue<int>> useNumberOfStatement = new Dictionary<IStatement, Queue<int>>(ReferenceEqualityComparer<IStatement>.Instance);
             public int NumberOfUses;
 
             /// <summary>

--- a/src/Compiler/Infer/Transforms/CopyPropagationTransform.cs
+++ b/src/Compiler/Infer/Transforms/CopyPropagationTransform.cs
@@ -123,12 +123,16 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             {
                 FactorManager.FactorInfo info = context.InputAttributes.Get<FactorManager.FactorInfo>(imie);
                 if (info != null)
+                {
                     fcnInfo = info.GetMessageFcnInfoFromFactor();
+                }
                 else
                 {
                     ParameterInfo[] parameters = method.GetParameters();
-                    fcnInfo = new MessageFcnInfo(method, parameters);
-                    fcnInfo.DependencyInfo = FactorManager.GetDependencyInfo(method);
+                    fcnInfo = new MessageFcnInfo(method, parameters)
+                    {
+                        DependencyInfo = FactorManager.GetDependencyInfo(method)
+                    };
                 }
                 //context.InputAttributes.Set(method, fcnInfo);
             }

--- a/src/Compiler/Infer/Transforms/DeadCodeTransform.cs
+++ b/src/Compiler/Infer/Transforms/DeadCodeTransform.cs
@@ -261,9 +261,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         {
             foreach (NodeIndex node in nodes)
             {
-                Loop nodeLoop = blockOfNode[node] as Loop;
                 // when the target is also in a while loop, you need the initializer to precede target's entire loop
-                NodeIndex target = (nodeLoop == null || nodeLoop.indices.Count == 0) ? node : nodeLoop.indices[0];
+                NodeIndex target = (!(blockOfNode[node] is Loop nodeLoop) || nodeLoop.indices.Count == 0) ? node : nodeLoop.indices[0];
                 foreach (NodeIndex source in g.dependencyGraph.SourcesOf(node))
                 {
                     if (source >= node && usedNodes.Contains(source) && blockOfNode[source] is Loop loop)

--- a/src/Compiler/Infer/Transforms/DeadCodeTransform.cs
+++ b/src/Compiler/Infer/Transforms/DeadCodeTransform.cs
@@ -110,7 +110,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             /// <summary>
             /// Nodes in the loop whose outputs are used by the loop before they are updated.
             /// </summary>
-            public Set<IStatement> initializers = new Set<IStatement>(new IdentityComparer<IStatement>());
+            public Set<IStatement> initializers = new Set<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
 
             public List<NodeIndex> tail;
             public List<NodeIndex> firstIterPostBlock = new List<NodeIndex>();

--- a/src/Compiler/Infer/Transforms/DependencyAnalysisTransform.cs
+++ b/src/Compiler/Infer/Transforms/DependencyAnalysisTransform.cs
@@ -82,7 +82,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         /// Records all times that a variable is declared or assigned to
         /// </summary>
         private Dictionary<IVariableDeclaration, MutationInformation> mutInfos =
-            new Dictionary<IVariableDeclaration, MutationInformation>(new IdentityComparer<IVariableDeclaration>());
+            new Dictionary<IVariableDeclaration, MutationInformation>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
 
         private bool convertingLoopInitializer;
 
@@ -103,7 +103,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 Dictionary<IVariableDeclaration, CodeRecognizer.Bounds> bounds = null;
                 if (mutatedExpressions.Count > 0)
                 {
-                    bounds = new Dictionary<IVariableDeclaration, CodeRecognizer.Bounds>(new IdentityComparer<IVariableDeclaration>());
+                    bounds = new Dictionary<IVariableDeclaration, CodeRecognizer.Bounds>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
                     Recognizer.AddLoopBounds(bounds, ist);
                 }
                 foreach (IExpression mutated in mutatedExpressions)
@@ -394,7 +394,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                     Error("Cannot find dependency information for statement: " + ist);
                     continue;
                 }
-                var bounds = new Dictionary<IVariableDeclaration, CodeRecognizer.Bounds>(new IdentityComparer<IVariableDeclaration>());
+                var bounds = new Dictionary<IVariableDeclaration, CodeRecognizer.Bounds>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
                 Recognizer.AddLoopBounds(bounds, ist);
                 bool debug = false;
                 if (debug)
@@ -427,7 +427,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 DependencyInformation di2 = (DependencyInformation)di.Clone();
                 di2.dependencyTypeOf.Clear();
                 // For each mutating statement, stores the loop indices in mutated that must be iterated to cover affected (i.e. loops that cannot be merged).
-                Dictionary<IStatement, Set<IVariableDeclaration>> extraIndicesOfStmt = new Dictionary<IStatement, Set<IVariableDeclaration>>(new IdentityComparer<IStatement>());
+                Dictionary<IStatement, Set<IVariableDeclaration>> extraIndicesOfStmt = new Dictionary<IStatement, Set<IVariableDeclaration>>(ReferenceEqualityComparer<IStatement>.Instance);
                 foreach (IStatement exprStmt in di.DeclDependencies)
                 {
                     var mutatingStmts = GetStatementsThatMutate(ist, exprStmt, true, false, ist, bounds, di2.offsetIndexOf, extraIndicesOfStmt);
@@ -551,7 +551,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 DependencyInformation di2 = context.InputAttributes.Get<DependencyInformation>(mutatingStmt);
                 if (di2.HasDependency(DependencyType.Cancels, affectedStmt))
                 {
-                    var replacements = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+                    var replacements = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
                     replacements[mutatingStmt] = null;
                     di.Replace(replacements);
                     //DependencyType type = di.dependencyTypeOf[mutatingStmt];
@@ -1631,8 +1631,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                         ignoreExpr = Builder.ArrayIndex(expr, ignoreIndex);
                 }
                 var offsets = new OffsetInfo();
-                var extraIndices = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
-                var bounds = new Dictionary<IVariableDeclaration, CodeRecognizer.Bounds>(new IdentityComparer<IVariableDeclaration>());
+                var extraIndices = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
+                var bounds = new Dictionary<IVariableDeclaration, CodeRecognizer.Bounds>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
                 var allocations = new List<Mutation>();
                 var mutationsOnly = new List<Mutation>();
                 foreach (Mutation m in mutations)
@@ -1664,12 +1664,12 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                         if (extraIndices.Count > 0 && extraIndicesOfStmt != null)
                         {
                             extraIndicesOfStmt[m.stmt] = extraIndices;
-                            extraIndices = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+                            extraIndices = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
                         }
                     }
                 }
                 // prune allocations that are fully overwritten by some other allocation or mutation
-                Set<IStatement> overwritten = new Set<IStatement>(new IdentityComparer<IStatement>());
+                Set<IStatement> overwritten = new Set<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
                 foreach (Mutation m in allocations)
                 {
                     IStatement ist = m.stmt;

--- a/src/Compiler/Infer/Transforms/DependencyGraph.cs
+++ b/src/Compiler/Infer/Transforms/DependencyGraph.cs
@@ -194,7 +194,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             bool deleteCancels = false,
             bool readAfterWriteOnly = false)
         {
-            Dictionary<IStatement, int> indexOfNode = new Dictionary<IStatement, int>(new IdentityComparer<IStatement>());
+            Dictionary<IStatement, int> indexOfNode = new Dictionary<IStatement, int>(ReferenceEqualityComparer<IStatement>.Instance);
             for (int i = 0; i < nodes.Count; i++)
             {
                 indexOfNode[nodes[i]] = i;

--- a/src/Compiler/Infer/Transforms/DependencyGraph2.cs
+++ b/src/Compiler/Infer/Transforms/DependencyGraph2.cs
@@ -38,17 +38,17 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         /// <summary>
         /// Maps from a statement to the index of every position it occurs in the schedule (but only if it occurs more than once)
         /// </summary>
-        public Dictionary<IStatement, Set<NodeIndex>> duplicates = new Dictionary<IStatement, Set<NodeIndex>>(new IdentityComparer<IStatement>());
+        public Dictionary<IStatement, Set<NodeIndex>> duplicates = new Dictionary<IStatement, Set<NodeIndex>>(ReferenceEqualityComparer<IStatement>.Instance);
 
         /// <summary>
         /// Maps from a source statement (which has not yet received an index) to the index of its targets
         /// </summary>
-        public Dictionary<IStatement, Set<NodeIndex>> backEdges = new Dictionary<IStatement, Set<EdgeIndex>>(new IdentityComparer<IStatement>());
+        public Dictionary<IStatement, Set<NodeIndex>> backEdges = new Dictionary<IStatement, Set<EdgeIndex>>(ReferenceEqualityComparer<IStatement>.Instance);
 
         /// <summary>
         /// Maps from a statement to the last position it occurs in the schedule
         /// </summary>
-        public Dictionary<IStatement, NodeIndex> indexOfNode = new Dictionary<IStatement, int>(new IdentityComparer<IStatement>());
+        public Dictionary<IStatement, NodeIndex> indexOfNode = new Dictionary<IStatement, int>(ReferenceEqualityComparer<IStatement>.Instance);
 
         public enum BackEdgeHandling
         {

--- a/src/Compiler/Infer/Transforms/DependencyPruningTransform.cs
+++ b/src/Compiler/Infer/Transforms/DependencyPruningTransform.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         internal static bool debug;
         IBlockStatement debugBlock;
         private LoopMergingInfo loopMergingInfo;
-        private Dictionary<IStatement, int> indexOfStatement = new Dictionary<IStatement, int>(new IdentityComparer<IStatement>());
+        private Dictionary<IStatement, int> indexOfStatement = new Dictionary<IStatement, int>(ReferenceEqualityComparer<IStatement>.Instance);
 
         protected override void DoConvertMethodBody(IList<IStatement> outputs, IList<IStatement> inputs)
         {
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         {
             // collapse dependencies that have the same unique index.
             Dictionary<int, KeyValuePair<int, IStatement>> nodeOfUniqueIndex = new Dictionary<int, KeyValuePair<int, IStatement>>();
-            Set<IStatement> sourcesToRemove = new Set<IStatement>(new IdentityComparer<IStatement>());
+            Set<IStatement> sourcesToRemove = new Set<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
             foreach (IStatement source in di.GetDependenciesOfType(DependencyType.Dependency))
             {
                 int sourceIndex;

--- a/src/Compiler/Infer/Transforms/ForwardBackwardTransform.cs
+++ b/src/Compiler/Infer/Transforms/ForwardBackwardTransform.cs
@@ -64,8 +64,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         /// <summary>
         /// For each context, store a map from original statement to transformed statement
         /// </summary>
-        private Dictionary<ICollection<IStatement>, Dictionary<IStatement, IStatement>> transformedStmtsInContext = new Dictionary<ICollection<IStatement>, Dictionary<IStatement, IStatement>>(new IdentityComparer<object>());
-        private Dictionary<IStatement, Set<IVariableDeclaration>> reversedLoopVarsInStmt = new Dictionary<IStatement, Set<IVariableDeclaration>>(new IdentityComparer<IStatement>());
+        private Dictionary<ICollection<IStatement>, Dictionary<IStatement, IStatement>> transformedStmtsInContext = new Dictionary<ICollection<IStatement>, Dictionary<IStatement, IStatement>>(ReferenceEqualityComparer<object>.Instance);
+        private Dictionary<IStatement, Set<IVariableDeclaration>> reversedLoopVarsInStmt = new Dictionary<IStatement, Set<IVariableDeclaration>>(ReferenceEqualityComparer<IStatement>.Instance);
         private LoopMergingInfo loopMergingInfo;
         private Stack<StackFrame> stackFrames = new Stack<StackFrame>();
         private IVariableDeclaration currentLoopVar;
@@ -80,7 +80,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         /// For each original special statement, gives its transformed statement in each loop context
         /// </summary>
         private Dictionary<IStatement, Dictionary<Set<IVariableDeclaration>, IStatement>> specialTransformedStmts =
-            new Dictionary<IStatement, Dictionary<Set<IVariableDeclaration>, IStatement>>(new IdentityComparer<IStatement>());
+            new Dictionary<IStatement, Dictionary<Set<IVariableDeclaration>, IStatement>>(ReferenceEqualityComparer<IStatement>.Instance);
 
         protected class StackFrame
         {
@@ -152,7 +152,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         /// <param name="replacementsInContext"></param>
         private void CollectTransformedStmts(ICollection<IStatement> outputBlock, Dictionary<ICollection<IStatement>, Dictionary<IStatement, IStatement>> replacementsInContext)
         {
-            var replacements = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+            var replacements = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
             replacementsInContext[outputBlock] = replacements;
             Dictionary<IStatement, IStatement> transformedStmts;
             if (transformedStmtsInContext.TryGetValue(outputBlock, out transformedStmts))
@@ -230,9 +230,9 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         {
             // construct a replacement dictionary for every context
             // the replacement will be an AnyStatement containing all transformed versions that are compatible with this context
-            var replacementsInContext = new Dictionary<ICollection<IStatement>, Dictionary<IStatement, IStatement>>(new IdentityComparer<object>());
+            var replacementsInContext = new Dictionary<ICollection<IStatement>, Dictionary<IStatement, IStatement>>(ReferenceEqualityComparer<object>.Instance);
             ICollection<IStatement> rootContext = outputs;
-            transformedStmtsInContext[rootContext] = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+            transformedStmtsInContext[rootContext] = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
             CollectTransformedStmts(rootContext, replacementsInContext);
             DistributeTransformedStmts(rootContext, replacementsInContext);
 
@@ -623,7 +623,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             if (loopIndex >= infos.Count)
             {
                 // start a new context
-                Dictionary<IStatement, IStatement> transformedStmts = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+                Dictionary<IStatement, IStatement> transformedStmts = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
                 if (transformedStmtsInContext.ContainsKey(outputStmts))
                     throw new Exception("Internal: context transformed twice");
                 transformedStmtsInContext[outputStmts] = transformedStmts;
@@ -693,7 +693,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                     }
                 }
                 // put the nodes into a Set for fast membership checking
-                Set<IStatement> originalStmts = new Set<IStatement>(new IdentityComparer<IStatement>());
+                Set<IStatement> originalStmts = new Set<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
                 foreach (NodeIndex node in currentBlock)
                 {
                     originalStmts.Add(inputStmts[node]);

--- a/src/Compiler/Infer/Transforms/IncrementPruningTransform.cs
+++ b/src/Compiler/Infer/Transforms/IncrementPruningTransform.cs
@@ -24,9 +24,9 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             }
         }
 
-        Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+        Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
         HashSet<IncrementStatement> incrementStatements = new HashSet<IncrementStatement>();
-        HashSet<IStatement> visitedStatements = new HashSet<IStatement>(new IdentityComparer<IStatement>());
+        HashSet<IStatement> visitedStatements = new HashSet<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
         bool inWhileLoop;
         int ancestorIndexOfWhile;
 

--- a/src/Compiler/Infer/Transforms/InitializerTransform.cs
+++ b/src/Compiler/Infer/Transforms/InitializerTransform.cs
@@ -142,7 +142,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         protected override void DoConvertMethodBody(IList<IStatement> outputs, IList<IStatement> inputs)
         {
-            Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+            Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
             ProcessStatements(outputs, outputs, inputs, replacements);
             // update all dependencies
             foreach (IStatement ist in outputs)

--- a/src/Compiler/Infer/Transforms/IterationTransform.cs
+++ b/src/Compiler/Infer/Transforms/IterationTransform.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         private ModelCompiler compiler;
         LoopCountAnalysisTransform analysis;
-        Dictionary<IStatement, IEnumerable<IStatement>> clonesOfStatement = new Dictionary<IStatement, IEnumerable<IStatement>>(new IdentityComparer<IStatement>());
+        Dictionary<IStatement, IEnumerable<IStatement>> clonesOfStatement = new Dictionary<IStatement, IEnumerable<IStatement>>(ReferenceEqualityComparer<IStatement>.Instance);
         private LoopMergingInfo loopMergingInfo;
 
         public IterationTransform(ModelCompiler compiler)
@@ -441,7 +441,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
     internal class LoopCountAnalysisTransform : ShallowCopyTransform
     {
-        public Dictionary<IVariableDeclaration, int> loopVarCount = new Dictionary<IVariableDeclaration, int>(new IdentityComparer<IVariableDeclaration>());
+        public Dictionary<IVariableDeclaration, int> loopVarCount = new Dictionary<IVariableDeclaration, int>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
 
         protected override IStatement ConvertFor(IForStatement ifs)
         {

--- a/src/Compiler/Infer/Transforms/IterativeProcessTransform.cs
+++ b/src/Compiler/Infer/Transforms/IterativeProcessTransform.cs
@@ -493,7 +493,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             IndexedProperty<NodeIndex, Set<IParameterDeclaration>> parameterDependencies = dependencyGraph.CreateNodeData<Set<IParameterDeclaration>>(null);
             // stores virtual dependency edges along which parameterDeps should flow
             IndexedProperty<NodeIndex, Set<NodeIndex>> containerDependencies = dependencyGraph.CreateNodeData<Set<NodeIndex>>(null);
-            Dictionary<IStatement, int> indexOfNode = new Dictionary<IStatement, int>(new IdentityComparer<IStatement>());
+            Dictionary<IStatement, int> indexOfNode = new Dictionary<IStatement, int>(ReferenceEqualityComparer<IStatement>.Instance);
             Set<NodeIndex> inputNodes = new Set<NodeIndex>();
             Set<NodeIndex> loopNodes = new Set<NodeIndex>();
             int whileNodeIndex = -1;
@@ -583,7 +583,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 // Additionally, if the statement is an assignment whose lhs is indexed by a parameter, then we need to re-execute the initializer statements
                 // when the parameter changes.  This case is also handled by GetConditionAndTargetIndexExpressions.
                 Set<IParameterDeclaration> parametersUsedInCondition =
-                    new Set<IParameterDeclaration>(new IdentityComparer<IParameterDeclaration>());
+                    new Set<IParameterDeclaration>(ReferenceEqualityComparer<IParameterDeclaration>.Instance);
                 parametersUsedInCondition.AddRange(Recognizer.GetConditionAndTargetIndexExpressions(ist)
                     .SelectMany(Recognizer.GetArgumentReferenceExpressions)
                     .Select(iare => iare.Parameter.Resolve()));
@@ -620,7 +620,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 nodes.Add(iws);
                 whileNodeIndex = dependencyGraph.AddNode();
                 indexOfNode[iws] = whileNodeIndex;
-                Set<IParameterDeclaration> parameterDeps = new Set<IParameterDeclaration>(new IdentityComparer<IParameterDeclaration>());
+                Set<IParameterDeclaration> parameterDeps = new Set<IParameterDeclaration>(ReferenceEqualityComparer<IParameterDeclaration>.Instance);
                 parameterDependencies[whileNodeIndex] = parameterDeps;
                 if (IsConvergenceLoop(iws))
                 {
@@ -813,7 +813,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 {
                     Set<IParameterDeclaration> initParams = initParameters[sourceIndex];
                     if (initParams == null)
-                        initParams = new Set<IParameterDeclaration>(new IdentityComparer<IParameterDeclaration>());
+                        initParams = new Set<IParameterDeclaration>(ReferenceEqualityComparer<IParameterDeclaration>.Instance);
                     initParams.AddRange(parameterDeps);
                     if (!hasLoopAncestor[loopNode])
                     {
@@ -886,7 +886,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             // use the parameter dependencies to define subroutines
             List<Subroutine> subroutines = new List<Subroutine>();
             Dictionary<SubroutineDependencies, int> indexOfSubroutine = new Dictionary<SubroutineDependencies, int>();
-            Set<IParameterDeclaration> emptySet = new Set<IParameterDeclaration>(new IdentityComparer<IParameterDeclaration>());
+            Set<IParameterDeclaration> emptySet = new Set<IParameterDeclaration>(ReferenceEqualityComparer<IParameterDeclaration>.Instance);
             // loop statements in their original order
             foreach (NodeIndex target in dependencyGraph.Nodes)
             {
@@ -1414,8 +1414,9 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         }
 
         Set<T> AddParameterDependencies<T>(Set<T> set, IEnumerable<T> itemsToAdd)
+            where T : class
         {
-            var result = Set<T>.FromEnumerable(new IdentityComparer<T>(), set);
+            var result = Set<T>.FromEnumerable(ReferenceEqualityComparer<T>.Instance, set);
             result.AddRange(itemsToAdd);
             return result;
         }

--- a/src/Compiler/Infer/Transforms/LocalAllocationTransform.cs
+++ b/src/Compiler/Infer/Transforms/LocalAllocationTransform.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             IMethodDeclaration imd = context.FindAncestor<IMethodDeclaration>();
             loopMergingInfo = context.InputAttributes.Get<LoopMergingInfo>(imd);
             List<IWhileStatement> whileStatements = new List<IWhileStatement>();
-            Set<IStatement> initializerStatements = new Set<IStatement>(new IdentityComparer<IStatement>());
+            Set<IStatement> initializerStatements = new Set<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
             List<int> whileNumberOfNode = new List<int>();
             // the number of containers that must be shared with the previous statement.
             List<int> sharedContainerCountOfNode = new List<NodeIndex>();
@@ -627,7 +627,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                         CloneInfos info = cloneInfosOfNode[node];
                         IStatement initSt = nodes[node];
                         Set<IVariableDeclaration> mutatedVariables = GetMutatedVariables(initSt);
-                        Set<IVariableDeclaration> newMutatedVariables = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+                        Set<IVariableDeclaration> newMutatedVariables = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
                         foreach (var entry in info.targetsByReversedLoops)
                         {
                             var reversedLoops = entry.Key;
@@ -904,7 +904,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         private bool CheckNodesAreUnique()
         {
             // check all non-null nodes are unique
-            Set<IStatement> stmts = new Set<IStatement>(new IdentityComparer<IStatement>());
+            Set<IStatement> stmts = new Set<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
             foreach (var ist in nodes)
             {
                 if (ist == null)
@@ -961,7 +961,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         private class Replacements
         {
-            public Dictionary<IStatement, IStatement> statementReplacements = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+            public Dictionary<IStatement, IStatement> statementReplacements = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
             public Dictionary<IVariableDeclaration, IVariableDeclaration> variableReplacements = new Dictionary<IVariableDeclaration, IVariableDeclaration>();
 
             public int Count
@@ -1117,7 +1117,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         private Set<IVariableDeclaration> GetMutatedVariables(IStatement stmt)
         {
-            Set<IVariableDeclaration> mutatedVariables = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+            Set<IVariableDeclaration> mutatedVariables = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
             ForEachInitializerStatement(stmt, init =>
             {
                 if (init is IExpressionStatement)

--- a/src/Compiler/Infer/Transforms/LocalAllocationTransform2.cs
+++ b/src/Compiler/Infer/Transforms/LocalAllocationTransform2.cs
@@ -89,7 +89,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             IMethodDeclaration imd = context.FindAncestor<IMethodDeclaration>();
             loopMergingInfo = context.InputAttributes.Get<LoopMergingInfo>(imd);
             List<IWhileStatement> whileStatements = new List<IWhileStatement>();
-            Set<IStatement> initializerStatements = new Set<IStatement>(new IdentityComparer<IStatement>());
+            Set<IStatement> initializerStatements = new Set<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
             List<int> whileNumberOfNode = new List<int>();
             // the number of containers that must be shared with the previous statement.
             List<int> sharedContainerCountOfNode = new List<NodeIndex>();
@@ -570,7 +570,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         private bool CheckNodesAreUnique()
         {
             // check all non-null nodes are unique
-            Set<IStatement> stmts = new Set<IStatement>(new IdentityComparer<IStatement>());
+            Set<IStatement> stmts = new Set<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
             foreach (var ist in nodes)
             {
                 if (ist == null)
@@ -628,7 +628,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         private class Replacements
         {
-            public Dictionary<IStatement, IStatement> statementReplacements = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+            public Dictionary<IStatement, IStatement> statementReplacements = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
             public Dictionary<IVariableDeclaration, IVariableDeclaration> variableReplacements = new Dictionary<IVariableDeclaration, IVariableDeclaration>();
 
             public int Count
@@ -731,7 +731,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         private Set<IVariableDeclaration> GetMutatedVariables(IStatement stmt)
         {
-            Set<IVariableDeclaration> mutatedVariables = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+            Set<IVariableDeclaration> mutatedVariables = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
             ForEachInitializerStatement(stmt, init =>
             {
                 if (init is IExpressionStatement)
@@ -1032,7 +1032,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                     bool anyMutated = false;
                     bool allMutated = true;
                     Set<IVariableDeclaration> mutatedVariables = GetMutatedVariables(ist);
-                    Set<IVariableDeclaration> newMutatedVariables = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+                    Set<IVariableDeclaration> newMutatedVariables = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
                     foreach (var mutatedVariable in mutatedVariables)
                     {
                         IVariableDeclaration newMutatedVariable;

--- a/src/Compiler/Infer/Transforms/LocalTransform.cs
+++ b/src/Compiler/Infer/Transforms/LocalTransform.cs
@@ -350,7 +350,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         /// <summary>
         /// Maps an IForStatement to its LocalInfos
         /// </summary>
-        internal Dictionary<IStatement, Dictionary<IExpression, LocalInfo>> localInfoOfStmt = new Dictionary<IStatement, Dictionary<IExpression, LocalInfo>>(new IdentityComparer<IStatement>());
+        internal Dictionary<IStatement, Dictionary<IExpression, LocalInfo>> localInfoOfStmt = new Dictionary<IStatement, Dictionary<IExpression, LocalInfo>>(ReferenceEqualityComparer<IStatement>.Instance);
         private Stack<IStatement> openContainers = new Stack<IStatement>();
         private bool InPartitionedLoop;
         ModelCompiler compiler;
@@ -633,7 +633,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             info.count++;
             if (info.containingStatements == null)
             {
-                info.containingStatements = new HashSet<IStatement>(openContainers, new IdentityComparer<IStatement>());
+                info.containingStatements = new HashSet<IStatement>(openContainers, ReferenceEqualityComparer<IStatement>.Instance);
                 info.containers = GetContainers();
             }
             else

--- a/src/Compiler/Infer/Transforms/LoopCuttingTransform.cs
+++ b/src/Compiler/Infer/Transforms/LoopCuttingTransform.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         }
 
         private bool convertingBrokenLoop;
-        private Dictionary<IVariableDeclaration, LoopVarInfo> loopVarInfos = new Dictionary<IVariableDeclaration, LoopVarInfo>(new IdentityComparer<IVariableDeclaration>());
+        private Dictionary<IVariableDeclaration, LoopVarInfo> loopVarInfos = new Dictionary<IVariableDeclaration, LoopVarInfo>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
         private bool hoistAttributes;
 
         internal LoopCuttingTransform(bool hoistAttributes)

--- a/src/Compiler/Infer/Transforms/LoopMergingTransform.cs
+++ b/src/Compiler/Infer/Transforms/LoopMergingTransform.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         private bool isTopLevel;
         private LoopMergingInfo loopMergingInfo;
         private List<IStatement> openContainers = new List<IStatement>();
-        private Dictionary<IStatement, Set<int>> stmtsOfContainer = new Dictionary<IStatement, Set<int>>(new IdentityComparer<IStatement>());
+        private Dictionary<IStatement, Set<int>> stmtsOfContainer = new Dictionary<IStatement, Set<int>>(ReferenceEqualityComparer<IStatement>.Instance);
 
         protected override IMethodDeclaration DoConvertMethod(IMethodDeclaration md, IMethodDeclaration imd)
         {

--- a/src/Compiler/Infer/Transforms/LoopReversalTransform.cs
+++ b/src/Compiler/Infer/Transforms/LoopReversalTransform.cs
@@ -36,8 +36,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         internal static bool debug;
         private LoopMergingInfo loopMergingInfo;
-        private Set<IVariableDeclaration> loopVarsToReverse = new Set<IVariableDeclaration>();
-        private Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+        private readonly Set<IVariableDeclaration> loopVarsToReverse = new Set<IVariableDeclaration>();
+        private readonly Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
         private Dictionary<IStatement, Set<IVariableDeclaration>> loopVarsToReverseInStatement;
         IBlockStatement debugBlock;
 
@@ -191,7 +191,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
     /// </summary>
     internal class LoopReversalAnalysisTransform : ShallowCopyTransform
     {
-        private bool debug;
+        private readonly bool debug;
 
         public LoopReversalAnalysisTransform(bool debug)
         {
@@ -318,7 +318,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                             continue;
                         NodeIndex source = node;
                         List<IStatement> containersOfSource = containersOfNode[source];
-                        bool hasLoopVar = containersOfSource.Any(container => container is IForStatement && Recognizer.LoopVariable((IForStatement)container) == loopVar);
+                        bool hasLoopVar = containersOfSource.Any(container => container is IForStatement ifs && Recognizer.LoopVariable(ifs) == loopVar);
                         if (!hasLoopVar) continue;
                         nodesOfInterest.Add(node);
                         IStatement sourceSt = nodes[source];
@@ -453,12 +453,10 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         {
             for (int i = 0; i < System.Math.Min(containersOfTarget.Count, containersOfSource.Count); i++)
             {
-                if (containersOfTarget[i] is IForStatement)
+                if (containersOfTarget[i] is IForStatement afs)
                 {
-                    if (!(containersOfSource[i] is IForStatement))
+                    if (!(containersOfSource[i] is IForStatement bfs))
                         break;
-                    IForStatement afs = (IForStatement)containersOfTarget[i];
-                    IForStatement bfs = (IForStatement)containersOfSource[i];
                     IVariableDeclaration loopVar = Recognizer.LoopVariable(afs);
                     if (Recognizer.LoopVariable(bfs) != loopVar)
                         break;

--- a/src/Compiler/Infer/Transforms/LoopReversalTransform.cs
+++ b/src/Compiler/Infer/Transforms/LoopReversalTransform.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         internal static bool debug;
         private LoopMergingInfo loopMergingInfo;
         private readonly Set<IVariableDeclaration> loopVarsToReverse = new Set<IVariableDeclaration>();
-        private readonly Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+        private readonly Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
         private Dictionary<IStatement, Set<IVariableDeclaration>> loopVarsToReverseInStatement;
         IBlockStatement debugBlock;
 
@@ -210,7 +210,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             }
         }
 
-        public Dictionary<IStatement, Set<IVariableDeclaration>> loopVarsToReverseInStatement = new Dictionary<IStatement, Set<IVariableDeclaration>>(new IdentityComparer<IStatement>());
+        public Dictionary<IStatement, Set<IVariableDeclaration>> loopVarsToReverseInStatement = new Dictionary<IStatement, Set<IVariableDeclaration>>(ReferenceEqualityComparer<IStatement>.Instance);
 
         public List<string> log = new List<string>();
 

--- a/src/Compiler/Infer/Transforms/MessageFcnInfo.cs
+++ b/src/Compiler/Infer/Transforms/MessageFcnInfo.cs
@@ -1,0 +1,238 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+namespace Microsoft.ML.Probabilistic.Compiler.Transforms
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using Microsoft.ML.Probabilistic.Utilities;
+    using Microsoft.ML.Probabilistic.Compiler.Attributes;
+    using Microsoft.ML.Probabilistic.Factors.Attributes;
+    using Microsoft.ML.Probabilistic.Compiler;
+    using System.Linq;
+
+    /// <summary>
+    /// Records information about the operator method 
+    /// </summary>
+    internal class MessageFcnInfo : ICompilerAttribute
+    {
+        public readonly MethodInfo Method;
+
+        /// <summary>
+        /// The name of the factor edge being computed.
+        /// </summary>
+        public string TargetParameter;
+
+        public string Suffix;
+
+        /// <summary>
+        /// True if the method has a result parameter
+        /// </summary>
+        public bool PassResult
+        {
+            get { return (ResultParameterIndex != -1); }
+        }
+
+        /// <summary>
+        /// True if the method has a resultIndex parameter
+        /// </summary>
+        public bool PassResultIndex
+        {
+            get { return (ResultIndexParameterIndex != -1); }
+        }
+
+        /// <summary>
+        /// True if the message function performs sampling.
+        /// </summary>
+        public readonly bool IsStochastic;
+
+        public IReadOnlyList<FactorEdge> Dependencies, Requirements, Triggers;
+
+        /// <summary>
+        /// Includes all parameters, including buffers, result, and resultIndex.
+        /// </summary>
+        public readonly IReadOnlyDictionary<string, FactorEdge> factorEdgeOfParameter;
+
+        public DependencyInformation DependencyInfo;
+
+        /// <summary>
+        /// Indicates whether to skip the message if all arguments are uniform.
+        /// </summary>
+        /// <remarks>
+        /// Only meaningful if Requirements.Count == 0.
+        /// </remarks>
+        public bool SkipIfAllUniform;
+
+        /// <summary>
+        /// Indicates whether the method has AllTriggersAttribute.
+        /// </summary>
+        public readonly bool AllTriggers;
+
+        /// <summary>
+        /// Indicates whether the method has NoTriggersAttribute.
+        /// </summary>
+        public bool NoTriggers;
+
+        /// <summary>
+        /// If the message is not supported, provides the explanation.
+        /// </summary>
+        /// <remarks>
+        /// Will be null if the message is supported.
+        /// </remarks>
+        public readonly string NotSupportedMessage;
+
+        /// <summary>
+        /// True if the function returns the product of all arguments.
+        /// </summary>
+        public readonly bool IsMultiplyAll;
+
+        /// <summary>
+        /// Index of the IsReturned parameter, or -1 if none.
+        /// </summary>
+        public readonly int ReturnedParameterIndex = -1;
+
+        /// <summary>
+        /// Index of the IsReturnedInAllElements parameter, or -1 if none.
+        /// </summary>
+        public readonly int ReturnedInAllElementsParameterIndex = -1;
+
+        /// <summary>
+        /// Index of the result parameter, or -1 if none.
+        /// </summary>
+        public readonly int ResultParameterIndex = -1;
+
+        /// <summary>
+        /// Index of the resultIndex parameter, or -1 if none.
+        /// </summary>
+        public readonly int ResultIndexParameterIndex = -1;
+
+        /// <summary>
+        /// True if the parameter has IndexedAttribute.  Array may be null if no parameters have the attribute.
+        /// </summary>
+        public readonly bool[] IsIndexedParameter;
+
+        public MessageFcnInfo(MethodInfo method, IReadOnlyCollection<ParameterInfo> parameters, IReadOnlyDictionary<string, FactorEdge> factorEdgeOfParameter = null)
+        {
+            this.Method = method;
+            this.factorEdgeOfParameter = factorEdgeOfParameter;
+            int parameterIndex = 0;
+            foreach (ParameterInfo parameter in parameters)
+            {
+                if (parameter.Name == "result" || parameter.Name == "Result")
+                {
+                    if (ResultParameterIndex != -1) throw new Exception("Only one parameter of a method can be the result");
+                    ResultParameterIndex = parameterIndex;
+                }
+                else if (parameter.Name == "resultIndex" || parameter.Name == "ResultIndex")
+                {
+                    if (ResultIndexParameterIndex != -1) throw new Exception("Only one parameter of a method can be the resultIndex");
+                    ResultIndexParameterIndex = parameterIndex;
+                }
+                else if (parameter.IsDefined(typeof(IsReturnedAttribute), false))
+                {
+                    if (ReturnedParameterIndex != -1) throw new Exception("IsReturnedAttribute can only be attached to one parameter of a method");
+                    // MessageTransform must not replace this method if it has a NoInit attribute.
+                    if (!parameter.IsDefined(typeof(NoInitAttribute), false) && !parameter.IsDefined(typeof(DiodeAttribute), false))
+                        ReturnedParameterIndex = parameterIndex;
+                }
+                else if (parameter.IsDefined(typeof(IsReturnedInEveryElementAttribute), false))
+                {
+                    if (ReturnedInAllElementsParameterIndex != -1) throw new Exception("IsReturnedInAllElementsAttribute can only be attached to one parameter of a method");
+                    ReturnedInAllElementsParameterIndex = parameterIndex;
+                }
+                if (parameter.IsDefined(typeof(IndexedAttribute), false))
+                {
+                    if (IsIndexedParameter == null) IsIndexedParameter = new bool[parameters.Count];
+                    IsIndexedParameter[parameterIndex] = true;
+                }
+                parameterIndex++;
+            }
+            AllTriggers = Method.IsDefined(typeof(AllTriggersAttribute), false);
+            IsMultiplyAll = Method.IsDefined(typeof(MultiplyAllAttribute), false);
+            IsStochastic = Method.IsDefined(typeof(Stochastic), false);
+            object[] attrs = Method.GetCustomAttributes(typeof(NotSupportedAttribute), false);
+            if (attrs.Length > 0)
+            {
+                NotSupportedMessage = ((NotSupportedAttribute)attrs[0]).Message;
+            }
+        }
+
+        /// <summary>
+        /// Copy constructor.
+        /// </summary>
+        /// <param name="that"></param>
+        public MessageFcnInfo(MessageFcnInfo that)
+        {
+            Method = that.Method;
+            TargetParameter = that.TargetParameter;
+            Suffix = that.Suffix;
+            IsStochastic = that.IsStochastic;
+            Dependencies = that.Dependencies;
+            Requirements = that.Requirements;
+            Triggers = that.Triggers;
+            SkipIfAllUniform = that.SkipIfAllUniform;
+            NotSupportedMessage = that.NotSupportedMessage;
+            factorEdgeOfParameter = that.factorEdgeOfParameter;
+            DependencyInfo = that.DependencyInfo;
+            IsMultiplyAll = that.IsMultiplyAll;
+            ReturnedParameterIndex = that.ReturnedParameterIndex;
+            ReturnedInAllElementsParameterIndex = that.ReturnedInAllElementsParameterIndex;
+            ResultParameterIndex = that.ResultParameterIndex;
+            ResultIndexParameterIndex = that.ResultIndexParameterIndex;
+        }
+
+        /// <summary>
+        /// Get the field names and types of message function parameters.
+        /// </summary>
+        /// <returns>A list of (field name, parameter type) in the same order as the parameters of the function.</returns>
+        /// <remarks>
+        /// The field names are not necessarily the same as the parameter names of the method.
+        /// The field names are a subset of the entries in the FactorInfo of the factor.
+        /// Additionally, a parameter may have the special field name "result" or "resultIndex".
+        /// </remarks>
+        public List<KeyValuePair<string, Type>> GetParameterTypes()
+        {
+            List<KeyValuePair<string, Type>> result = new List<KeyValuePair<string, Type>>();
+            ParameterInfo[] parameters = Method.GetParameters();
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                ParameterInfo parameter = parameters[i];
+                if (factorEdgeOfParameter.ContainsKey(parameter.Name))
+                {
+                    result.Add(new KeyValuePair<string, Type>(factorEdgeOfParameter[parameter.Name].ToString(), parameter.ParameterType));
+                }
+                else
+                {
+                    result.Add(new KeyValuePair<string, Type>(FactorManager.Uncapitalize(parameter.Name), parameter.ParameterType));
+                }
+            }
+            return result;
+        }
+
+        public override string ToString()
+        {
+            System.Text.StringBuilder s = new System.Text.StringBuilder(StringUtil.MethodSignatureToString(Method));
+            s.AppendLine();
+            if (TargetParameter != null)
+            {
+                s.Append("  target: ");
+                s.Append(TargetParameter);
+                s.AppendLine();
+            }
+            if (Suffix != null)
+            {
+                s.Append("  suffix: ");
+                s.AppendLine(Suffix);
+            }
+            s.AppendLine(DependencyInfo.ToString());
+            return s.ToString();
+        }
+    }
+
+#if SUPPRESS_XMLDOC_WARNINGS
+#pragma warning restore 1591
+#endif
+}

--- a/src/Compiler/Infer/Transforms/MessageTransform.cs
+++ b/src/Compiler/Infer/Transforms/MessageTransform.cs
@@ -73,12 +73,12 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         /// <summary>
         /// The set of variables that have at least one definition with a non-unit derivative
         /// </summary>
-        protected Set<IVariableDeclaration> hasNonUnitDerivative = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+        protected Set<IVariableDeclaration> hasNonUnitDerivative = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
 
         protected Dictionary<IExpression, Type> initialiserType = new Dictionary<IExpression, Type>();
 
         protected Dictionary<IVariableDeclaration, IVariableDeclaration> derivOfVariable =
-            new Dictionary<IVariableDeclaration, IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+            new Dictionary<IVariableDeclaration, IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
 
         private static readonly MessageDirection[] directions = { MessageDirection.Forwards, MessageDirection.Backwards };
 

--- a/src/Compiler/Infer/Transforms/PruningTransform.cs
+++ b/src/Compiler/Infer/Transforms/PruningTransform.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             if (PruneUniformStmts)
             {
                 // When statements are pruned from the code, they must also be pruned from the DependencyInformation attributes of all other statements that might refer to them.
-                Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+                Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
                 foreach (NodeIndex targetIndex in g.dependencyGraph.Nodes)
                 {
                     if (g.isUniform[targetIndex])

--- a/src/Compiler/Infer/Transforms/ReplicationTransform.cs
+++ b/src/Compiler/Infer/Transforms/ReplicationTransform.cs
@@ -342,8 +342,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 }
                 // split expr into a target and extra indices, where target will be replicated and extra indices will be added later
                 var extraIndices = new List<IEnumerable<IExpression>>();
-                IExpression exprToReplicate;
-                AddUnreplicatedIndices(rlc.loops[currentLoop], expr, extraIndices, out exprToReplicate);
+                AddUnreplicatedIndices(rlc.loops[currentLoop], expr, extraIndices, out IExpression exprToReplicate);
 
                 VariableInformation varInfo = VariableInformation.GetVariableInformation(context, baseVar);
                 IExpression loopSize = Recognizer.LoopSizeExpression(loop);

--- a/src/Compiler/Infer/Transforms/SchedulingTransform.cs
+++ b/src/Compiler/Infer/Transforms/SchedulingTransform.cs
@@ -48,8 +48,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         private ModelCompiler compiler;
         private int whileDepth;
         private List<IList<IStatement>> initStmtsOfWhile = new List<IList<IStatement>>();
-        private Set<IStatement> topLevelWhileStmts = new Set<IStatement>(new IdentityComparer<IStatement>());
-        private Dictionary<IWhileStatement, IWhileStatement> convertedWhiles = new Dictionary<IWhileStatement, IWhileStatement>(new IdentityComparer<IWhileStatement>());
+        private Set<IStatement> topLevelWhileStmts = new Set<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
+        private Dictionary<IWhileStatement, IWhileStatement> convertedWhiles = new Dictionary<IWhileStatement, IWhileStatement>(ReferenceEqualityComparer<IWhileStatement>.Instance);
         private List<IStatement> statementsToFinalize = new List<IStatement>();
         private Dictionary<NodeIndex, NodeIndex> groupOf;
         private Dictionary<NodeIndex, SerialLoopInfo> loopInfoOfGroup;
@@ -378,7 +378,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 // It starts by constructing a dependency graph where inner while loops are single nodes.
                 // Then it recursively tests for cycles, constructing a schedule in the process.
                 // If there are no cycles, then the constructed schedule is returned.
-                Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+                Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
                 // if a DependencyInformation refers to an inner statement of a block, make it refer to the block instead
                 foreach (IStatement stmt in inputStmts)
                 {
@@ -759,7 +759,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 NodeIndex target = g.dependencyGraph.TargetOf(edge);
                 Set<NodeIndex> sourceGroups = new Set<NodeIndex>();
                 ForEachGroupOf(source, group => sourceGroups.Add(group));
-                Set<IVariableDeclaration> commonLoopVars = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+                Set<IVariableDeclaration> commonLoopVars = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
                 ForEachGroupOf(target, group =>
                 {
                     if (sourceGroups.Contains(group))
@@ -1088,7 +1088,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
     internal class LoopAnalysisTransform : ShallowCopyTransform
     {
         HashSet<IVariableDeclaration> loopVars;
-        public Dictionary<IStatement, HashSet<IVariableDeclaration>> loopVarsOfStatement = new Dictionary<IStatement, HashSet<IVariableDeclaration>>(new IdentityComparer<IStatement>());
+        public Dictionary<IStatement, HashSet<IVariableDeclaration>> loopVarsOfStatement = new Dictionary<IStatement, HashSet<IVariableDeclaration>>(ReferenceEqualityComparer<IStatement>.Instance);
 
         protected override IStatement ConvertWhile(IWhileStatement iws)
         {

--- a/src/Compiler/Infer/Transforms/ShallowCopyTransform.cs
+++ b/src/Compiler/Infer/Transforms/ShallowCopyTransform.cs
@@ -186,11 +186,11 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         protected virtual IMethodDeclaration ConvertMethod(IMethodDeclaration imd)
         {
             context.OpenMember(imd);
-            if (imd is IConstructorDeclaration)
+            if (imd is IConstructorDeclaration icd)
             {
                 IConstructorDeclaration cd = Builder.ConstructorDecl();
                 context.SetPrimaryOutput(cd);
-                IMethodDeclaration cd2 = DoConvertConstructor(cd, (IConstructorDeclaration)imd);
+                IMethodDeclaration cd2 = DoConvertConstructor(cd, icd);
                 context.CloseMember(imd);
                 if (cd2 != null) context.InputAttributes.CopyObjectAttributesTo(imd, context.OutputAttributes, cd2);
                 return cd2;
@@ -504,57 +504,57 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         protected virtual IStatement DoConvertStatement(IStatement ist)
         {
-            if (ist is IBlockStatement)
+            if (ist is IBlockStatement ibs)
             {
-                return ConvertBlockAlreadyOpen((IBlockStatement)ist);
+                return ConvertBlockAlreadyOpen(ibs);
             }
-            else if (ist is IExpressionStatement)
+            else if (ist is IExpressionStatement ies)
             {
-                return ConvertExpressionStatement((IExpressionStatement)ist);
+                return ConvertExpressionStatement(ies);
             }
-            else if (ist is IMethodReturnStatement)
+            else if (ist is IMethodReturnStatement imrs)
             {
-                return ConvertReturnStatement((IMethodReturnStatement)ist);
+                return ConvertReturnStatement(imrs);
             }
-            else if (ist is IConditionStatement)
+            else if (ist is IConditionStatement ics)
             {
-                return ConvertCondition((IConditionStatement)ist);
+                return ConvertCondition(ics);
             }
-            else if (ist is IForStatement)
+            else if (ist is IForStatement ifs)
             {
-                return ConvertFor((IForStatement)ist);
+                return ConvertFor(ifs);
             }
-            else if (ist is IRepeatStatement)
+            else if (ist is IRepeatStatement irs)
             {
-                return ConvertRepeat((IRepeatStatement)ist);
+                return ConvertRepeat(irs);
             }
-            else if (ist is IWhileStatement)
+            else if (ist is IWhileStatement iws)
             {
-                return ConvertWhile((IWhileStatement)ist);
+                return ConvertWhile(iws);
             }
-            else if (ist is IForEachStatement)
+            else if (ist is IForEachStatement ifes)
             {
-                return ConvertForEach((IForEachStatement)ist);
+                return ConvertForEach(ifes);
             }
-            else if (ist is IUsingStatement)
+            else if (ist is IUsingStatement ius)
             {
-                return ConvertUsing((IUsingStatement)ist);
+                return ConvertUsing(ius);
             }
-            else if (ist is ICommentStatement)
+            else if (ist is ICommentStatement icms)
             {
-                return ConvertComment((ICommentStatement)ist);
+                return ConvertComment(icms);
             }
-            else if (ist is ISwitchStatement)
+            else if (ist is ISwitchStatement iss)
             {
-                return ConvertSwitch((ISwitchStatement)ist);
+                return ConvertSwitch(iss);
             }
-            else if (ist is IBreakStatement)
+            else if (ist is IBreakStatement ibrs)
             {
-                return ConvertBreak((IBreakStatement)ist);
+                return ConvertBreak(ibrs);
             }
-            else if (ist is IThrowExceptionStatement)
+            else if (ist is IThrowExceptionStatement ites)
             {
-                return ConvertThrow((IThrowExceptionStatement)ist);
+                return ConvertThrow(ites);
             }
             else throw new Exception("Unhandled statement: " + ist.GetType());
         }
@@ -584,10 +584,10 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         protected virtual void ConvertSwitchCase(IList<ISwitchCase> cases, ISwitchCase isc)
         {
             ISwitchCase isc2;
-            if (isc is IConditionCase)
+            if (isc is IConditionCase icc)
             {
                 IConditionCase cc = Builder.CondCase();
-                cc.Condition = ConvertExpression(((IConditionCase)isc).Condition);
+                cc.Condition = ConvertExpression(icc.Condition);
                 isc2 = cc;
             }
             else
@@ -645,49 +645,49 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         protected virtual IExpression DoConvertExpression(IExpression expr)
         {
-            if (expr is IAssignExpression) return ConvertAssign((IAssignExpression)expr);
-            if (expr is IMethodInvokeExpression) return ConvertMethodInvoke((IMethodInvokeExpression)expr);
-            if (expr is IMethodReferenceExpression) return ConvertMethodRefExpr((IMethodReferenceExpression)expr);
-            if (expr is IUnaryExpression) return ConvertUnary((IUnaryExpression)expr);
-            if (expr is ILiteralExpression) return ConvertLiteral((ILiteralExpression)expr);
-            if (expr is IVariableDeclarationExpression) return ConvertVariableDeclExpr((IVariableDeclarationExpression)expr);
-            if (expr is IVariableReferenceExpression) return ConvertVariableRefExpr((IVariableReferenceExpression)expr);
-            if (expr is IArrayIndexerExpression) return ConvertArrayIndexer((IArrayIndexerExpression)expr);
-            if (expr is IArrayCreateExpression) return ConvertArrayCreate((IArrayCreateExpression)expr);
-            if (expr is IArgumentReferenceExpression) return ConvertArgumentRef((IArgumentReferenceExpression)expr);
-            if (expr is IFieldReferenceExpression) return ConvertFieldRefExpr((IFieldReferenceExpression)expr);
-            if (expr is IBinaryExpression) return ConvertBinary((IBinaryExpression)expr);
-            if (expr is IPropertyReferenceExpression) return ConvertPropertyRefExpr((IPropertyReferenceExpression)expr);
-            if (expr is IThisReferenceExpression) return ConvertThis((IThisReferenceExpression)expr);
-            if (expr is IBlockExpression) return ConvertBlockExpr((IBlockExpression)expr);
-            if (expr is IConditionExpression) return ConvertConditionExpr((IConditionExpression)expr);
-            if (expr is ICastExpression) return ConvertCastExpr((ICastExpression)expr);
-            if (expr is ICheckedExpression) return ConvertCheckedExpr((ICheckedExpression)expr);
-            if (expr is IBaseReferenceExpression) return ConvertBaseRef((IBaseReferenceExpression)expr);
-            if (expr is ITypeReferenceExpression)
+            if (expr is IAssignExpression iae) return ConvertAssign(iae);
+            if (expr is IMethodInvokeExpression imie) return ConvertMethodInvoke(imie);
+            if (expr is IMethodReferenceExpression imre) return ConvertMethodRefExpr(imre);
+            if (expr is IUnaryExpression iue) return ConvertUnary(iue);
+            if (expr is ILiteralExpression ile) return ConvertLiteral(ile);
+            if (expr is IVariableDeclarationExpression ivde) return ConvertVariableDeclExpr(ivde);
+            if (expr is IVariableReferenceExpression ivre) return ConvertVariableRefExpr(ivre);
+            if (expr is IArrayIndexerExpression iaie) return ConvertArrayIndexer(iaie);
+            if (expr is IArrayCreateExpression iace) return ConvertArrayCreate(iace);
+            if (expr is IArgumentReferenceExpression iare) return ConvertArgumentRef(iare);
+            if (expr is IFieldReferenceExpression ifre) return ConvertFieldRefExpr(ifre);
+            if (expr is IBinaryExpression ibe) return ConvertBinary(ibe);
+            if (expr is IPropertyReferenceExpression ipre) return ConvertPropertyRefExpr(ipre);
+            if (expr is IThisReferenceExpression ithis) return ConvertThis(ithis);
+            if (expr is IBlockExpression ible) return ConvertBlockExpr(ible);
+            if (expr is IConditionExpression ice) return ConvertConditionExpr(ice);
+            if (expr is ICastExpression icaste) return ConvertCastExpr(icaste);
+            if (expr is ICheckedExpression iche) return ConvertCheckedExpr(iche);
+            if (expr is IBaseReferenceExpression ibre) return ConvertBaseRef(ibre);
+            if (expr is ITypeReferenceExpression itre)
             {
-                return ConvertTypeRefExpr((ITypeReferenceExpression)expr);
+                return ConvertTypeRefExpr(itre);
             }
-            if (expr is ITypeOfExpression)
+            if (expr is ITypeOfExpression itoe)
             {
-                return ConvertTypeOfExpr((ITypeOfExpression)expr);
+                return ConvertTypeOfExpr(itoe);
             }
-            if (expr is IDelegateCreateExpression)
+            if (expr is IDelegateCreateExpression idce)
             {
-                return ConvertDelegateCreate((IDelegateCreateExpression)expr);
+                return ConvertDelegateCreate(idce);
             }
-            if (expr is IObjectCreateExpression)
+            if (expr is IObjectCreateExpression ioce)
             {
-                return ConvertObjectCreate((IObjectCreateExpression)expr);
+                return ConvertObjectCreate(ioce);
             }
-            if (expr is IPropertyIndexerExpression) return ConvertPropertyIndexerExpr((IPropertyIndexerExpression)expr);
-            if (expr is IAddressDereferenceExpression) return ConvertAddressDereference((IAddressDereferenceExpression)expr);
-            if (expr is IAddressOutExpression) return ConvertAddressOut((IAddressOutExpression)expr);
-            if (expr is IAnonymousMethodExpression) return ConvertAnonymousMethodExpression((IAnonymousMethodExpression)expr);
-            if (expr is IDefaultExpression) return ConvertDefaultExpr((IDefaultExpression)expr);
-            if (expr is IEventReferenceExpression) return ConvertEventRefExpr((IEventReferenceExpression)expr);
-            if (expr is IDelegateInvokeExpression) return ConvertDelegateInvoke((IDelegateInvokeExpression)expr);
-            if (expr is ILambdaExpression) return ConvertLambda((ILambdaExpression)expr);
+            if (expr is IPropertyIndexerExpression ipie) return ConvertPropertyIndexerExpr(ipie);
+            if (expr is IAddressDereferenceExpression iade) return ConvertAddressDereference(iade);
+            if (expr is IAddressOutExpression iaoe) return ConvertAddressOut(iaoe);
+            if (expr is IAnonymousMethodExpression iame) return ConvertAnonymousMethodExpression(iame);
+            if (expr is IDefaultExpression ide) return ConvertDefaultExpr(ide);
+            if (expr is IEventReferenceExpression iere) return ConvertEventRefExpr(iere);
+            if (expr is IDelegateInvokeExpression idie) return ConvertDelegateInvoke(idie);
+            if (expr is ILambdaExpression lambda) return ConvertLambda(lambda);
             if (expr == null) Error("expression is null");
             else Error("Unhandled expression: " + expr + " " + expr.GetType().Name);
             return expr;
@@ -695,7 +695,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         private IExpression ConvertLambda(ILambdaExpression iLambdaExpression)
         {
-            ILambdaExpression ile = new Microsoft.ML.Probabilistic.Compiler.CodeModel.Concrete.XLambdaExpression();
+            ILambdaExpression ile = new CodeModel.Concrete.XLambdaExpression();
             ile.Body = ConvertExpression(iLambdaExpression.Body);
             foreach (var ivd in iLambdaExpression.Parameters)
             {
@@ -859,7 +859,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         protected virtual IExpression ConvertDefaultExpr(IDefaultExpression ide)
         {
-            if (ide.Type is ITypeReference) ConvertTypeReference((ITypeReference)ide.Type);
+            if (ide.Type is ITypeReference itr) ConvertTypeReference(itr);
             return ide;
         }
 
@@ -1108,7 +1108,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 }
                 count++;
             }
-            return (newExprs == null) ? exprColl : newExprs;
+            return newExprs ?? exprColl;
         }
 
         protected virtual IExpression ConvertMethodInvoke(IMethodInvokeExpression imie)

--- a/src/Compiler/Infer/Transforms/StocAnalysisTransform.cs
+++ b/src/Compiler/Infer/Transforms/StocAnalysisTransform.cs
@@ -35,8 +35,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             get { return "StocAnalysisTransform"; }
         }
 
-        private Set<IVariableDeclaration> varsWithConstantDefinition = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
-        private Dictionary<IVariableDeclaration, int> stochasticConditionsOf = new Dictionary<IVariableDeclaration, int>(new IdentityComparer<IVariableDeclaration>());
+        private Set<IVariableDeclaration> varsWithConstantDefinition = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
+        private Dictionary<IVariableDeclaration, int> stochasticConditionsOf = new Dictionary<IVariableDeclaration, int>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
         private int numberOfStochasticConditions;
         private bool convertConstants;
         // for DistributionAnalysis

--- a/src/Compiler/Infer/Transforms/UniquenessTransform.cs
+++ b/src/Compiler/Infer/Transforms/UniquenessTransform.cs
@@ -33,10 +33,10 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         bool isInnerStatement;
         private LoopMergingInfo loopMergingInfo;
-        Set<IStatement> previousStatements = new Set<IStatement>(new IdentityComparer<IStatement>());
-        Dictionary<IStatement, IStatement> originalStatementOfClone = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
-        Dictionary<IStatement, IEnumerable<IStatement>> clonesOfStatement = new Dictionary<IStatement, IEnumerable<IStatement>>(new IdentityComparer<IStatement>());
-        Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(new IdentityComparer<IStatement>());
+        Set<IStatement> previousStatements = new Set<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
+        Dictionary<IStatement, IStatement> originalStatementOfClone = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
+        Dictionary<IStatement, IEnumerable<IStatement>> clonesOfStatement = new Dictionary<IStatement, IEnumerable<IStatement>>(ReferenceEqualityComparer<IStatement>.Instance);
+        Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
         int whileCount;
 
         protected override IMethodDeclaration DoConvertMethod(IMethodDeclaration md, IMethodDeclaration imd)
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         /// <param name="outputs"></param>
         private void PostProcessDependencies(ICollection<IStatement> outputs)
         {
-            Dictionary<IStatement, int> indexOfStatement = new Dictionary<IStatement, NodeIndex>(new IdentityComparer<IStatement>());
+            Dictionary<IStatement, int> indexOfStatement = new Dictionary<IStatement, NodeIndex>(ReferenceEqualityComparer<IStatement>.Instance);
             if (clonesOfStatement.Count == 0) return;
             DeadCodeTransform.ForEachStatement(outputs,
                 _ => { },

--- a/src/Compiler/Infer/Transforms/VariableTransform.cs
+++ b/src/Compiler/Infer/Transforms/VariableTransform.cs
@@ -32,17 +32,17 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         /// <summary>
         /// All variables that have been assigned to so far
         /// </summary>
-        private Set<IVariableDeclaration> variablesAssigned = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+        private Set<IVariableDeclaration> variablesAssigned = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
 
-        private Set<IVariableDeclaration> variablesLackingVariableFactor = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+        private Set<IVariableDeclaration> variablesLackingVariableFactor = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
 
         private Set<IExpression> targetsOfCurrentAssignment;
 
         private Dictionary<object, IVariableDeclaration> useOfVariable =
-            new Dictionary<object, IVariableDeclaration>(new IdentityComparer<object>());
+            new Dictionary<object, IVariableDeclaration>(ReferenceEqualityComparer<object>.Instance);
 
         private Dictionary<object, IVariableDeclaration> marginalOfVariable =
-            new Dictionary<object, IVariableDeclaration>(new IdentityComparer<object>());
+            new Dictionary<object, IVariableDeclaration>(ReferenceEqualityComparer<object>.Instance);
 
         private IAlgorithm algorithmDefault;
         private VariableAnalysisTransform analysis;
@@ -81,7 +81,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         protected override IExpression ConvertAssign(IAssignExpression iae)
         {
             var oldTargets = targetsOfCurrentAssignment;
-            targetsOfCurrentAssignment = new Set<IExpression>(new IdentityComparer<IExpression>());
+            targetsOfCurrentAssignment = new Set<IExpression>(ReferenceEqualityComparer<IExpression>.Instance);
             iae = (IAssignExpression)base.ConvertAssign(iae);
             targetsOfCurrentAssignment.Add(iae.Target);
             IExpression rhs = iae.Expression;
@@ -435,7 +435,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
     /// </summary>
     internal class VariableAnalysisTransform : ShallowCopyTransform
     {
-        public Set<IVariableDeclaration> variablesExcludingVariableFactor = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+        public Set<IVariableDeclaration> variablesExcludingVariableFactor = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
         bool useJaggedSubarrayWithMarginal;
 
         public override string Name

--- a/src/Compiler/Infer/Visualizers/Default/GraphViews/ModelView.cs
+++ b/src/Compiler/Infer/Visualizers/Default/GraphViews/ModelView.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Visualizers.GraphViews
         private Group GroupInstance = new Group();
         private int Count = 0;
         private Set<Node> childNodes = new Set<Node>();
-        private Dictionary<IModelExpression, Node> nodeOfExpr = new Dictionary<IModelExpression, Node>(new IdentityComparer<IModelExpression>());
+        private Dictionary<IModelExpression, Node> nodeOfExpr = new Dictionary<IModelExpression, Node>(ReferenceEqualityComparer<IModelExpression>.Instance);
         // condition variables that have already been linked to an expression
         private Dictionary<IModelExpression, List<Variable>> conditionVariables = new Dictionary<IModelExpression, List<Variable>>();
         private Dictionary<ConditionContext, Node> nodeOfContext = new Dictionary<ConditionContext, Node>();

--- a/src/Compiler/Infer/Visualizers/Default/GraphViews/TaskGraphView.cs
+++ b/src/Compiler/Infer/Visualizers/Default/GraphViews/TaskGraphView.cs
@@ -76,7 +76,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Visualizers.GraphViews
             }
             foreach (IStatement ist in looptasks) AddNode(g, ist, Stage.Update);
             foreach (IStatement ist in pretasks) AddEdges(g, ist, Stage.Initialisation);
-            Set<IStatement> edgesDone = new Set<IStatement>(new IdentityComparer<IStatement>());
+            Set<IStatement> edgesDone = new Set<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
             foreach (IStatement ist in looptasks)
             {
                 if (edgesDone.Contains(ist)) continue;
@@ -166,7 +166,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Visualizers.GraphViews
 
         protected void SetNodeForStatement(IStatement ist, Stage stg, Node nd)
         {
-            if (!stmtNodeMap.ContainsKey(stg)) stmtNodeMap[stg] = new Dictionary<IStatement, Node>(new IdentityComparer<IStatement>());
+            if (!stmtNodeMap.ContainsKey(stg)) stmtNodeMap[stg] = new Dictionary<IStatement, Node>(ReferenceEqualityComparer<IStatement>.Instance);
             stmtNodeMap[stg][ist] = nd;
         }
 

--- a/src/Compiler/TransformFramework/AttributeRegistry.cs
+++ b/src/Compiler/TransformFramework/AttributeRegistry.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
 using Microsoft.ML.Probabilistic;
 using Microsoft.ML.Probabilistic.Collections;
 using Microsoft.ML.Probabilistic.Utilities;
@@ -34,7 +36,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
             }
             else
             {
-                registry = new Dictionary<TObject, Set<TAttribute>>(new IdentityComparer<TObject>());
+                registry = new Dictionary<TObject, Set<TAttribute>>(ReferenceEqualityComparer<TObject>.Instance);
             }
         }
 
@@ -43,7 +45,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// </summary>
         protected bool IsIdentityEquality
         {
-            get { return (registry.Comparer is IdentityComparer<TObject>); }
+            get { return (registry.Comparer is ReferenceEqualityComparer<TObject>); }
         }
 
         /*public AttributeRegistry(IEqualityComparer<TObject> comparer)
@@ -324,16 +326,21 @@ namespace Microsoft.ML.Probabilistic.Compiler
         }
     }
 
-    internal class IdentityComparer<T> : EqualityComparer<T>
+    internal class ReferenceEqualityComparer<T> : IEqualityComparer<T>
+        where T : class
     {
-        public override bool Equals(T x, T y)
+        private ReferenceEqualityComparer()
         {
-            return object.ReferenceEquals(x, y);
         }
 
-        public override int GetHashCode(T obj)
-        {
-            return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
-        }
+        public static ReferenceEqualityComparer<T> Instance { get; } = new ReferenceEqualityComparer<T>();
+
+        #region IEqualityComparer<T> Members
+
+        public bool Equals(T x, T y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(T obj) => RuntimeHelpers.GetHashCode(obj);
+
+        #endregion
     }
 }

--- a/src/Compiler/TransformFramework/CodeRecognizer.cs
+++ b/src/Compiler/TransformFramework/CodeRecognizer.cs
@@ -137,12 +137,10 @@ namespace Microsoft.ML.Probabilistic.Compiler
 
         public IMethodReference GetMethodReference(IExpression expr)
         {
-            if (!(expr is IMethodInvokeExpression))
+            if (!(expr is IMethodInvokeExpression mie))
                 return null;
-            IMethodInvokeExpression mie = (IMethodInvokeExpression)expr;
-            if (!(mie.Method is IMethodReferenceExpression))
+            if (!(mie.Method is IMethodReferenceExpression imre))
                 return null;
-            IMethodReferenceExpression imre = (IMethodReferenceExpression)mie.Method;
             return imre.Method;
         }
 
@@ -1496,10 +1494,10 @@ namespace Microsoft.ML.Probabilistic.Compiler
 
         public IExpression StripFieldsAndProperties(IExpression expr)
         {
-            if (expr is IPropertyReferenceExpression)
-                return ((IPropertyReferenceExpression)expr).Target;
-            else if (expr is IFieldReferenceExpression)
-                return ((IFieldReferenceExpression)expr).Target;
+            if (expr is IPropertyReferenceExpression ipre)
+                return ipre.Target;
+            else if (expr is IFieldReferenceExpression ifre)
+                return ifre.Target;
             else
                 return expr;
         }
@@ -1525,8 +1523,8 @@ namespace Microsoft.ML.Probabilistic.Compiler
             {
                 if (arrayExpr.Equals(expr))
                     return true;
-                if (expr is IArrayIndexerExpression)
-                    expr = ((IArrayIndexerExpression)expr).Target;
+                if (expr is IArrayIndexerExpression iaie)
+                    expr = iaie.Target;
                 else
                 {
                     IExpression oldexpr = expr;
@@ -1546,8 +1544,8 @@ namespace Microsoft.ML.Probabilistic.Compiler
         public IParameterDeclaration GetParameterDeclaration(IExpression expr)
         {
             expr = GetTarget(expr);
-            if (expr is IArgumentReferenceExpression)
-                return ((IArgumentReferenceExpression)expr).Parameter.Resolve();
+            if (expr is IArgumentReferenceExpression iare)
+                return iare.Parameter.Resolve();
             else
                 return null;
         }
@@ -1561,8 +1559,8 @@ namespace Microsoft.ML.Probabilistic.Compiler
         public IFieldReference GetFieldReference(IExpression expr)
         {
             expr = GetTarget(expr);
-            if (expr is IFieldReferenceExpression)
-                return ((IFieldReferenceExpression)expr).Field;
+            if (expr is IFieldReferenceExpression ifre)
+                return ifre.Field;
             else
                 return null;
         }
@@ -1576,10 +1574,10 @@ namespace Microsoft.ML.Probabilistic.Compiler
         public IVariableDeclaration GetVariableDeclaration(IExpression expr)
         {
             expr = GetTarget(expr);
-            if (expr is IVariableReferenceExpression)
-                return ((IVariableReferenceExpression)expr).Variable.Resolve();
-            else if (expr is IVariableDeclarationExpression)
-                return ((IVariableDeclarationExpression)expr).Variable;
+            if (expr is IVariableReferenceExpression ivre)
+                return ivre.Variable.Resolve();
+            else if (expr is IVariableDeclarationExpression ivde)
+                return ivde.Variable;
             else
                 return null;
         }
@@ -1604,16 +1602,16 @@ namespace Microsoft.ML.Probabilistic.Compiler
         public object GetArrayDeclaration(IExpression expr)
         {
             expr = StripIndexers(expr);
-            if (expr is IVariableReferenceExpression)
-                return ((IVariableReferenceExpression)expr).Variable.Resolve();
-            else if (expr is IVariableDeclarationExpression)
-                return ((IVariableDeclarationExpression)expr).Variable;
-            else if (expr is IArgumentReferenceExpression)
-                return ((IArgumentReferenceExpression)expr).Parameter.Resolve();
-            else if (expr is IFieldReferenceExpression)
-                return ((IFieldReferenceExpression)expr).Field.Resolve();
-            else if (expr is IPropertyReferenceExpression)
-                return ((IPropertyReferenceExpression)expr).Property.Resolve();
+            if (expr is IVariableReferenceExpression ivre)
+                return ivre.Variable.Resolve();
+            else if (expr is IVariableDeclarationExpression ivde)
+                return ivde.Variable;
+            else if (expr is IArgumentReferenceExpression iare)
+                return iare.Parameter.Resolve();
+            else if (expr is IFieldReferenceExpression ifre)
+                return ifre.Field.Resolve();
+            else if (expr is IPropertyReferenceExpression ipre)
+                return ipre.Property.Resolve();
             else
                 return null;
         }
@@ -1648,34 +1646,34 @@ namespace Microsoft.ML.Probabilistic.Compiler
         private void ForEachPrefix(IExpression expr, Action<IExpression> action)
         {
             // This method must be kept consistent with GetTargets.
-            if (expr is IArrayIndexerExpression)
-                ForEachPrefix(((IArrayIndexerExpression)expr).Target, action);
-            else if (expr is IAddressOutExpression)
-                ForEachPrefix(((IAddressOutExpression)expr).Expression, action);
-            else if (expr is IPropertyReferenceExpression)
-                ForEachPrefix(((IPropertyReferenceExpression)expr).Target, action);
-            else if (expr is IFieldReferenceExpression)
+            if (expr is IArrayIndexerExpression iaie)
+                ForEachPrefix(iaie.Target, action);
+            else if (expr is IAddressOutExpression iaoe)
+                ForEachPrefix(iaoe.Expression, action);
+            else if (expr is IPropertyReferenceExpression ipre)
+                ForEachPrefix(ipre.Target, action);
+            else if (expr is IFieldReferenceExpression ifre)
             {
-                IExpression target = ((IFieldReferenceExpression)expr).Target;
+                IExpression target = ifre.Target;
                 if (!(target is IThisReferenceExpression))
                     ForEachPrefix(target, action);
             }
-            else if (expr is ICastExpression)
-                ForEachPrefix(((ICastExpression)expr).Expression, action);
-            else if (expr is IPropertyIndexerExpression)
-                ForEachPrefix(((IPropertyIndexerExpression)expr).Target, action);
-            else if (expr is IEventReferenceExpression)
-                ForEachPrefix(((IEventReferenceExpression)expr).Target, action);
-            else if (expr is IUnaryExpression)
-                ForEachPrefix(((IUnaryExpression)expr).Expression, action);
-            else if (expr is IAddressReferenceExpression)
-                ForEachPrefix(((IAddressReferenceExpression)expr).Expression, action);
-            else if (expr is IMethodInvokeExpression)
-                ForEachPrefix(((IMethodInvokeExpression)expr).Method, action);
-            else if (expr is IMethodReferenceExpression)
-                ForEachPrefix(((IMethodReferenceExpression)expr).Target, action);
-            else if (expr is IDelegateInvokeExpression)
-                ForEachPrefix(((IDelegateInvokeExpression)expr).Target, action);
+            else if (expr is ICastExpression ice)
+                ForEachPrefix(ice.Expression, action);
+            else if (expr is IPropertyIndexerExpression ipie)
+                ForEachPrefix(ipie.Target, action);
+            else if (expr is IEventReferenceExpression iere)
+                ForEachPrefix(iere.Target, action);
+            else if (expr is IUnaryExpression iue)
+                ForEachPrefix(iue.Expression, action);
+            else if (expr is IAddressReferenceExpression iare)
+                ForEachPrefix(iare.Expression, action);
+            else if (expr is IMethodInvokeExpression imie)
+                ForEachPrefix(imie.Method, action);
+            else if (expr is IMethodReferenceExpression imre)
+                ForEachPrefix(imre.Target, action);
+            else if (expr is IDelegateInvokeExpression idie)
+                ForEachPrefix(idie.Target, action);
             action(expr);
         }
 
@@ -1688,8 +1686,8 @@ namespace Microsoft.ML.Probabilistic.Compiler
         {
             foreach(var decl in GetVariablesAndParameters(expr))
             {
-                if (decl is IVariableDeclaration)
-                    yield return (IVariableDeclaration)decl;
+                if (decl is IVariableDeclaration ivd)
+                    yield return ivd;
             }
         }
 
@@ -1763,8 +1761,8 @@ namespace Microsoft.ML.Probabilistic.Compiler
 
         public IEnumerable<IArgumentReferenceExpression> GetArgumentReferenceExpressions(IExpression expr)
         {
-            if (expr is IArgumentReferenceExpression)
-                yield return (IArgumentReferenceExpression)expr;
+            if (expr is IArgumentReferenceExpression are)
+                yield return are;
             else if (expr is IArrayIndexerExpression iaie)
             {
                 foreach (IExpression index in iaie.Indices)
@@ -1886,16 +1884,14 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns></returns>
         public IVariableDeclaration GetVariableDeclaration(IStatement ist)
         {
-            if (ist is IExpressionStatement)
+            if (ist is IExpressionStatement ies)
             {
-                IExpressionStatement ies = ist as IExpressionStatement;
-                if (ies.Expression is IVariableDeclarationExpression)
-                    return ((IVariableDeclarationExpression)ies.Expression).Variable;
-                else if (ies.Expression is IAssignExpression)
+                if (ies.Expression is IVariableDeclarationExpression ivde)
+                    return ivde.Variable;
+                else if (ies.Expression is IAssignExpression iae)
                 {
-                    IAssignExpression iae = ies.Expression as IAssignExpression;
-                    if (iae.Target is IVariableDeclarationExpression)
-                        return ((IVariableDeclarationExpression)iae.Target).Variable;
+                    if (iae.Target is IVariableDeclarationExpression ivde2)
+                        return ivde2.Variable;
                 }
             }
             return null;
@@ -2123,7 +2119,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 throw new ArgumentException("Loop condition does not have loop variable on the left");
             IExpressionStatement initializer = (IExpressionStatement)loop.Initializer;
             IAssignExpression initAssignExpr = (IAssignExpression)initializer.Expression;
-            IExpression initializationExpression = (IExpression)initAssignExpr.Expression;
+            IExpression initializationExpression = initAssignExpr.Expression;
 
             if (condition.Operator == BinaryOperator.LessThan)
             {
@@ -2168,14 +2164,14 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns></returns>
         public int ForLoopDepth(IStatement ist)
         {
-            if (ist is IForStatement)
+            if (ist is IForStatement ifs)
             {
-                return 1 + ForLoopDepth(((IForStatement)ist).Body);
+                return 1 + ForLoopDepth(ifs.Body);
             }
-            else if (ist is IBlockStatement)
+            else if (ist is IBlockStatement ibs)
             {
                 int maxLoopDepth = 0;
-                foreach (var st in ((IBlockStatement)ist).Statements)
+                foreach (var st in ibs.Statements)
                 {
                     int stDepth = ForLoopDepth(st);
                     if (stDepth > maxLoopDepth)
@@ -2185,9 +2181,9 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 }
                 return maxLoopDepth;
             }
-            else if (ist is IConditionStatement)
+            else if (ist is IConditionStatement ics)
             {
-                return ForLoopDepth(((IConditionStatement)ist).Then);
+                return ForLoopDepth(ics.Then);
             }
             else
             {
@@ -2198,9 +2194,9 @@ namespace Microsoft.ML.Probabilistic.Compiler
 
         public IExpressionStatement FirstExpressionStatement(IStatement ist)
         {
-            if (ist is IForStatement)
+            if (ist is IForStatement ifs)
             {
-                foreach (var st in ((IForStatement)ist).Body.Statements)
+                foreach (var st in ifs.Body.Statements)
                 {
                     if (!(st is ICommentStatement))
                     {
@@ -2208,9 +2204,9 @@ namespace Microsoft.ML.Probabilistic.Compiler
                     }
                 }
             }
-            else if (ist is IConditionStatement)
+            else if (ist is IConditionStatement ics)
             {
-                foreach (var st in ((IConditionStatement)ist).Then.Statements)
+                foreach (var st in ics.Then.Statements)
                 {
                     if (!(st is ICommentStatement))
                     {
@@ -2218,9 +2214,9 @@ namespace Microsoft.ML.Probabilistic.Compiler
                     }
                 }
             }
-            else if (ist is IExpressionStatement)
+            else if (ist is IExpressionStatement ies)
             {
-                return (IExpressionStatement)ist;
+                return ies;
             }
             return null;
             //throw new Exception("Didn't find expression statement");
@@ -2286,8 +2282,8 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 return st;
             }
             if (expr is IArgumentReferenceExpression) return false;
-            if (expr is IPropertyReferenceExpression) return IsStochastic(context, ((IPropertyReferenceExpression)expr).Target);
-            if (expr is IFieldReferenceExpression) return IsStochastic(context, ((IFieldReferenceExpression)expr).Target);
+            if (expr is IPropertyReferenceExpression ipre) return IsStochastic(context, ipre.Target);
+            if (expr is IFieldReferenceExpression ifre) return IsStochastic(context, ifre.Target);
             if (expr is IArrayCreateExpression) return false;
             if (expr is IObjectCreateExpression ioce)
             {
@@ -2312,7 +2308,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 return IsStochastic(context, ipie.Target) || IsAnyStochastic(context, ipie.Indices);
             }
             if (expr is IAddressDereferenceExpression) return false;
-            if (expr is IAddressOutExpression) return IsStochastic(context, ((IAddressOutExpression)expr).Expression);
+            if (expr is IAddressOutExpression iaoe) return IsStochastic(context, iaoe.Expression);
             if (expr is ILambdaExpression) return false; // todo: stochastic case?
             if (expr is IAnonymousMethodExpression) return false;
             if (expr is ITypeOfExpression) return false;

--- a/src/Compiler/TransformFramework/CodeRecognizer.cs
+++ b/src/Compiler/TransformFramework/CodeRecognizer.cs
@@ -589,7 +589,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 // if mutated = array[i][j] and affected = array[i] then j is extra index
                 // but if mutated = array[i][i] and affected = array[i] then i is not an extra index
                 Containers containers = Containers.GetContainersNeededForExpression(context, affected);
-                Set<IVariableDeclaration> loopVars = new Set<IVariableDeclaration>(new IdentityComparer<IVariableDeclaration>());
+                Set<IVariableDeclaration> loopVars = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
                 foreach (IStatement container in containers.inputs)
                 {
                     if (container is IForStatement ifs)
@@ -1410,7 +1410,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
 
         internal Set<ConditionBinding> GetBindings(IStatement stmt)
         {
-            var bounds = new Dictionary<IVariableDeclaration, Bounds>(new IdentityComparer<IVariableDeclaration>());
+            var bounds = new Dictionary<IVariableDeclaration, Bounds>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
             AddLoopBounds(bounds, stmt);
             var bindings = new Set<ConditionBinding>();
             foreach (var entry in bounds)

--- a/src/Compiler/TransformFramework/LanguageWriter.cs
+++ b/src/Compiler/TransformFramework/LanguageWriter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// </summary>
         protected Dictionary<string, string> typeReferenceMap = new Dictionary<string, string>();
 
-        private Set<Assembly> referencedAssemblies = new Set<Assembly>();
+        private readonly Set<Assembly> referencedAssemblies = new Set<Assembly>();
 
         public ICollection<Assembly> ReferencedAssemblies
         {
@@ -600,8 +600,8 @@ namespace Microsoft.ML.Probabilistic.Compiler
         {
             // find the parent Assembly and add a reference to it
             object owner = itr.Owner;
-            while (owner is ITypeReference) owner = ((ITypeReference) owner).Owner;
-            if (owner is Assembly) ReferencedAssemblies.Add((Assembly) owner);
+            while (owner is ITypeReference reference) owner = reference.Owner;
+            if (owner is Assembly assembly) ReferencedAssemblies.Add(assembly);
             else if(owner != null) throw new InferCompilerException("unknown assembly for type reference: " + itr.DotNetType);
         }
 
@@ -807,10 +807,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachBlockStatement(IBlockStatement ibs)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = ibs;
-            sn.StartString = BlockStatementStart(ibs);
-            sn.EndString = BlockStatementEnd(ibs);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = ibs,
+                StartString = BlockStatementStart(ibs),
+                EndString = BlockStatementEnd(ibs)
+            };
             AddChild(sn);
             nodeStack.Push(sn);
             AttachStatements(ibs.Statements);
@@ -825,10 +827,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachBreakStatement(IBreakStatement ibs)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = ibs;
-            sn.StartString = BreakStatementStart(ibs);
-            sn.EndString = BreakStatementEnd(ibs);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = ibs,
+                StartString = BreakStatementStart(ibs),
+                EndString = BreakStatementEnd(ibs)
+            };
             AddChild(sn);
             return sn;
         }
@@ -840,10 +844,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachCommentStatement(ICommentStatement ics)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = ics;
-            sn.StartString = CommentStatementStart(ics);
-            sn.EndString = CommentStatementEnd(ics);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = ics,
+                StartString = CommentStatementStart(ics),
+                EndString = CommentStatementEnd(ics)
+            };
             AddChild(sn);
             return sn;
         }
@@ -886,10 +892,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
 
         public virtual SourceNode AttachContinueStatement(IContinueStatement ics)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = ics;
-            sn.StartString = ContinueStatementStart(ics);
-            sn.EndString = ContinueStatementEnd(ics);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = ics,
+                StartString = ContinueStatementStart(ics),
+                EndString = ContinueStatementEnd(ics)
+            };
             AddChild(sn);
             return sn;
         }
@@ -901,10 +909,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachExpressionStatement(IExpressionStatement ies)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = ies;
-            sn.StartString = ExpressionStatementStart(ies);
-            sn.EndString = ExpressionStatementEnd(ies);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = ies,
+                StartString = ExpressionStatementStart(ies),
+                EndString = ExpressionStatementEnd(ies)
+            };
             AddChild(sn);
             return sn;
         }
@@ -916,10 +926,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachForEachStatement(IForEachStatement ifes)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = ifes;
-            sn.StartString = ForEachStatementStart(ifes);
-            sn.EndString = ForEachStatementEnd(ifes);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = ifes,
+                StartString = ForEachStatementStart(ifes),
+                EndString = ForEachStatementEnd(ifes)
+            };
             AddChild(sn);
             nodeStack.Push(sn);
             currTab++;
@@ -936,10 +948,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachForStatement(IForStatement ifs)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = ifs;
-            sn.StartString = ForStatementStart(ifs);
-            sn.EndString = ForStatementEnd(ifs);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = ifs,
+                StartString = ForStatementStart(ifs),
+                EndString = ForStatementEnd(ifs)
+            };
             AddChild(sn);
             nodeStack.Push(sn);
             currTab++;
@@ -957,10 +971,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachRepeatStatement(IRepeatStatement irs)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = irs;
-            sn.StartString = RepeatStatementStart(irs);
-            sn.EndString = RepeatStatementEnd(irs);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = irs,
+                StartString = RepeatStatementStart(irs),
+                EndString = RepeatStatementEnd(irs)
+            };
             AddChild(sn);
             nodeStack.Push(sn);
             currTab++;
@@ -977,10 +993,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachMethodReturnStatement(IMethodReturnStatement imrs)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = imrs;
-            sn.StartString = MethodReturnStatementStart(imrs);
-            sn.EndString = MethodReturnStatementEnd(imrs);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = imrs,
+                StartString = MethodReturnStatementStart(imrs),
+                EndString = MethodReturnStatementEnd(imrs)
+            };
             AddChild(sn);
             return sn;
         }
@@ -992,10 +1010,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachSwitchStatement(ISwitchStatement iss)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = iss;
-            sn.StartString = SwitchStatementStart(iss);
-            sn.EndString = SwitchStatementEnd(iss);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = iss,
+                StartString = SwitchStatementStart(iss),
+                EndString = SwitchStatementEnd(iss)
+            };
             AddChild(sn);
             nodeStack.Push(sn);
             currTab++;
@@ -1015,10 +1035,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachSwitchCase(ISwitchCase isc)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = isc;
-            sn.StartString = SwitchCaseStart(isc);
-            sn.EndString = SwitchCaseEnd(isc);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = isc,
+                StartString = SwitchCaseStart(isc),
+                EndString = SwitchCaseEnd(isc)
+            };
 
             AddChild(sn);
             nodeStack.Push(sn);
@@ -1037,10 +1059,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachCatchClause(ICatchClause icc)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = icc;
-            sn.StartString = CatchClauseStart(icc);
-            sn.EndString = CatchClauseEnd(icc);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = icc,
+                StartString = CatchClauseStart(icc),
+                EndString = CatchClauseEnd(icc)
+            };
 
             AddChild(sn);
             nodeStack.Push(sn);
@@ -1058,10 +1082,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns></returns>
         public virtual SourceNode AttachThrowExceptionStatement(IThrowExceptionStatement ites)
         {
-            SourceNode sn = new SourceNode();
-            sn.ASTElement = ites;
-            sn.StartString = ThrowExceptionStart(ites);
-            sn.EndString = ThrowExceptionEnd(ites);
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = ites,
+                StartString = ThrowExceptionStart(ites),
+                EndString = ThrowExceptionEnd(ites)
+            };
             AddChild(sn);
             return sn;
         }
@@ -1125,10 +1151,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachUsingStatement(IUsingStatement ius)
         {
-            SourceNode sn = new SourceNode();
-            sn.StartString = UsingStatementStart(ius);
-            sn.EndString = UsingStatementEnd(ius);
-            sn.ASTElement = ius;
+            SourceNode sn = new SourceNode
+            {
+                ASTElement = ius,
+                StartString = UsingStatementStart(ius),
+                EndString = UsingStatementEnd(ius)
+            };
             AddChild(sn);
             nodeStack.Push(sn);
             currTab++;
@@ -1145,10 +1173,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns>source node</returns>
         public virtual SourceNode AttachWhileStatement(IWhileStatement iws)
         {
-            SourceNode sn = new SourceNode();
-            sn.StartString = WhileStatementStart(iws);
-            sn.EndString = WhileStatementEnd(iws);
-            sn.ASTElement = iws;
+            SourceNode sn = new SourceNode
+            {
+                StartString = WhileStatementStart(iws),
+                EndString = WhileStatementEnd(iws),
+                ASTElement = iws
+            };
             AddChild(sn);
             nodeStack.Push(sn);
             currTab++;

--- a/src/Compiler/TransformFramework/TransformResults.cs
+++ b/src/Compiler/TransformFramework/TransformResults.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
     {
         private List<TransformError> errorsAndWarnings = new List<TransformError>();
         public IReadOnlyList<TransformError> ErrorsAndWarnings { get { return errorsAndWarnings.AsReadOnly(); } }
-        protected Dictionary<object, List<TransformError>> errorMap = new Dictionary<object, List<TransformError>>(new IdentityComparer<object>());
+        protected Dictionary<object, List<TransformError>> errorMap = new Dictionary<object, List<TransformError>>(ReferenceEqualityComparer<object>.Instance);
         public int ErrorCount { get; private set; }
         public int WarningCount { get; private set; }
         public ICodeTransform Transform;

--- a/src/Learners/Runners/Evaluator/MetricValueDistributionCollection.cs
+++ b/src/Learners/Runners/Evaluator/MetricValueDistributionCollection.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Runners
         /// <summary>
         /// The mapping from metric names to metric value distributions.
         /// </summary>
-        private readonly IDictionary<string, MetricValueDistribution> metricNameToValueDistribution =
+        private readonly Dictionary<string, MetricValueDistribution> metricNameToValueDistribution =
             new Dictionary<string, MetricValueDistribution>();
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Runners
         /// <returns>A string that represents the current object.</returns>
         public override string ToString()
         {
-            return StringUtil.DictionaryToString(this.metricNameToValueDistribution, " | ");
+            return StringUtil.DictionaryToString<string,MetricValueDistribution>(this.metricNameToValueDistribution, " | ");
         }
     }
 }

--- a/src/Runtime/Core/Utils/StringUtil.cs
+++ b/src/Runtime/Core/Utils/StringUtil.cs
@@ -428,9 +428,9 @@ namespace Microsoft.ML.Probabilistic.Utilities
         public static string ToString(object o)
         {
             if (o == null) return "null";
-            if (o is Type)
+            if (o is Type type1)
             {
-                return TypeToString((Type) o);
+                return TypeToString(type1);
             }
             else
             {
@@ -462,13 +462,13 @@ namespace Microsoft.ML.Probabilistic.Utilities
             // if the object is a dictionary, print it like one.
             // if the object is enumerable, print it like an array.
             // otherwise print its properties.
-            if (o is IDictionary)
+            if (o is IDictionary dictionary)
             {
-                return DictionaryToString((IDictionary) o, Environment.NewLine);
+                return DictionaryToString(dictionary, Environment.NewLine);
             }
-            else if (o is IEnumerable)
+            else if (o is IEnumerable enumerable)
             {
-                return EnumerableToString((IEnumerable) o, Environment.NewLine);
+                return EnumerableToString(enumerable, Environment.NewLine);
             } 
             else if (IsIndexable(o))
             {
@@ -485,7 +485,7 @@ namespace Microsoft.ML.Probabilistic.Utilities
         /// <param name="dict"></param>
         /// <param name="delimiter"></param>
         /// <returns></returns>
-        public static string DictionaryToString<KeyType, ValueType>(IDictionary<KeyType, ValueType> dict, string delimiter)
+        public static string DictionaryToString<KeyType, ValueType>(IEnumerable<KeyValuePair<KeyType, ValueType>> dict, string delimiter)
         {
             StringBuilder s = new StringBuilder();
             int i = 0;
@@ -743,8 +743,7 @@ namespace Microsoft.ML.Probabilistic.Utilities
 
         public static int[] ArrayLowerBounds(Array a)
         {
-            bool allZero;
-            return ArrayLowerBounds(a, out allZero);
+            return ArrayLowerBounds(a, out bool allZero);
         }
 
         public static int[] ArrayLowerBounds(Array a, out bool allZero)
@@ -798,7 +797,7 @@ namespace Microsoft.ML.Probabilistic.Utilities
             int i = 0;
             for (int d = 0; d < strides.Length; d++)
             {
-                i = i + index[d]*strides[d];
+                i += index[d]*strides[d];
             }
             return i;
         }

--- a/src/Runtime/Distributions/Automata/StringAutomaton.cs
+++ b/src/Runtime/Distributions/Automata/StringAutomaton.cs
@@ -217,5 +217,46 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// </summary>
         public void Write(BinaryWriter writer) => 
             Write(writer.Write, writer.Write, c => c.Write(writer.Write, writer.Write));
+
+        /// <summary>
+        /// Determines whether this automaton has cycles or not.
+        /// </summary>
+        public bool HasCycles()
+        {
+            TryDeterminize();
+            return HasCycles(this, new ArrayDictionary<bool>(), Start.Index);
+        }
+
+        /// <summary>
+        /// Recursively walk this automaton to check for cycles.
+        /// </summary>
+        /// <param name="automaton">This automaton.</param>
+        /// <param name="visitedStates">The states visited at this point</param>
+        /// <param name="stateIndex">The index of the next state to process</param>
+        private static bool HasCycles(StringAutomaton automaton, ArrayDictionary<bool> visitedStates, int stateIndex)
+        {
+            if (visitedStates.ContainsKey(stateIndex) && visitedStates[stateIndex])
+            {
+                return true;
+            }
+
+            var currentState = automaton.States[stateIndex];
+            visitedStates[stateIndex] = true;
+            foreach (var transition in currentState.Transitions)
+            {
+                if (transition.Weight.IsZero)
+                {
+                    continue;
+                }
+
+                if (HasCycles(automaton, visitedStates, transition.DestinationStateIndex))
+                {
+                    return true;
+                }
+            }
+
+            visitedStates[stateIndex] = false;
+            return false;
+        }
     }
 }

--- a/src/Runtime/Distributions/Distribution.cs
+++ b/src/Runtime/Distributions/Distribution.cs
@@ -403,7 +403,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         public static T SetTo<T, TValue>(T result, TValue value)
             where T : SettableTo<TValue>
         {
-            if (object.ReferenceEquals(result, null) || result.Equals(default(T))) result = (T)((ICloneable)value).Clone();
+            if (result == null || result.Equals(default(T))) result = (T)((ICloneable)value).Clone();
             else result.SetTo(value);
             return result;
         }
@@ -440,7 +440,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
             where T : SettableToProduct<U>, SettableTo<U>, U, SettableToUniform
         {
             int count = dists.Count;
-            if ((object.ReferenceEquals(result, null) || result.Equals(default(T)))
+            if ((result == null || result.Equals(default(T)))
                 && count > 0) result = (T)((ICloneable)dists[0]).Clone();
             if (count > 1)
             {
@@ -473,7 +473,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
             where T : SettableToProduct<U>, SettableTo<U>, U, SettableToUniform
         {
             int count = dists.Length;
-            if ((object.ReferenceEquals(result, null) || result.Equals(default(T)))
+            if ((result == null || result.Equals(default(T)))
                 && count > 0) result = (T)((ICloneable)dists[0]).Clone();
             if (count > 1)
             {
@@ -598,7 +598,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
             where T : SettableToProduct<U>, SettableTo<U>, SettableToUniform, U
         {
             if (index < 0 || index > count) throw new ArgumentOutOfRangeException(nameof(index));
-            if ((object.ReferenceEquals(result, null) || result.Equals(default(T)))
+            if ((result == null || result.Equals(default(T)))
                 && count > 0) result = (T)((ICloneable)dists[0]).Clone();
             if (count == 0)
             {

--- a/src/Runtime/Distributions/ICanTruncateLeft.cs
+++ b/src/Runtime/Distributions/ICanTruncateLeft.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Distributions
+{
+    using System;
+
+    /// <summary>
+    /// Whether the distribution can be left-truncated.
+    /// </summary>
+    public interface ICanTruncateLeft<TDomain>
+    where TDomain : IComparable<TDomain>
+    {
+        /// <summary>
+        /// Gets the start point of the truncated distribution.
+        /// </summary>
+        /// <returns>The start point.</returns>
+        TDomain GetStartPoint();
+
+        /// <summary>
+        /// Truncates the distribution at the given point.
+        /// </summary>
+        /// <param name="startPoint">All values less than this are guaranteed to have zero probability.</param>
+        void TruncateLeft(TDomain startPoint);
+    }
+}

--- a/src/Runtime/Distributions/ICanTruncateRight.cs
+++ b/src/Runtime/Distributions/ICanTruncateRight.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Distributions
+{
+    using System;
+
+    /// <summary>
+    /// Whether the distribution can be right truncated.
+    /// </summary>
+    public interface ICanTruncateRight<TDomain>
+        where TDomain : IComparable<TDomain>
+    {
+        /// <summary>
+        /// Gets the end point of the truncated distribution.
+        /// </summary>
+        /// <returns>The end point.</returns>
+        TDomain GetEndPoint();
+
+        /// <summary>
+        /// Truncates the distribution at the given point.
+        /// </summary>
+        /// <param name="endPoint">All domain values greater than this are guaranteed to have zero probability.</param>
+        void TruncateRight(TDomain endPoint);
+    }
+}

--- a/src/Runtime/Distributions/LeftTruncatedPoisson.cs
+++ b/src/Runtime/Distributions/LeftTruncatedPoisson.cs
@@ -1,0 +1,863 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Distributions
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    using Microsoft.ML.Probabilistic.Factors.Attributes;
+    using Microsoft.ML.Probabilistic.Math;
+    using Microsoft.ML.Probabilistic.Serialization;
+
+    /// <summary>
+    /// Left-truncated Com-Poisson distribution.
+    /// </summary>
+    [DataContract]
+    [Quality(QualityBand.Experimental)]
+    public class LeftTruncatedPoisson : IDistribution<int>,
+                                        CanGetMean<double>,
+                                        Sampleable<int>,
+                                        SettableToProduct<LeftTruncatedPoisson>,
+                                        SettableToRatio<LeftTruncatedPoisson>,
+                                        SettableToPower<LeftTruncatedPoisson>,
+                                        SettableToWeightedSum<LeftTruncatedPoisson>,
+                                        SettableTo<LeftTruncatedPoisson>,
+                                        SettableTo<Discrete>,
+                                        SettableToPartialUniform<LeftTruncatedPoisson>,
+                                        SettableToPartialUniform<Discrete>,
+                                        CanGetLogAverageOf<LeftTruncatedPoisson>,
+                                        CanGetAverageLog<LeftTruncatedPoisson>,
+                                        CanGetLogNormalizer,
+                                        ICanTruncateLeft<int>
+    {
+        /// <summary>
+        /// Tolerance for numerical calculations.
+        /// </summary>
+        public const double Tolerance = 1e-10;
+
+        /// <summary>
+        /// The non-truncated distribution.
+        /// </summary>
+        [DataMember]
+        private Poisson nonTruncatedDistribution;
+
+        private Lazy<double> logNormalizer;
+        private Lazy<double> meanLogFactorial;
+        private Lazy<double> sumLogFactorial;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeftTruncatedPoisson" /> class.
+        /// </summary>
+        /// <param name="rate">The rate parameter of the underlying CoM-Poisson distribution.</param>
+        /// <param name="precision">The precision parameter of the underlying CoM-Poisson distribution.</param>
+        /// <param name="startPoint">The index of the first non-zero term in the truncated distribution.</param>
+        [Construction("Rate", "Precision", "StartPoint")]
+        public LeftTruncatedPoisson(double rate, double precision, int startPoint)
+            : this(new Poisson(rate, precision), startPoint)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeftTruncatedPoisson" /> class.
+        /// </summary>
+        /// <param name="rate">
+        /// The rate parameter of the underlying Poisson distribution. The precision parameter is assumed to be
+        /// 1.0.
+        /// </param>
+        /// <param name="startPoint">The index of the first non-zero term in the truncated distribution.</param>
+        public LeftTruncatedPoisson(double rate, int startPoint)
+            : this(new Poisson(rate, 1.0), startPoint)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeftTruncatedPoisson" /> class.
+        /// </summary>
+        /// <param name="nonTruncatedDistribution">The non-truncated CoM-Poisson distribution.</param>
+        /// <param name="startPoint">The index of the first non-zero term in the truncated distribution.</param>
+        public LeftTruncatedPoisson(Poisson nonTruncatedDistribution, int startPoint)
+        {
+            this.nonTruncatedDistribution = nonTruncatedDistribution;
+            this.StartPoint = nonTruncatedDistribution.IsPointMass ? nonTruncatedDistribution.Point : startPoint;
+            this.ResetCache();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeftTruncatedPoisson" /> class.
+        /// </summary>
+        public LeftTruncatedPoisson()
+        {
+            this.SetToUniform();
+        }
+
+        /// <summary>
+        /// The first non-zero point.
+        /// </summary>
+        [DataMember]
+        public int StartPoint { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the rate parameter of the COM-Poisson distribution, always >= 0.
+        /// </summary>
+        public double Rate
+        {
+            get => this.nonTruncatedDistribution.Rate;
+
+            set
+            {
+                this.nonTruncatedDistribution.Rate = value;
+                this.ResetCache();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the precision parameter of the COM-Poisson distribution
+        /// </summary>
+        public double Precision
+        {
+            get => this.nonTruncatedDistribution.Precision;
+
+            set
+            {
+                this.nonTruncatedDistribution.Precision = value;
+                this.ResetCache();
+            }
+        }
+
+        /// <summary>
+        /// Returns the log normalizer of the instance.
+        /// </summary>
+        public double LogNormalizer => this.logNormalizer.Value;
+
+        /// <summary>
+        /// Returns the mean log factorial of the instance.
+        /// </summary>
+        public double MeanLogFactorial => this.meanLogFactorial.Value;
+
+        /// <summary>
+        /// Returns the log normalizer of the instance.
+        /// </summary>
+        public double SumLogFactorial => this.sumLogFactorial.Value;
+
+        /// <summary>
+        /// Gets a value indicating whether the current distribution represents a point mass.
+        /// </summary>
+        public bool IsPointMass => this.nonTruncatedDistribution.IsPointMass;
+
+        /// <summary>
+        /// Gets or sets the distribution as a point mass.
+        /// </summary>
+        public int Point
+        {
+            get => Math.Max(this.nonTruncatedDistribution.Point, this.StartPoint);
+
+            set
+            {
+                this.nonTruncatedDistribution.Point = value;
+                this.StartPoint = value;
+                this.ResetCache();
+            }
+        }
+
+        /// <summary>
+        /// Creates a new truncated COM-Poisson which is the product of two other truncated COM-Poissons
+        /// </summary>
+        /// <param name="a">The first COM-Poisson</param>
+        /// <param name="b">The second COM-Poisson</param>
+        /// <returns>Result of the product.</returns>
+        public static LeftTruncatedPoisson operator *(LeftTruncatedPoisson a, LeftTruncatedPoisson b)
+        {
+            var result = new LeftTruncatedPoisson();
+            result.SetToProduct(a, b);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new truncated COM-Poisson which is the ratio of two other truncated COM-Poissons
+        /// </summary>
+        /// <param name="numerator">The numerator distribution</param>
+        /// <param name="denominator">The denominator distribution</param>
+        /// <returns>Result of the ratio calculation.</returns>
+        public static LeftTruncatedPoisson operator /(LeftTruncatedPoisson numerator, LeftTruncatedPoisson denominator)
+        {
+            var result = new LeftTruncatedPoisson();
+            result.SetToRatio(numerator, denominator);
+            return result;
+        }
+
+        /// <summary>
+        /// Raises a truncated COM-Poisson to a power.
+        /// </summary>
+        /// <param name="dist">The distribution.</param>
+        /// <param name="exponent">The power to raise to.</param>
+        /// <returns><paramref name="dist" /> raised to power <paramref name="exponent" />.</returns>
+        public static LeftTruncatedPoisson operator ^(LeftTruncatedPoisson dist, double exponent)
+        {
+            var result = new LeftTruncatedPoisson();
+            result.SetToPower(dist, exponent);
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the log normalizer of a left-truncated Poisson.
+        /// TODO: integrate this with Poisson.GetLogNormalizer.
+        /// </summary>
+        /// <param name="rate">Rate parameter.</param>
+        /// <param name="prec">Precision parameter.</param>
+        /// <param name="startPoint">Start point.</param>
+        /// <returns>The log normalizer of the distribution.</returns>
+        public static double GetLogNormalizer(double rate, double prec, int startPoint)
+        {
+            if (startPoint == 0)
+            {
+                return Poisson.GetLogNormalizer(rate, prec);
+            }
+            else if (prec == 0.0)
+            {
+                if (rate >= 1)
+                {
+                    return 0.0;
+                }
+
+                return (startPoint * Math.Log(rate)) - Math.Log(1.0 - rate);
+            }
+            else
+            {
+                // The following commented recursion becomes numerically unstable very quickly.
+                // double lhs = GetLogNormalizer(rate, prec, startPoint - 1);
+                // double rhs = (startPoint - 1) * Math.Log(rate) - prec * MMath.GammaLn(startPoint);
+                // return MMath.LogDifferenceOfExp(lhs, rhs);
+                // So do the infinite sum instead.
+                const int MaxIterations = 1000;
+                var logRate = Math.Log(rate);
+                var maxIndex = MaxIterations + startPoint;
+
+                // First term
+                var logTerm = (startPoint * logRate) - (prec * MMath.GammaLn(startPoint + 1));
+                var result = logTerm;
+                int i;
+                for (i = startPoint + 1; i < maxIndex; i++)
+                {
+                    var deltaLogTerm = logRate - (prec * Math.Log(i));
+                    logTerm += deltaLogTerm;
+                    result = MMath.LogSumExp(result, logTerm);
+                    if (deltaLogTerm < 0)
+                    {
+                        // Truncation error.
+                        // The rest of the series is sum_{i=0..infinity} exp(term + delta(i)*i)
+                        // because delta is decreasing, we can bound the sum of the rest of the series
+                        // by sum_{i=0..infinity} exp(term + delta*i) = exp(term)/(1 - exp(delta))
+                        var r = Math.Exp(logTerm - result) / (1 - Math.Exp(deltaLogTerm));
+
+                        // Truncation error in log domain: log(z+r)-log(z) = log(1 + r/z) =approx r/
+                        if (r < Tolerance)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                if (i == maxIndex)
+                {
+                    throw new ArithmeticException("Unable to calculate log normalizer");
+                }
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Gets the log probability when some calculations have been done externally.
+        /// </summary>
+        /// <param name="value">The domain value.</param>
+        /// <param name="logRate">The log of the rate.</param>
+        /// <param name="precision">The precision.</param>
+        /// <param name="logNormalizer">The log normalizer.</param>
+        /// <returns>The log probability of the value.</returns>
+        public static double GetLogProb(int value, double logRate, double precision, double logNormalizer) =>
+            (value * logRate) - (precision * MMath.GammaLn(value + 1)) - logNormalizer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeftTruncatedPoisson" /> struct given a target
+        /// mean and a start point.
+        /// </summary>
+        /// <param name="targetMean">The desired mean of the Truncated Poisson.</param>
+        /// <param name="precision">The desired precision of the Truncated Poisson.</param>
+        /// <param name="startPoint">The start point.</param>
+        /// <param name="tolerance">Tolerance for mean.</param>
+        /// <param name="maxIterations">Maximum iterations for binary search.</param>
+        /// <returns>A new instance with the target mean.</returns>
+        public static LeftTruncatedPoisson FromMeanAndStartPoint(
+            double targetMean,
+            double precision,
+            int startPoint,
+            double tolerance = Tolerance,
+            int maxIterations = 100)
+        {
+            if (targetMean < startPoint)
+            {
+                throw new ArgumentException("Truncated Poisson: desired mean cannot be less than start point (M: {targetMean}, S: {startPoint})");
+            }
+
+            if (startPoint == 0)
+            {
+                return new LeftTruncatedPoisson(targetMean, startPoint);
+            }
+
+            if (precision == 0)
+            {
+                // Exact calculation.
+                var numer = targetMean - startPoint;
+                var denom = numer + 1.0;
+                return new LeftTruncatedPoisson(numer / denom, 0.0, startPoint);
+            }
+
+            if (targetMean - startPoint < double.Epsilon)
+            {
+                return PointMass(startPoint);
+            }
+
+            // Avoid numerical issues
+            if (targetMean < startPoint + tolerance)
+            {
+                targetMean = startPoint + tolerance;
+            }
+
+            // Do a binary search.
+            var rateUpperBound = targetMean;
+            var rateLowerBound = targetMean - startPoint;
+
+            var current = new LeftTruncatedPoisson(targetMean, startPoint);
+
+            var oldMean = double.MaxValue;
+            for (var i = 0; i < maxIterations; i++)
+            {
+                var rateCurrent = 0.5 * (rateLowerBound + rateUpperBound);
+                current = new LeftTruncatedPoisson(rateCurrent, precision, startPoint);
+                var currentMean = current.GetMean();
+
+                if (Math.Abs(currentMean - oldMean) < tolerance || Math.Abs(currentMean - targetMean) < tolerance)
+                {
+                    break;
+                }
+
+                if (currentMean < targetMean)
+                {
+                    rateLowerBound = rateCurrent;
+                }
+                else
+                {
+                    rateUpperBound = rateCurrent;
+                }
+            }
+
+            return current;
+        }
+
+        /// <summary>
+        /// Instantiates a uniform truncated Com-Poisson distribution
+        /// </summary>
+        /// <returns>A new uniform Com-Poisson distribution</returns>
+        [Construction(UseWhen = "IsUniform")]
+        [Skip]
+        public static LeftTruncatedPoisson Uniform()
+        {
+            var result = new LeftTruncatedPoisson();
+            result.SetToUniform();
+            return result;
+        }
+
+        /// <summary>
+        /// Instantiates a uniform truncated Com-Poisson distribution beyond a given start point.
+        /// </summary>
+        /// <param name="startPoint">Start point.</param>
+        /// <returns>A new uniform Com-Poisson distribution</returns>
+        public static LeftTruncatedPoisson TruncatedUniform(int startPoint)
+        {
+            var result = new LeftTruncatedPoisson();
+            result.SetToPartialUniform(startPoint);
+            result.ResetCache();
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a truncated Com-Poisson distribution which only allows one value.
+        /// </summary>
+        /// <param name="value">The value of the point mass.</param>
+        /// <returns>A point mass at the given value.</returns>
+        [Construction("Point", UseWhen = "IsPointMass")]
+        public static LeftTruncatedPoisson PointMass(int value)
+        {
+            var result = new LeftTruncatedPoisson
+            {
+                Point = value,
+                StartPoint = value
+            };
+
+            result.ResetCache();
+            return result;
+        }
+
+        /// <summary>
+        /// Computes sum_{x=start..infinity} log(x!) lambda^x / x!^nu
+        /// </summary>
+        /// <param name="lambda">The rate.</param>
+        /// <param name="nu">The precision.</param>
+        /// <param name="startPoint">The start point.</param>
+        /// <returns>The sum log factorial.</returns>
+        public static double GetSumLogFactorial(double lambda, double nu, int startPoint)
+        {
+            if (startPoint == 0)
+            {
+                return Poisson.GetSumLogFactorial(lambda, nu);
+            }
+            else if (double.IsPositiveInfinity(nu))
+            {
+                throw new ArgumentException("nu = Inf");
+            }
+            else if (lambda < 0)
+            {
+                throw new ArgumentException("lambda (" + lambda + ") < 0");
+            }
+            else if (nu < 0)
+            {
+                throw new ArgumentException("nu (" + nu + ") < 0");
+            }
+            else if (lambda == 0)
+            {
+                return 0.0;
+            }
+
+            const int MaxIters = 10000;
+            var term2 = MMath.GammaLn(startPoint + 1);
+            var term = Math.Exp((startPoint * Math.Log(lambda)) - (nu * term2));
+            var result = term2 * term;
+            int i;
+            for (i = startPoint + 1; i < MaxIters; i++)
+            {
+                var oldterm2 = term2;
+                term2 += Math.Log(i);
+                var delta = lambda / Math.Pow(i, nu);
+                term *= delta;
+                result += term * term2;
+                delta *= term2 / oldterm2; // delta = term*term2 / (oldterm*oldterm2)
+                if ((i > 2) && (delta < 1))
+                {
+                    // delta is decreasing, so remainder of series can be bounded by
+                    // sum_{i=0..infinity} term*term2*delta^i = term*term2/(1-delta)
+                    var r = (term * term2) / result / (1 - delta);
+                    if (r < Tolerance)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a cloned copy of this distribution.
+        /// </summary>
+        /// <returns>The copy.</returns>
+        public object Clone() => new LeftTruncatedPoisson(this.Rate, this.Precision, this.StartPoint);
+
+        /// <summary>
+        /// Gets a value indicating how close this distribution is to another distribution.
+        /// in terms of probabilities they assign to sequences.
+        /// </summary>
+        /// <param name="that">The other distribution.</param>
+        /// <returns>The max difference.</returns>
+        public double MaxDiff(object that)
+        {
+            if (!(that is LeftTruncatedPoisson))
+            {
+                return double.PositiveInfinity;
+            }
+
+            var thatd = (LeftTruncatedPoisson)that;
+
+            return Math.Max(this.nonTruncatedDistribution.MaxDiff(thatd.nonTruncatedDistribution), (double)Math.Abs(this.StartPoint - thatd.StartPoint));
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the current distribution is uniform.
+        /// </summary>
+        public bool IsUniform() => this.IsPartialUniform() && (this.StartPoint == 0);
+
+        /// <summary>
+        /// Asks whether this instance is proper or not. A truncated COM-Poisson distribution
+        /// is proper if Rate >= 0 and (Precision > 0 or (Precision == 0 and Rate &lt; 1)).
+        /// </summary>
+        /// <returns>True if proper, false otherwise</returns>
+        public bool IsProper() => this.nonTruncatedDistribution.IsProper();
+
+        /// <summary>
+        /// Sets the current distribution to be uniform.
+        /// </summary>
+        public void SetToUniform()
+        {
+            this.nonTruncatedDistribution.SetToUniform();
+            this.StartPoint = 0;
+            this.ResetCache();
+        }
+
+        /// <summary>
+        /// Sets the current distribution to be uniform beyond a given start point.
+        /// </summary>
+        /// <param name="startPoint">The start point.</param>
+        public void SetToPartialUniform(int startPoint)
+        {
+            this.nonTruncatedDistribution.SetToUniform();
+            this.StartPoint = startPoint;
+            this.ResetCache();
+        }
+
+        /// <summary>
+        /// Sets the parameters to represent the product of two truncated COM-Poissons.
+        /// </summary>
+        /// <param name="a">The first truncated COM-Poisson</param>
+        /// <param name="b">The second truncated COM-Poisson</param>
+        public void SetToProduct(LeftTruncatedPoisson a, LeftTruncatedPoisson b)
+        {
+            this.nonTruncatedDistribution = a.nonTruncatedDistribution * b.nonTruncatedDistribution;
+            this.StartPoint = Math.Max(a.StartPoint, b.StartPoint);
+            this.ResetCache();
+        }
+
+        /// <summary>
+        /// Sets the parameters to represent the ratio of two truncated COM-Poisson distributions
+        /// </summary>
+        /// <param name="numerator">The numerator truncated distribution</param>
+        /// <param name="denominator">The denominator truncated distribution</param>
+        /// <param name="forceProper">If true, the result has precision >= 0 and rate &lt;= 1</param>
+        /// <remarks>
+        /// The result may not be proper. No error is thrown in this case.
+        /// </remarks>
+        public void SetToRatio(LeftTruncatedPoisson numerator, LeftTruncatedPoisson denominator, bool forceProper = false)
+        {
+            this.nonTruncatedDistribution = numerator.nonTruncatedDistribution / denominator.nonTruncatedDistribution;
+            this.StartPoint = Math.Max(numerator.StartPoint, denominator.StartPoint);
+            this.ResetCache();
+        }
+
+        /// <summary>
+        /// Sets the parameters to represent the power of a truncated COM-Poisson to some exponent.
+        /// </summary>
+        /// <param name="dist">The source truncated COM-Poisson</param>
+        /// <param name="exponent">The exponent</param>
+        public void SetToPower(LeftTruncatedPoisson dist, double exponent)
+        {
+            this.nonTruncatedDistribution = dist.nonTruncatedDistribution ^ exponent;
+            this.StartPoint = dist.StartPoint;
+            this.ResetCache();
+        }
+
+        /// <summary>
+        /// Set the parameters to match the moments of a mixture distribution.
+        /// </summary>
+        /// <param name="weight1">The first weight</param>
+        /// <param name="dist1">The first distribution</param>
+        /// <param name="weight2">The second weight</param>
+        /// <param name="dist2">The second distribution</param>
+        public void SetToSum(double weight1, LeftTruncatedPoisson dist1, double weight2, LeftTruncatedPoisson dist2)
+        {
+            var nonTrunc = default(Poisson);
+            nonTrunc.SetToSum(weight1, dist1.nonTruncatedDistribution, weight2, dist2.nonTruncatedDistribution);
+            this.nonTruncatedDistribution = nonTrunc;
+            this.StartPoint = Math.Max(dist1.StartPoint, dist2.StartPoint);
+            this.ResetCache();
+        }
+
+        /// <summary>
+        /// Gets the log of the integral of the product of this truncated COM-Poisson with another truncated COM-Poisson.
+        /// </summary>
+        /// <param name="that">The other truncated COM-Poisson</param>
+        public double GetLogAverageOf(LeftTruncatedPoisson that)
+        {
+            if (this.IsPointMass)
+            {
+                return that.GetLogProb(this.Point);
+            }
+            else if (that.IsPointMass)
+            {
+                return this.GetLogProb(that.Point);
+            }
+            else
+            {
+                var product = new LeftTruncatedPoisson();
+                product.SetToProduct(this, that);
+
+                return (this.GetLogNormalizer() + that.GetLogNormalizer()) - product.GetLogNormalizer();
+            }
+        }
+
+        /// <summary>
+        /// Gets the expected logarithm of a truncated COM-Poisson under this truncated COM-Poisson.
+        /// </summary>
+        /// <param name="that">The distribution to take the logarithm of.</param>
+        /// <returns>
+        ///     <c>sum_x this.Evaluate(x)*Math.Log(that.Evaluate(x))</c>
+        /// </returns>
+        /// <remarks>This is also known as the cross entropy.</remarks>
+        public double GetAverageLog(LeftTruncatedPoisson that)
+        {
+            if (that.IsPointMass)
+            {
+                if (this.IsPointMass && (this.Point == that.Point))
+                {
+                    return 0.0;
+                }
+                else
+                {
+                    return double.NegativeInfinity;
+                }
+            }
+            else if (!this.IsProper())
+            {
+                throw new ImproperDistributionException(this);
+            }
+            else if (this.StartPoint < that.StartPoint)
+            {
+                return double.NegativeInfinity;
+            }
+            else
+            {
+                return (this.GetMean() * Math.Log(that.Rate)) - (that.Precision * this.GetMeanLogFactorial()) - that.GetLogNormalizer();
+            }
+        }
+
+        /// <summary>
+        /// Gets the log of the normalizer of this distribution.
+        /// </summary>
+        /// <returns>The log of the normalizer.</returns>
+        public double GetLogNormalizer()
+        {
+            return this.LogNormalizer;
+        }
+
+        /// <summary>
+        /// Gets the log probability for a given domain value.
+        /// </summary>
+        /// <param name="value">The domain value.</param>
+        /// <returns>The log probability of the value.</returns>
+        public double GetLogProb(int value)
+        {
+            if (value < this.StartPoint)
+            {
+                return double.NegativeInfinity;
+            }
+            else if (this.IsPointMass)
+            {
+                return value == this.Point ? 0.0 : double.NegativeInfinity;
+            }
+            else if (this.IsPartialUniform())
+            {
+                return 0.0;
+            }
+            else
+            {
+                return GetLogProb(value, Math.Log(this.Rate), this.Precision, this.GetLogNormalizer());
+            }
+        }
+
+        /// <summary>
+        /// Emits a random sample from this distribution.
+        /// </summary>
+        /// <returns>A random sample.</returns>
+        [Stochastic]
+        public int Sample()
+        {
+            if (this.IsPointMass)
+            {
+                return this.Point;
+            }
+
+            // This is an inefficient rejection sampler which will not scale as
+            // the start point gets large compared with the mean. If this is to be
+            // used in anger we should revisit this.
+            int result;
+            do
+            {
+                result = Poisson.Sample(this.Rate, this.Precision);
+            }
+            while (result < this.StartPoint);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Emits a random sample from this distribution.
+        /// </summary>
+        /// <param name="result">This argument is ignored.</param>
+        /// <returns>A random sample.</returns>
+        [Stochastic]
+        public int Sample(int result) => this.Sample();
+
+        /// <summary>
+        /// Gets the mean of this distribution.
+        /// </summary>
+        /// <returns>The mean.</returns>
+        public double GetMean()
+        {
+            if (this.Precision == 1.0)
+            {
+                if (this.StartPoint == 0)
+                {
+                    return this.nonTruncatedDistribution.GetMean();
+                }
+                else if (this.IsPointMass)
+                {
+                    return this.Point;
+                }
+                else
+                {
+                    var logMean = (Math.Log(this.Rate) + GetLogNormalizer(this.Rate, 1.0, this.StartPoint - 1)) - GetLogNormalizer(this.Rate, 1.0, this.StartPoint);
+
+                    return Math.Exp(logMean);
+                }
+            }
+            else if ((this.Precision == 0.0) && (this.Rate < 1.0))
+            {
+                if (this.StartPoint == 0)
+                {
+                    return this.nonTruncatedDistribution.GetMean();
+                }
+                else
+                {
+                    return ((this.Rate + this.StartPoint) - (this.Rate * this.StartPoint)) / (1.0 - this.Rate);
+                }
+            }
+            else
+            {
+                throw new NotImplementedException("Calculation for mean is only available for Precision = 1, or Precision = 0 and Rate < 1");
+            }
+        }
+
+        /// <inheritdoc />
+        public void SetTo(LeftTruncatedPoisson value)
+        {
+            this.nonTruncatedDistribution.SetTo(value.nonTruncatedDistribution);
+            this.StartPoint = value.StartPoint;
+            this.ResetCache();
+        }
+
+        /// <inheritdoc />
+        public void SetTo(Discrete value)
+        {
+            var startPoint = value.GetLogProbs().FindFirstIndex(prob => !double.IsNegativeInfinity(prob));
+            var mean = value.GetMean();
+            const double Delta = 0.01;
+            if (mean - startPoint < Delta)
+            {
+                mean = startPoint + Delta;
+            }
+
+            var projection = FromMeanAndStartPoint(mean, 1.0, startPoint);
+            this.SetTo(projection);
+        }
+
+        /// <summary>
+        /// Overrides ToString method.
+        /// </summary>
+        /// <returns>String representation of instance.</returns>
+        public override string ToString()
+        {
+            if (this.IsPointMass)
+            {
+                return "TruncPois.PointMass(" + this.Point + ")";
+            }
+            else if (this.IsPartialUniform())
+            {
+                if (this.StartPoint > 0)
+                {
+                    return "TruncPois.Uniform(" + this.StartPoint + ")";
+                }
+                else
+                {
+                    return "TruncPois.Uniform";
+                }
+            }
+            else if (this.Precision == 1.0)
+            {
+                return string.Format("TruncPois:Rate={0:0.000},Start={1}(mean={2:0.00})", this.Rate, this.StartPoint, this.GetMean());
+            }
+            else
+            {
+                return string.Format("TruncPois:Rate={0:0.000},Prec={1:0.00},Start={2}", this.Rate, this.Precision, this.StartPoint);
+            }
+        }
+
+        /// <summary>
+        /// Set non-zero support to uniform
+        /// </summary>
+        public void SetToPartialUniform()
+        {
+            this.nonTruncatedDistribution.SetToUniform();
+        }
+
+        /// <inheritdoc />
+        public void SetToPartialUniformOf(LeftTruncatedPoisson dist)
+        {
+            this.SetToPartialUniform();
+            this.StartPoint = dist.StartPoint;
+            this.ResetCache();
+        }
+
+        /// <inheritdoc />
+        public void SetToPartialUniformOf(Discrete dist)
+        {
+            this.SetToPartialUniform();
+            this.StartPoint = dist.GetLogProbs().FindFirstIndex(prob => !double.IsNegativeInfinity(prob));
+            this.ResetCache();
+        }
+
+        /// <inheritdoc />
+        public bool IsPartialUniform() => this.nonTruncatedDistribution.IsUniform();
+
+        /// <inheritdoc />
+        public int GetStartPoint()
+        {
+            return this.StartPoint;
+        }
+
+        /// <inheritdoc />
+        public void TruncateLeft(int startPoint)
+        {
+            this.StartPoint = startPoint;
+            this.ResetCache();
+        }
+
+        /// <summary>
+        /// Resets the cache for this instance.
+        /// </summary>
+        internal void ResetCache()
+        {
+            this.logNormalizer = new Lazy<double>(() => GetLogNormalizer(this.Rate, this.Precision, this.StartPoint));
+            this.meanLogFactorial = new Lazy<double>(this.GetMeanLogFactorial);
+            this.sumLogFactorial = new Lazy<double>(() => GetSumLogFactorial(this.Rate, this.Precision, this.StartPoint));
+        }
+
+        /// <summary>
+        /// Computes (sum_{x=start..infinity} log(x!) Rate^x / x!^Precision) / (sum_{x=start..infinity} Rate^x / x!^Precision )
+        /// </summary>
+        /// <returns>The mean log factorial.</returns>
+        private double GetMeanLogFactorial()
+        {
+            if (this.IsPointMass)
+            {
+                return MMath.GammaLn(this.Point + 1);
+            }
+            else if (!this.IsProper())
+            {
+                throw new ImproperDistributionException(this);
+            }
+            else
+            {
+                return this.SumLogFactorial / Math.Exp(this.LogNormalizer);
+            }
+        }
+    }
+}

--- a/src/Runtime/Distributions/TruncatedPoisson.cs
+++ b/src/Runtime/Distributions/TruncatedPoisson.cs
@@ -1,0 +1,706 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Distributions
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    using Microsoft.ML.Probabilistic.Factors.Attributes;
+    using Microsoft.ML.Probabilistic.Math;
+    using Microsoft.ML.Probabilistic.Serialization;
+
+    /// <summary>
+    /// Left-and-right-truncated Com-Poisson distribution.
+    /// </summary>
+    [DataContract]
+    [Quality(QualityBand.Experimental)]
+    public class TruncatedPoisson : IDistribution<int>,
+                                     CanGetMean<double>,
+                                     Sampleable<int>,
+                                     SettableToProduct<TruncatedPoisson>,
+                                     SettableTo<TruncatedPoisson>,
+                                     SettableTo<LeftTruncatedPoisson>,
+                                     SettableTo<Discrete>,
+                                     SettableToPartialUniform<TruncatedPoisson>,
+                                     SettableToPartialUniform<Discrete>,
+                                     CanGetLogAverageOf<TruncatedPoisson>,
+                                     CanGetAverageLog<TruncatedPoisson>,
+                                     CanGetLogNormalizer,
+                                     ICanTruncateLeft<int>,
+                                     ICanTruncateRight<int>
+    {
+        public const int PositiveInfinityEndPoint = int.MaxValue;
+
+        /// <summary>
+        /// The left-truncated distribution.
+        /// </summary>
+        [DataMember]
+        private LeftTruncatedPoisson leftTruncatedDistribution;
+
+        private Lazy<double> logNormalizer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TruncatedPoisson" /> class.
+        /// </summary>
+        /// <param name="rate">The rate parameter of the underlying CoM-Poisson distribution.</param>
+        /// <param name="startPoint">The index of the first non-zero term in the truncated distribution.</param>
+        public TruncatedPoisson(double rate, int startPoint)
+            : this(rate, 1.0, startPoint)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TruncatedPoisson" /> class.
+        /// </summary>
+        /// <param name="rate">The rate parameter of the underlying CoM-Poisson distribution.</param>
+        /// <param name="precision">The precision parameter of the underlying CoM-Poisson distribution.</param>
+        /// <param name="startPoint">The index of the first non-zero term in the truncated distribution.</param>
+        public TruncatedPoisson(double rate, double precision, int startPoint)
+            : this(new LeftTruncatedPoisson(rate, precision, startPoint), PositiveInfinityEndPoint)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TruncatedPoisson" /> class.
+        /// </summary>
+        /// <param name="rate">The rate parameter of the underlying CoM-Poisson distribution.</param>
+        /// <param name="precision">The precision parameter of the underlying CoM-Poisson distribution.</param>
+        /// <param name="startPoint">The index of the first non-zero term in the truncated distribution.</param>
+        /// <param name="endPoint">The index of the last non-zero term in the truncated distribution.</param>
+        [Construction("Rate", "Precision", "StartPoint", "EndPoint")]
+        public TruncatedPoisson(double rate, double precision, int startPoint, int endPoint)
+            : this(new LeftTruncatedPoisson(rate, precision, startPoint), endPoint)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TruncatedPoisson" /> class.
+        /// </summary>
+        /// <param name="nonTruncatedDistribution">The underlying CoM-Poisson distribution.</param>
+        /// <param name="startPoint">The index of the first non-zero term in the truncated distribution.</param>
+        public TruncatedPoisson(Poisson nonTruncatedDistribution, int startPoint)
+            : this(new LeftTruncatedPoisson(nonTruncatedDistribution, startPoint))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TruncatedPoisson" /> class.
+        /// </summary>
+        /// <param name="truncatedDistribution">The underlying left-truncated CoM-Poisson distribution.</param>
+        public TruncatedPoisson(LeftTruncatedPoisson truncatedDistribution)
+            : this(truncatedDistribution, PositiveInfinityEndPoint)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TruncatedPoisson" /> class.
+        /// </summary>
+        /// <param name="nonTruncatedDistribution">The underlying CoM-Poisson distribution.</param>
+        /// <param name="startPoint">The index of the first non-zero term in the truncated distribution.</param>
+        /// <param name="endPoint">The index of the last non-zero term in the truncated distribution.</param>
+        public TruncatedPoisson(Poisson nonTruncatedDistribution, int startPoint, int endPoint)
+            : this(new LeftTruncatedPoisson(nonTruncatedDistribution, startPoint), endPoint)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TruncatedPoisson" /> class.
+        /// </summary>
+        /// <param name="leftTruncatedDistribution">The underlying left-truncated CoM-Poisson distribution.</param>
+        /// <param name="endPoint">The index of the last non-zero term in the truncated distribution.</param>
+        public TruncatedPoisson(LeftTruncatedPoisson leftTruncatedDistribution, int endPoint)
+        {
+            this.leftTruncatedDistribution = leftTruncatedDistribution;
+            this.EndPoint = leftTruncatedDistribution.IsPointMass ? leftTruncatedDistribution.Point : endPoint;
+            this.ResetCache();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TruncatedPoisson" /> class.
+        /// </summary>
+        public TruncatedPoisson()
+        {
+            this.leftTruncatedDistribution = new LeftTruncatedPoisson();
+            this.SetToUniform();
+        }
+
+        /// <summary>
+        /// The last non-zero point.
+        /// </summary>
+        [DataMember]
+        public int EndPoint { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the rate parameter of the COM-Poisson distribution, always >= 0.
+        /// </summary>
+        public double Rate
+        {
+            get => this.leftTruncatedDistribution.Rate;
+
+            set
+            {
+                this.leftTruncatedDistribution.Rate = value;
+                this.ResetCache();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the precision parameter of the COM-Poisson distribution
+        /// </summary>
+        public double Precision
+        {
+            get => this.leftTruncatedDistribution.Precision;
+
+            set
+            {
+                this.leftTruncatedDistribution.Precision = value;
+                this.ResetCache();
+            }
+        }
+
+        /// <summary>
+        /// The first non-zero point.
+        /// </summary>
+        public int StartPoint => this.leftTruncatedDistribution.StartPoint;
+
+        /// <summary>
+        /// Returns the log normalizer of the instance.
+        /// </summary>
+        public double LogNormalizer => this.logNormalizer.Value;
+
+        /// <summary>
+        /// Gets a value indicating whether the current distribution represents a point mass.
+        /// </summary>
+        public bool IsPointMass => this.leftTruncatedDistribution.IsPointMass || (this.StartPoint == this.EndPoint);
+
+        /// <summary>
+        /// Gets or sets the distribution as a point mass.
+        /// </summary>
+        public int Point
+        {
+            get => Math.Min(this.leftTruncatedDistribution.Point, this.EndPoint);
+
+            set
+            {
+                this.leftTruncatedDistribution.Point = value;
+                this.EndPoint = value;
+                this.ResetCache();
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the current distribution is right-truncated.
+        /// </summary>
+        public bool EndPointIsPositiveInfinity => this.EndPoint == PositiveInfinityEndPoint;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TruncatedPoisson" /> struct given a target
+        /// mean, a start point and a end point.
+        /// </summary>
+        /// <param name="targetMean">The desired mean of the Truncated Poisson.</param>
+        /// <param name="precision">The desired precision of the Truncated Poisson.</param>
+        /// <param name="startPoint">The start point.</param>
+        /// <param name="tolerance">Tolerance for mean.</param>
+        /// <param name="maxIterations">Maximum iterations for binary search.</param>
+        /// <returns>A new instance with the target mean.</returns>
+        public static TruncatedPoisson FromMeanAndStartPoint(
+            double targetMean,
+            double precision,
+            int startPoint,
+            double tolerance = LeftTruncatedPoisson.Tolerance,
+            int maxIterations = 100) =>
+            FromMeanAndStartPointAndEndPoint(targetMean, precision, startPoint, PositiveInfinityEndPoint, tolerance, maxIterations);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TruncatedPoisson" /> struct given a target
+        /// mean, a start point and a end point.
+        /// </summary>
+        /// <param name="targetMean">The desired mean of the Truncated Poisson.</param>
+        /// <param name="precision">The desired precision of the Truncated Poisson.</param>
+        /// <param name="startPoint">The start point.</param>
+        /// <param name="endPoint">The end point.</param>
+        /// <param name="tolerance">Tolerance for mean.</param>
+        /// <param name="maxIterations">Maximum iterations for binary search.</param>
+        /// <returns>A new instance with the target mean.</returns>
+        public static TruncatedPoisson FromMeanAndStartPointAndEndPoint(
+            double targetMean,
+            double precision,
+            int startPoint,
+            int endPoint,
+            double tolerance = LeftTruncatedPoisson.Tolerance,
+            int maxIterations = 100)
+        {
+            if (targetMean < startPoint)
+            {
+                throw new ArgumentException(
+                    $"Doubly Truncated Poisson: desired mean cannot be less than start point (M: {targetMean}, S: {startPoint}, E: {endPoint})");
+            }
+
+            if (targetMean > endPoint)
+            {
+                throw new ArgumentException($"Doubly Truncated Poisson: desired mean cannot be more than end point (M: {targetMean}, S: {startPoint}, E: {endPoint})");
+            }
+
+            if (endPoint == PositiveInfinityEndPoint)
+            {
+                var truncatedDistribution = LeftTruncatedPoisson.FromMeanAndStartPoint(targetMean, precision, startPoint, tolerance, maxIterations);
+                return new TruncatedPoisson(truncatedDistribution, endPoint);
+            }
+
+            if (startPoint == endPoint || targetMean - startPoint < double.Epsilon)
+            {
+                return PointMass(startPoint);
+            }
+
+            // Avoid numerical issues
+            if (targetMean < startPoint + tolerance)
+            {
+                targetMean = startPoint + tolerance;
+            }
+
+            // Do a binary search.
+            double rateUpperBound;
+            double rateLowerBound;
+            TruncatedPoisson current;
+            if (precision == 0)
+            {
+                rateUpperBound = 1.0;
+                rateLowerBound = 0.0;
+                current = new TruncatedPoisson(0.5, precision, startPoint, endPoint);
+            }
+            else
+            {
+                rateUpperBound = targetMean;
+                rateLowerBound = targetMean - startPoint;
+                current = new TruncatedPoisson(targetMean, 1.0, startPoint, endPoint);
+            }
+
+            var oldMean = double.MaxValue;
+            for (var i = 0; i < maxIterations; i++)
+            {
+                var rateCurrent = 0.5 * (rateLowerBound + rateUpperBound);
+                current = new TruncatedPoisson(rateCurrent, precision, startPoint, endPoint);
+                var currentMean = current.GetMean();
+
+                if (Math.Abs(currentMean - oldMean) < tolerance || Math.Abs(currentMean - targetMean) < tolerance)
+                {
+                    break;
+                }
+
+                oldMean = currentMean;
+
+                if (currentMean < targetMean)
+                {
+                    rateLowerBound = rateCurrent;
+                }
+                else
+                {
+                    rateUpperBound = rateCurrent;
+                }
+            }
+
+            return current;
+        }
+
+        /// <summary>
+        /// Gets the log normalizer of a truncated Poisson.
+        /// </summary>
+        /// <param name="rate">Rate parameter.</param>
+        /// <param name="prec">Precision parameter.</param>
+        /// <param name="startPoint">Start point.</param>
+        /// <param name="endPoint">End point.</param>
+        /// <returns>The log normalizer of the distribution.</returns>
+        public static double GetLogNormalizer(double rate, double prec, int startPoint, int endPoint)
+        {
+            if ((prec == 0.0) && (rate >= 1))
+            {
+                return 0.0;
+            }
+
+            return MMath.LogDifferenceOfExp(
+                LeftTruncatedPoisson.GetLogNormalizer(rate, prec, startPoint),
+                LeftTruncatedPoisson.GetLogNormalizer(rate, prec, endPoint + 1));
+        }
+
+        /// <summary>
+        /// Creates a truncated Com-Poisson distribution which only allows one value.
+        /// </summary>
+        /// <param name="value">The value of the point mass.</param>
+        /// <returns>A point mass at the given value.</returns>
+        [Construction("Point", UseWhen = "IsPointMass")]
+        public static TruncatedPoisson PointMass(int value)
+        {
+            var leftTruncatedDistribution = LeftTruncatedPoisson.PointMass(value);
+            var result = new TruncatedPoisson(leftTruncatedDistribution, value);
+            return result;
+        }
+
+        /// <summary>
+        /// Instantiates a uniform truncated Com-Poisson distribution beyond a given start point.
+        /// </summary>
+        /// <param name="startPoint">The index of the first non-zero term in the truncated distribution.</param>
+        /// <returns>A new uniform truncated Com-Poisson distribution</returns>
+        public static TruncatedPoisson PartialUniform(int startPoint) => PartialUniform(startPoint, PositiveInfinityEndPoint);
+
+        /// <summary>
+        /// Instantiates a uniform truncated Com-Poisson distribution between given start and end points.
+        /// </summary>
+        /// <param name="startPoint">The index of the first non-zero term in the truncated distribution.</param>
+        /// <param name="endPoint">The index of the last non-zero term in the truncated distribution.</param>
+        /// <returns>A new uniform truncated Com-Poisson distribution</returns>
+        public static TruncatedPoisson PartialUniform(int startPoint, int endPoint)
+        {
+            var result = new TruncatedPoisson();
+            result.SetToPartialUniform(startPoint, endPoint);
+            return result;
+        }
+
+        /// <summary>
+        /// Instantiates a uniform truncated Com-Poisson distribution
+        /// </summary>
+        /// <returns>A new uniform Com-Poisson distribution</returns>
+        [Construction(UseWhen = "IsUniform")]
+        [Skip]
+        public static TruncatedPoisson Uniform()
+        {
+            var result = new TruncatedPoisson();
+            result.SetToUniform();
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a cloned copy of this distribution.
+        /// </summary>
+        /// <returns>The copy.</returns>
+        public object Clone() => new TruncatedPoisson(this.Rate, this.Precision, this.StartPoint, this.EndPoint);
+
+        /// <summary>
+        /// Gets the log of the integral of the product of this truncated COM-Poisson with another truncated COM-Poisson.
+        /// </summary>
+        /// <param name="that">The other truncated COM-Poisson</param>
+        public double GetLogAverageOf(TruncatedPoisson that)
+        {
+            if (this.IsPointMass)
+            {
+                return that.GetLogProb(this.Point);
+            }
+            else if (that.IsPointMass)
+            {
+                return this.GetLogProb(that.Point);
+            }
+            else
+            {
+                var product = new TruncatedPoisson();
+                product.SetToProduct(this, that);
+
+                return (this.LogNormalizer + that.LogNormalizer) - product.LogNormalizer;
+            }
+        }
+
+        /// <summary>
+        /// Gets the log of the normalizer of this distribution.
+        /// </summary>
+        /// <returns>The log of the normalizer.</returns>
+        public double GetLogNormalizer()
+        {
+            return this.LogNormalizer;
+        }
+
+        /// <summary>
+        /// Gets the log probability for a given domain value.
+        /// </summary>
+        /// <param name="value">The domain value.</param>
+        /// <returns>The log probability of the value.</returns>
+        public double GetLogProb(int value)
+        {
+            if (this.EndPointIsPositiveInfinity)
+            {
+                return this.leftTruncatedDistribution.GetLogProb(value);
+            }
+            else if ((value > this.EndPoint) || (value < this.StartPoint))
+            {
+                return double.NegativeInfinity;
+            }
+            else if (this.IsPointMass)
+            {
+                return value == this.Point ? 0.0 : double.NegativeInfinity;
+            }
+            else
+            {
+                return LeftTruncatedPoisson.GetLogProb(value, Math.Log(this.Rate), this.Precision, this.GetLogNormalizer());
+            }
+        }
+
+        /// <summary>
+        /// Gets the mean of this distribution.
+        /// </summary>
+        /// <returns>The mean.</returns>
+        public double GetMean()
+        {
+            if (this.EndPointIsPositiveInfinity)
+            {
+                return this.leftTruncatedDistribution.GetMean();
+            }
+
+            if (this.IsPointMass)
+            {
+                return this.Point;
+            }
+
+            if ((this.Precision == 0.0) && (this.Rate < 1))
+            {
+                var rateToPower = Math.Pow(this.Rate, (this.EndPoint + 1) - this.StartPoint);
+                var numer = this.StartPoint - 1 - (this.EndPoint * rateToPower);
+                var denom = 1 - rateToPower;
+
+                return (numer / denom) + (1.0 / (1 - this.Rate));
+            }
+            else if (this.Precision == 1)
+            {
+                var logMean = (Math.Log(this.Rate) + GetLogNormalizer(this.Rate, this.Precision, this.StartPoint > 0 ? this.StartPoint - 1 : 0, this.EndPoint - 1))
+                              - GetLogNormalizer(this.Rate, this.Precision, this.StartPoint, this.EndPoint);
+                return Math.Exp(logMean);
+            }
+            else
+            {
+                throw new NotImplementedException("Calculation for mean is only available for Precision = 1, or Precision = 0 and Rate < 1");
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the current distribution is uniform.
+        /// </summary>
+        public bool IsUniform() => this.leftTruncatedDistribution.IsUniform() && (this.EndPoint == int.MaxValue);
+
+        /// <summary>
+        /// Asks whether this instance is proper or not. A truncated COM-Poisson distribution
+        /// is proper if Rate >= 0 and (Precision > 0 or (Precision == 0 and Rate &lt; 1)).
+        /// </summary>
+        /// <returns>True if proper, false otherwise</returns>
+        public bool IsProper() => this.leftTruncatedDistribution.IsProper();
+
+        /// <summary>
+        /// Gets a value indicating how close this distribution is to another distribution.
+        /// in terms of probabilities they assign to sequences.
+        /// </summary>
+        /// <param name="that">The other distribution.</param>
+        /// <returns>The max difference.</returns>
+        public double MaxDiff(object that)
+        {
+            if (!(that is TruncatedPoisson))
+            {
+                return double.PositiveInfinity;
+            }
+
+            var thatd = (TruncatedPoisson)that;
+
+            return Math.Max(this.leftTruncatedDistribution.MaxDiff(thatd.leftTruncatedDistribution), (double)Math.Abs(this.EndPoint - thatd.EndPoint));
+        }
+
+        /// <summary>
+        /// Emits a random sample from this distribution.
+        /// </summary>
+        /// <returns>A random sample.</returns>
+        [Stochastic]
+        public int Sample()
+        {
+            if (this.IsPointMass)
+            {
+                return this.Point;
+            }
+
+            int result;
+            do
+            {
+                result = this.leftTruncatedDistribution.Sample();
+            }
+            while (result > this.EndPoint);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Emits a random sample from this distribution.
+        /// </summary>
+        /// <param name="result">This argument is ignored.</param>
+        /// <returns>A random sample.</returns>
+        [Stochastic]
+        public int Sample(int result) => this.Sample();
+
+        /// <summary>
+        /// Sets the parameters to represent the product of two truncated COM-Poissons.
+        /// </summary>
+        /// <param name="a">The first truncated COM-Poisson</param>
+        /// <param name="b">The second truncated COM-Poisson</param>
+        public void SetToProduct(TruncatedPoisson a, TruncatedPoisson b)
+        {
+            if (Math.Max(a.StartPoint, b.StartPoint) > Math.Min(a.EndPoint, b.EndPoint))
+            {
+                throw new AllZeroException();
+            }
+
+            this.leftTruncatedDistribution = a.leftTruncatedDistribution * b.leftTruncatedDistribution;
+            this.EndPoint = Math.Min(a.EndPoint, b.EndPoint);
+            this.ResetCache();
+        }
+
+        /// <summary>
+        /// Sets the current distribution to be uniform.
+        /// </summary>
+        public void SetToUniform()
+        {
+            this.leftTruncatedDistribution.SetToUniform();
+            this.EndPoint = int.MaxValue;
+            this.ResetCache();
+        }
+
+        /// <summary>
+        /// Sets the current distribution to be uniform between given start and end points.
+        /// </summary>
+        /// <param name="startPoint">The index of the first non-zero term in the truncated distribution.</param>
+        /// <param name="endPoint">The index of the last non-zero term in the truncated distribution.</param>
+        public void SetToPartialUniform(int startPoint, int endPoint)
+        {
+            this.leftTruncatedDistribution.SetToPartialUniform(startPoint);
+            this.EndPoint = endPoint;
+            this.ResetCache();
+        }
+
+        /// <inheritdoc />
+        public void SetTo(TruncatedPoisson value)
+        {
+            this.leftTruncatedDistribution.SetTo(value.leftTruncatedDistribution);
+            this.EndPoint = value.EndPoint;
+            this.ResetCache();
+        }
+
+        /// <inheritdoc />
+        public void SetTo(LeftTruncatedPoisson value)
+        {
+            this.leftTruncatedDistribution.SetTo(value);
+            this.EndPoint = int.MaxValue;
+            this.ResetCache();
+        }
+
+        /// <inheritdoc />
+        public void SetTo(Discrete value)
+        {
+            var startPoint = value.GetLogProbs().FindFirstIndex(prob => !double.IsNegativeInfinity(prob));
+            var mean = value.GetMean();
+            const double Delta = 0.01;
+            if (mean - startPoint < Delta)
+            {
+                if (startPoint >= this.EndPoint)
+                {
+                    this.Point = this.EndPoint;
+                    return;
+                }
+                else
+                {
+                    mean = startPoint + Delta;
+                }
+            }
+
+            var projection = FromMeanAndStartPointAndEndPoint(mean, 1.0, startPoint, this.EndPoint);
+            this.SetTo(projection);
+        }
+
+        /// <summary>
+        /// Overrides ToString method.
+        /// </summary>
+        /// <returns>String representation of instance.</returns>
+        public override string ToString()
+        {
+            if (this.EndPointIsPositiveInfinity)
+            {
+                return this.leftTruncatedDistribution.ToString();
+            }
+
+            if (this.IsPointMass)
+            {
+                return "TruncPois.PointMass(" + this.Point + ")";
+            }
+            else if (this.IsPartialUniform())
+            {
+                return "TruncPois.Uniform(" + this.StartPoint + "," + this.EndPoint + ")";
+            }
+            else
+            {
+                return string.Format("TruncPois:Rate={0:0.000},Prec={1:0.00},Start={2}, End={3}", this.Rate, this.Precision, this.StartPoint, this.EndPoint);
+            }
+        }
+
+        /// <inheritdoc />
+        public double GetAverageLog(TruncatedPoisson that)
+        {
+            if (this.EndPointIsPositiveInfinity && that.EndPointIsPositiveInfinity)
+            {
+                return this.leftTruncatedDistribution.GetAverageLog(that.leftTruncatedDistribution);
+            }
+
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void SetToPartialUniform()
+        {
+            this.leftTruncatedDistribution.SetToPartialUniform();
+            this.ResetCache();
+        }
+
+        /// <inheritdoc />
+        public void SetToPartialUniformOf(TruncatedPoisson dist)
+        {
+            this.leftTruncatedDistribution.SetToPartialUniformOf(dist.leftTruncatedDistribution);
+            this.EndPoint = dist.EndPoint;
+            this.ResetCache();
+        }
+
+        /// <inheritdoc />
+        public void SetToPartialUniformOf(Discrete dist)
+        {
+            this.leftTruncatedDistribution.SetToPartialUniformOf(dist);
+            this.EndPoint = dist.GetLogProbs().FindLastIndex(prob => !double.IsNegativeInfinity(prob));
+            this.ResetCache();
+        }
+
+        /// <inheritdoc />
+        public bool IsPartialUniform() => this.leftTruncatedDistribution.IsPartialUniform();
+
+        /// <inheritdoc />
+        public int GetStartPoint()
+        {
+            return this.StartPoint;
+        }
+
+        /// <inheritdoc />
+        public void TruncateLeft(int startPoint)
+        {
+            this.leftTruncatedDistribution.TruncateLeft(startPoint);
+        }
+
+        /// <inheritdoc />
+        public int GetEndPoint()
+        {
+            return this.EndPoint;
+        }
+
+        /// <inheritdoc />
+        public void TruncateRight(int endPoint)
+        {
+            this.EndPoint = endPoint;
+            this.ResetCache();
+        }
+
+        /// <summary>
+        /// Resets the cache for this instance.
+        /// </summary>
+        private void ResetCache()
+        {
+            this.leftTruncatedDistribution.ResetCache();
+            this.logNormalizer = new Lazy<double>(() => this.EndPointIsPositiveInfinity ? this.leftTruncatedDistribution.LogNormalizer : GetLogNormalizer(this.Rate, this.Precision, this.StartPoint, this.EndPoint));
+        }
+    }
+}

--- a/src/Runtime/Distributions/WordStrings.cs
+++ b/src/Runtime/Distributions/WordStrings.cs
@@ -1,0 +1,160 @@
+﻿// <copyright file="WordStrings.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace Microsoft.ML.Probabilistic.Distributions
+{
+    using System;
+    using System.Linq;
+
+    using Microsoft.ML.Probabilistic.Collections;
+    using Microsoft.ML.Probabilistic.Distributions.Automata;
+
+    /// <summary>
+    /// Sets of strings of whole words.
+    /// </summary>
+    public static class WordStrings
+    {
+        /// <summary>
+        /// A uniform distribution over all non-word characters.
+        /// </summary>
+        private static readonly DiscreteChar NonWordCharacter = DiscreteChar.InRanges(DiscreteChar.LetterCharacterRanges + "09__{{}}''").Complement();
+
+        /// <summary>
+        /// Creates a uniform distribution over either the empty string or any string ending with a non-word character.
+        /// </summary>
+        /// <returns>The created distribution.</returns>
+        public static StringDistribution WordPrefix() => WordPrefix(DiscreteChar.Any());
+
+        /// <summary>
+        /// Creates a uniform distribution over either the empty string or any string ending with a non-word character.
+        /// Characters other than the last are restricted to be non-zero probability characters from a given distribution.
+        /// </summary>
+        /// <param name="allowedChars">The distribution representing allowed characters.</param>
+        /// <returns>The created distribution.</returns>
+        public static StringDistribution WordPrefix(DiscreteChar allowedChars) => EmptyOrEndsWith(allowedChars, NonWordCharacter);
+
+        public static StringDistribution EmptyOrEndsWith(DiscreteChar charsInMainString, DiscreteChar endsWith)
+        {
+            // TODO: fix equality and then use factory methods to create this
+            var result = new StringAutomaton.Builder();
+            result.Start.SetEndWeight(Weight.One);
+            var otherState1 = result.Start.AddEpsilonTransition(Weight.One);
+            otherState1.AddSelfTransition(charsInMainString, Weight.FromLogValue(-charsInMainString.GetLogAverageOf(charsInMainString)));
+            var otherState2 = otherState1.AddTransition(endsWith, Weight.FromLogValue(-endsWith.GetLogAverageOf(endsWith)));
+            otherState2.SetEndWeight(Weight.One);
+
+            return StringDistribution.FromWeightFunction(result.GetAutomaton());
+        }
+
+        /// <summary>
+        /// Creates a uniform distribution over either the empty string or any string starting with a non-word character.
+        /// </summary>
+        /// <returns>The created distribution.</returns>
+        public static StringDistribution WordSuffix() => WordSuffix(DiscreteChar.Any());
+
+        /// <summary>
+        /// Creates a uniform distribution over either the empty string or any string starting with a non-word character.
+        /// Characters other than the last are restricted to be non-zero probability characters from a given distribution.
+        /// </summary>
+        /// <param name="allowedChars">The distribution representing allowed characters.</param>
+        /// <returns>The created distribution.</returns>
+        public static StringDistribution WordSuffix(DiscreteChar allowedChars) => EmptyOrStartsWith(allowedChars, NonWordCharacter);
+
+        public static StringDistribution EmptyOrStartsWith(DiscreteChar charsInMainString, DiscreteChar startsWith)
+        {
+            // TODO: fix equality and then use factory methods to create this
+            var result = new StringAutomaton.Builder();
+            result.Start.SetEndWeight(Weight.One);
+            var otherState = result.Start.AddTransition(startsWith, Weight.FromLogValue(-startsWith.GetLogAverageOf(startsWith)));
+            otherState.AddSelfTransition(charsInMainString, Weight.FromLogValue(-charsInMainString.GetLogAverageOf(charsInMainString)));
+            otherState.SetEndWeight(Weight.One);
+
+            return StringDistribution.FromWeightFunction(result.GetAutomaton());
+        }
+
+        /// <summary>
+        /// Creates a uniform distribution over any string starting and ending with a non-word character (possibly of length 1).
+        /// </summary>
+        /// <returns>The created distribution.</returns>
+        public static StringDistribution WordMiddle() => WordMiddle(DiscreteChar.Any());
+
+        /// <summary>
+        /// Creates a uniform distribution over any string starting and ending with a non-word character.
+        /// Characters other than the first and the last are restricted to be non-zero probability characters
+        /// from a given distribution.
+        /// </summary>
+        /// <param name="allowedChars">The distribution representing allowed characters.</param>
+        /// <param name="nonWordCharacter">The word separating characters.</param>
+        /// <returns>The created distribution.</returns>
+        public static StringDistribution WordMiddle(DiscreteChar allowedChars, DiscreteChar? nonWordCharacter = null)
+        {
+            // TODO: fix equality and then use factory methods to create this
+            nonWordCharacter = nonWordCharacter ?? NonWordCharacter;
+            var result = new StringAutomaton.Builder();
+            var otherState1 = result.Start.AddTransition(
+                Option.FromNullable(nonWordCharacter),
+                Weight.FromLogValue(-nonWordCharacter.Value.GetLogAverageOf(nonWordCharacter.Value)));
+            otherState1.SetEndWeight(Weight.One);
+            var otherState2 = otherState1.AddEpsilonTransition(Weight.One)
+                .AddSelfTransition(allowedChars, Weight.FromLogValue(-allowedChars.GetLogAverageOf(allowedChars))).AddTransition(
+                    Option.FromNullable(nonWordCharacter),
+                    Weight.FromLogValue(-nonWordCharacter.Value.GetLogAverageOf(nonWordCharacter.Value)));
+            otherState2.SetEndWeight(Weight.One);
+
+            return StringDistribution.FromWeightFunction(result.GetAutomaton());
+        }
+
+        /// <summary>
+        /// Creates a uniform distribution over any string starting and ending with a non-word character,
+        /// with a length in given bounds.
+        /// </summary>
+        /// <param name="minLength">The minimum allowed string length.</param>
+        /// <param name="maxLength">The maximum allowed string length.</param>
+        /// <returns>The created distribution.</returns>
+        public static StringDistribution WordMiddle(int minLength, int maxLength) => WordMiddle(minLength, maxLength, DiscreteChar.Any());
+
+        /// <summary>
+        /// Creates a uniform distribution over any string starting and ending with a non-word character,
+        /// with a length in given bounds.
+        /// Characters other than the first and the last are restricted to be non-zero probability characters
+        /// from a given distribution.
+        /// </summary>
+        /// <param name="minLength">The minimum allowed string length.</param>
+        /// <param name="maxLength">The maximum allowed string length.</param>
+        /// <param name="allowedChars">The distribution representing allowed characters.</param>
+        /// <returns>The created distribution.</returns>
+        public static StringDistribution WordMiddle(int minLength, int maxLength, DiscreteChar allowedChars)
+        {
+            if (maxLength < minLength)
+            {
+                throw new ArgumentException("The maximum length cannot be less than the minimum length.");
+            }
+
+            if (minLength < 1)
+            {
+                throw new ArgumentException("The minimum length must be at least one.");
+            }
+
+            var nonWordChar = StringDistribution.Char(NonWordCharacter);
+            if ((minLength == 1) && (maxLength == 1))
+            {
+                return nonWordChar;
+            }
+
+            // TODO: make a PartialUniform copy of allowedChars
+            var suffix = StringDistribution.Repeat(allowedChars, minTimes: Math.Max(minLength - 2, 0), maxTimes: maxLength - 2);
+            suffix.AppendInPlace(nonWordChar);
+
+            if (minLength == 1)
+            {
+                var allowedChar = allowedChars.GetMode();
+                var allowedSuffix = new string(Enumerable.Repeat(allowedChar, Math.Max(minLength - 2, 0)).ToArray()) + ' ';
+                var suffixLogProb = suffix.GetLogProb(allowedSuffix);
+                suffix.SetToSumLog(suffixLogProb, StringDistribution.Empty(), 0.0, suffix);
+            }
+
+            return nonWordChar + suffix;
+        }
+    }
+}

--- a/src/Visualizers/Windows/GraphViews/TaskGraphView.cs
+++ b/src/Visualizers/Windows/GraphViews/TaskGraphView.cs
@@ -81,7 +81,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Visualizers
             }
             foreach (IStatement ist in looptasks) AddNode(g, ist, Stage.Update);
             foreach (IStatement ist in pretasks) AddEdges(g, ist, Stage.Initialisation);
-            Set<IStatement> edgesDone = new Set<IStatement>(new IdentityComparer<IStatement>());
+            Set<IStatement> edgesDone = new Set<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
             foreach (IStatement ist in looptasks)
             {
                 if (edgesDone.Contains(ist)) continue;
@@ -172,7 +172,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Visualizers
 
         protected void SetNodeForStatement(IStatement ist, Stage stg, Node nd)
         {
-            if (!stmtNodeMap.ContainsKey(stg)) stmtNodeMap[stg] = new Dictionary<IStatement, Node>(new IdentityComparer<IStatement>());
+            if (!stmtNodeMap.ContainsKey(stg)) stmtNodeMap[stg] = new Dictionary<IStatement, Node>(ReferenceEqualityComparer<IStatement>.Instance);
             stmtNodeMap[stg][ist] = nd;
         }
 

--- a/test/Learners/LearnersTests/MatchboxRecommenderTests.cs
+++ b/test/Learners/LearnersTests/MatchboxRecommenderTests.cs
@@ -1203,36 +1203,38 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
         /// </summary>
         private void InitializeNativeTrainingData()
         {
-            this.nativeTrainingData = new NativeDataset();
-            this.nativeTrainingData.UserIds = new[] { 1, 0, 1, 0, 0, 1 };
-            this.nativeTrainingData.ItemIds = new[] { 1, 0, 2, 3, 2, 3 };
-            this.nativeTrainingData.Ratings = new[] { 0, 1, 2, 3, 4, 5 };
-            this.nativeTrainingData.UserCount = 2;
-            this.nativeTrainingData.ItemCount = 4;
-            this.nativeTrainingData.NonZeroUserFeatureValues = new[]
+            this.nativeTrainingData = new NativeDataset
+            {
+                UserIds = new[] { 1, 0, 1, 0, 0, 1 },
+                ItemIds = new[] { 1, 0, 2, 3, 2, 3 },
+                Ratings = new[] { 0, 1, 2, 3, 4, 5 },
+                UserCount = 2,
+                ItemCount = 4,
+                NonZeroUserFeatureValues = new[]
                 {
                     new[] { 2, 3, 2.3, 3.2, 4 },
                     new[] { 6, 5.4, 4.5, 5, 4 }
-                };
-            this.nativeTrainingData.NonZeroUserFeatureIndices = new[]
+                },
+                NonZeroUserFeatureIndices = new[]
                 {
                     new[] { 0, 1, 2, 3, 4 },
                     new[] { 4, 3, 2, 1, 0 }
-                };
-            this.nativeTrainingData.NonZeroItemFeatureValues = new[]
+                },
+                NonZeroItemFeatureValues = new[]
                 {
                     new[] { 0.2, 0.0 },
                     new[] { 0.0, 0.0 },
                     new[] { 0.2, 0.9 },
                     new[] { 1.2, 1.1 }
-                };
-            this.nativeTrainingData.NonZeroItemFeatureIndices = new[]
+                },
+                NonZeroItemFeatureIndices = new[]
                 {
                     new[] { 0, 1 },
                     new[] { 1, 0 },
                     new[] { 0, 1 },
                     new[] { 1, 0 }
-                };
+                }
+            };
 
             this.nativeMapping = new NativeRecommenderTestMapping();
         }
@@ -1242,8 +1244,9 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
         /// </summary>
         private void InitializeStandardTrainingData()
         {
-            this.standardTrainingData = new StandardDataset();
-            this.standardTrainingData.Observations = new List<Tuple<User, Item, int?>>
+            this.standardTrainingData = new StandardDataset
+            {
+                Observations = new List<Tuple<User, Item, int?>>
                 {
                     new Tuple<User, Item, int?>(User.WithId("u0"), Item.WithId("i0"), 1),
                     new Tuple<User, Item, int?>(User.WithId("u1"), Item.WithId("i1"), 0),
@@ -1251,7 +1254,8 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
                     new Tuple<User, Item, int?>(User.WithId("u0"), Item.WithId("i3"), 3),
                     new Tuple<User, Item, int?>(User.WithId("u0"), Item.WithId("i2"), 4),
                     new Tuple<User, Item, int?>(User.WithId("u1"), Item.WithId("i3"), 5)
-                };
+                }
+            };
 
             this.standardTrainingDataFeatures = new FeatureProvider
                 {

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -82,6 +82,8 @@ namespace TestApp
             Stopwatch watch = new Stopwatch();
             watch.Start();
 
+            new StringFormatTests().StringFormatTest2();
+
             if (false)
             {
                 // Run all tests (need to run in 64-bit else OutOfMemory due to loading many DLLs)

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -82,8 +82,6 @@ namespace TestApp
             Stopwatch watch = new Stopwatch();
             watch.Start();
 
-            new StringFormatTests().StringFormatTest2();
-
             if (false)
             {
                 // Run all tests (need to run in 64-bit else OutOfMemory due to loading many DLLs)

--- a/test/Tests/FactorManagerTests.cs
+++ b/test/Tests/FactorManagerTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         internal void SpeedTest()
         {
             FactorManager.FactorInfo info = FactorManager.GetFactorInfo(new MethodReference(typeof(Factor), "ReplicateWithMarginal<>", typeof(bool[])).GetMethodInfo());
-            IDictionary<string, Type> parameterTypes = new Dictionary<string, Type>();
+            var parameterTypes = new Dictionary<string, Type>();
             Type ba = typeof(DistributionStructArray<Bernoulli, bool>);
             Type baa = typeof(DistributionRefArray<DistributionStructArray<Bernoulli, bool>, bool[]>);
             parameterTypes["Uses"] = baa;
@@ -99,10 +99,12 @@ namespace Microsoft.ML.Probabilistic.Tests
             FactorManager.FactorInfo info = FactorManager.GetFactorInfo(new MethodReference(typeof(Factor), "Not").GetMethodInfo());
             Console.WriteLine(info);
             Assert.True(info.IsDeterministicFactor);
-            IDictionary<string, Type> parameterTypes = new Dictionary<string, Type>();
-            parameterTypes["Not"] = typeof(Bernoulli);
-            parameterTypes["B"] = typeof(Bernoulli);
-            parameterTypes["result"] = typeof(Bernoulli);
+            var parameterTypes = new Dictionary<string, Type>
+            {
+                ["Not"] = typeof(Bernoulli),
+                ["B"] = typeof(Bernoulli),
+                ["result"] = typeof(Bernoulli)
+            };
             MessageFcnInfo fcninfo = info.GetMessageFcnInfo(factorManager, "AverageConditional", "Not", parameterTypes);
             Assert.False(fcninfo.PassResult);
             Assert.False(fcninfo.PassResultIndex);
@@ -115,14 +117,14 @@ namespace Microsoft.ML.Probabilistic.Tests
         public void UnaryFactorInfo()
         {
             FactorManager.FactorInfo info = FactorManager.GetFactorInfo(new MethodReference(typeof(Factor), "Random<>", typeof(bool), typeof(Bernoulli)).GetMethodInfo());
-            Console.WriteLine(info);
             Assert.False(info.IsDeterministicFactor);
-            IDictionary<string, Type> parameterTypes = new Dictionary<string, Type>();
-            parameterTypes["Random"] = typeof(Bernoulli);
-            parameterTypes["dist"] = typeof(Bernoulli);
-            parameterTypes["result"] = typeof(Bernoulli);
+            var parameterTypes = new Dictionary<string, Type>
+            {
+                ["Random"] = typeof(Bernoulli),
+                ["dist"] = typeof(Bernoulli),
+                ["result"] = typeof(Bernoulli)
+            };
             MessageFcnInfo fcninfo = info.GetMessageFcnInfo(factorManager, "AverageConditional", "Random", parameterTypes);
-            Console.WriteLine(fcninfo);
             Assert.False(fcninfo.PassResult);
             Assert.False(fcninfo.PassResultIndex);
             Assert.Equal(1, fcninfo.Dependencies.Count);
@@ -134,24 +136,24 @@ namespace Microsoft.ML.Probabilistic.Tests
             FactorManager.FactorInfo info =
                 FactorManager.GetFactorInfo(new MethodReference(typeof(Constrain), "EqualRandom<,>", typeof(bool), typeof(Bernoulli)).GetMethodInfo());
             Assert.Equal(2, info.ParameterNames.Count);
-            Console.WriteLine(info);
-            IDictionary<string, Type> parameterTypes = new Dictionary<string, Type>();
-            parameterTypes["value"] = typeof(Bernoulli);
-            parameterTypes["dist"] = typeof(Bernoulli);
-            parameterTypes["result"] = typeof(Bernoulli);
+            var parameterTypes = new Dictionary<string, Type>
+            {
+                ["value"] = typeof(Bernoulli),
+                ["dist"] = typeof(Bernoulli),
+                ["result"] = typeof(Bernoulli)
+            };
             MessageFcnInfo fcninfo = info.GetMessageFcnInfo(factorManager, "AverageConditional", "value", parameterTypes);
-            Console.WriteLine(fcninfo);
             Assert.False(fcninfo.PassResult);
             Assert.False(fcninfo.PassResultIndex);
             Assert.Equal(1, fcninfo.Dependencies.Count);
             Assert.Equal(1, fcninfo.Requirements.Count);
 
-            Console.WriteLine();
-            Console.WriteLine("All MessageFcnInfos:");
+            bool verbose = false;
+            if (verbose) Console.WriteLine("All MessageFcnInfos:");
             int count = 0;
             foreach (MessageFcnInfo fcninfo2 in info.GetMessageFcnInfos())
             {
-                Console.WriteLine(fcninfo2);
+                if (verbose) Console.WriteLine(fcninfo2);
                 CheckMessageFcnInfo(fcninfo2, info);
                 count++;
             }
@@ -179,17 +181,17 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             DependencyInformation depInfo;
             FactorManager.FactorInfo info = FactorManager.GetFactorInfo(new MethodReference(typeof(Factor), "Replicate<>", typeof(bool)).GetMethodInfo());
-            Console.WriteLine(info);
             Assert.True(info.IsDeterministicFactor);
-            IDictionary<string, Type> parameterTypes = new Dictionary<string, Type>();
-            parameterTypes["Uses"] = typeof(Bernoulli[]);
-            parameterTypes["Def"] = typeof(Bernoulli);
-            parameterTypes["resultIndex"] = typeof(int);
-            parameterTypes["result"] = typeof(Bernoulli);
+            var parameterTypes = new Dictionary<string, Type>
+            {
+                ["Uses"] = typeof(Bernoulli[]),
+                ["Def"] = typeof(Bernoulli),
+                ["resultIndex"] = typeof(int),
+                ["result"] = typeof(Bernoulli)
+            };
             for (int i = 0; i < 3; i++)
             {
                 MessageFcnInfo fcninfo = info.GetMessageFcnInfo(factorManager, "AverageConditional", "Uses", parameterTypes);
-                Console.WriteLine(fcninfo);
                 Assert.True(fcninfo.PassResult);
                 Assert.True(fcninfo.PassResultIndex);
                 Assert.Equal(2, fcninfo.Dependencies.Count);
@@ -199,12 +201,6 @@ namespace Microsoft.ML.Probabilistic.Tests
                 if (i == 0)
                 {
                     depInfo = FactorManager.GetDependencyInfo(fcninfo.Method);
-                    Console.WriteLine("Dependencies:");
-                    Console.WriteLine(StringUtil.ToString(depInfo.Dependencies));
-                    Console.WriteLine("Requirements:");
-                    Console.WriteLine(StringUtil.ToString(depInfo.Requirements));
-                    Console.WriteLine("Triggers:");
-                    Console.WriteLine(StringUtil.ToString(depInfo.Triggers));
                 }
             }
 
@@ -212,12 +208,12 @@ namespace Microsoft.ML.Probabilistic.Tests
             MessageFcnInfo fcninfo3 = info.GetMessageFcnInfo(factorManager, "AverageConditional", "Def", parameterTypes);
             Assert.True(fcninfo3.SkipIfAllUniform);
 
-            Console.WriteLine();
-            Console.WriteLine("All AverageConditional MessageFcnInfos:");
+            bool verbose = false;
+            if (verbose) Console.WriteLine("All AverageConditional MessageFcnInfos:");
             int count = 0;
             foreach (MessageFcnInfo fcninfo2 in info.GetMessageFcnInfos("AverageConditional", null, null))
             {
-                Console.WriteLine(fcninfo2);
+                if (verbose) Console.WriteLine(fcninfo2);
                 CheckMessageFcnInfo(fcninfo2, info);
                 count++;
             }
@@ -228,27 +224,21 @@ namespace Microsoft.ML.Probabilistic.Tests
         public void ReplicateMessageFcnInfo()
         {
             FactorManager.FactorInfo info = FactorManager.GetFactorInfo(new MethodReference(typeof(Factor), "Replicate<>", typeof(bool)).GetMethodInfo());
-            IDictionary<string, Type> parameterTypes = new Dictionary<string, Type>();
-            parameterTypes["Uses"] = typeof(DistributionArray<Bernoulli>);
-            parameterTypes["Def"] = typeof(Bernoulli);
-            parameterTypes["result"] = typeof(Bernoulli); //typeof(DistributionArray<Bernoulli>);
+            var parameterTypes = new Dictionary<string, Type>
+            {
+                ["Uses"] = typeof(DistributionArray<Bernoulli>),
+                ["Def"] = typeof(Bernoulli),
+                ["result"] = typeof(Bernoulli) //typeof(DistributionArray<Bernoulli>);
+            };
             MessageFcnInfo fcninfo = info.GetMessageFcnInfo(factorManager, "AverageLogarithm", "Def", parameterTypes);
-            Console.WriteLine(fcninfo);
             CheckMessageFcnInfo(fcninfo, info);
 
             parameterTypes["Uses"] = typeof(Bernoulli[]);
             fcninfo = info.GetMessageFcnInfo(factorManager, "AverageLogarithm", "Def", parameterTypes);
-            Console.WriteLine(fcninfo);
             CheckMessageFcnInfo(fcninfo, info);
 
             DependencyInformation depInfo;
             depInfo = FactorManager.GetDependencyInfo(fcninfo.Method);
-            Console.WriteLine("Dependencies:");
-            Console.WriteLine(StringUtil.ToString(depInfo.Dependencies));
-            Console.WriteLine("Requirements:");
-            Console.WriteLine(StringUtil.ToString(depInfo.Requirements));
-            Console.WriteLine("Triggers:");
-            Console.WriteLine(StringUtil.ToString(depInfo.Triggers));
         }
 
         [Fact]
@@ -258,11 +248,13 @@ namespace Microsoft.ML.Probabilistic.Tests
             DependencyInformation depInfo;
             FactorManager.FactorInfo info = FactorManager.GetFactorInfo(new MethodReference(typeof(Factor), "UsesEqualDef<>", typeof(bool)).GetMethodInfo());
             Assert.True(!info.IsDeterministicFactor);
-            IDictionary<string, Type> parameterTypes = new Dictionary<string, Type>();
-            parameterTypes["Uses"] = typeof(Bernoulli[]);
-            parameterTypes["Def"] = typeof(Bernoulli);
-            parameterTypes["resultIndex"] = typeof(int);
-            parameterTypes["result"] = typeof(Bernoulli);
+            var parameterTypes = new Dictionary<string, Type>
+            {
+                ["Uses"] = typeof(Bernoulli[]),
+                ["Def"] = typeof(Bernoulli),
+                ["resultIndex"] = typeof(int),
+                ["result"] = typeof(Bernoulli)
+            };
             for (int i = 0; i < 3; i++)
             {
                 MessageFcnInfo fcninfo = info.GetMessageFcnInfo(factorManager, "AverageLogarithm", "Uses", parameterTypes);
@@ -276,12 +268,6 @@ namespace Microsoft.ML.Probabilistic.Tests
                 if (i == 0)
                 {
                     depInfo = FactorManager.GetDependencyInfo(fcninfo.Method);
-                    Console.WriteLine("Dependencies:");
-                    Console.WriteLine(StringUtil.ToString(depInfo.Dependencies));
-                    Console.WriteLine("Requirements:");
-                    Console.WriteLine(StringUtil.ToString(depInfo.Requirements));
-                    Console.WriteLine("Triggers:");
-                    Console.WriteLine(StringUtil.ToString(depInfo.Triggers));
                 }
             }
             parameterTypes.Remove("resultIndex");
@@ -290,12 +276,6 @@ namespace Microsoft.ML.Probabilistic.Tests
             Assert.Equal(1, fcninfo2.Triggers.Count);
 
             depInfo = FactorManager.GetDependencyInfo(fcninfo2.Method);
-            Console.WriteLine("Dependencies:");
-            Console.WriteLine(StringUtil.ToString(depInfo.Dependencies));
-            Console.WriteLine("Requirements:");
-            Console.WriteLine(StringUtil.ToString(depInfo.Requirements));
-            Console.WriteLine("Triggers:");
-            Console.WriteLine(StringUtil.ToString(depInfo.Triggers));
         }
 
         [Fact]
@@ -303,24 +283,20 @@ namespace Microsoft.ML.Probabilistic.Tests
         public void DifferenceFactorInfo()
         {
             FactorManager.FactorInfo info = FactorManager.GetFactorInfo(new MethodReference(typeof(Factor), "Difference").GetMethodInfo());
-            Console.WriteLine(info);
             Assert.True(info.IsDeterministicFactor);
-            IDictionary<string, Type> parameterTypes = new Dictionary<string, Type>();
-            parameterTypes["Difference"] = typeof(Gaussian);
-            parameterTypes["A"] = typeof(Gaussian);
-            parameterTypes["B"] = typeof(Gaussian);
+            var parameterTypes = new Dictionary<string, Type>
+            {
+                ["Difference"] = typeof(Gaussian),
+                ["A"] = typeof(Gaussian),
+                ["B"] = typeof(Gaussian)
+            };
             //parameterTypes["result"] = typeof(Gaussian);
             MessageFcnInfo fcninfo = info.GetMessageFcnInfo(factorManager, "AverageConditional", "Difference", parameterTypes);
             Assert.False(fcninfo.PassResult);
             Assert.False(fcninfo.PassResultIndex);
             Assert.Equal(2, fcninfo.Dependencies.Count);
             Assert.Equal(2, fcninfo.Requirements.Count);
-            Console.WriteLine(fcninfo);
 
-            Console.WriteLine("Parameter types:");
-            Console.WriteLine(StringUtil.CollectionToString(fcninfo.GetParameterTypes(), ","));
-
-            Console.WriteLine();
             try
             {
                 fcninfo = info.GetMessageFcnInfo(factorManager, "Rubbish", "Difference", parameterTypes);
@@ -333,52 +309,47 @@ namespace Microsoft.ML.Probabilistic.Tests
                 Console.WriteLine("Different exception: " + ex);
             }
 
-            Console.WriteLine();
             Assert.Throws<ArgumentException>(() =>
             {
                 parameterTypes["result"] = typeof(double);
                 fcninfo = info.GetMessageFcnInfo(factorManager, "AverageConditional", "Difference", parameterTypes);
             });
 
-            Console.WriteLine();
-            Console.WriteLine("All messages to A:");
+            bool verbose = false;
+            if (verbose) Console.WriteLine("All messages to A:");
             int count = 0;
             foreach (MessageFcnInfo fcninfo2 in info.GetMessageFcnInfos(null, "A", null))
             {
-                Console.WriteLine(fcninfo2);
+                if (verbose) Console.WriteLine(fcninfo2);
                 CheckMessageFcnInfo(fcninfo2, info);
                 count++;
             }
             //Assert.Equal(8, count);
 
-            Console.WriteLine();
-            Console.WriteLine("All messages to Difference:");
+            if (verbose) Console.WriteLine("All messages to Difference:");
             count = 0;
             foreach (MessageFcnInfo fcninfo2 in info.GetMessageFcnInfos(null, "Difference", null))
             {
-                Console.WriteLine(fcninfo2);
                 CheckMessageFcnInfo(fcninfo2, info);
                 count++;
             }
             Assert.Equal(8, count);
 
-            Console.WriteLine();
-            Console.WriteLine("All AverageConditionals:");
+            if (verbose) Console.WriteLine("All AverageConditionals:");
             count = 0;
             foreach (MessageFcnInfo fcninfo2 in info.GetMessageFcnInfos("AverageConditional", null, null))
             {
-                Console.WriteLine(fcninfo2);
+                if (verbose) Console.WriteLine(fcninfo2);
                 CheckMessageFcnInfo(fcninfo2, info);
                 count++;
             }
             Assert.Equal(12, count);
 
-            Console.WriteLine();
-            Console.WriteLine("All MessageFcnInfos:");
+            if (verbose) Console.WriteLine("All MessageFcnInfos:");
             count = 0;
             foreach (MessageFcnInfo fcninfo2 in info.GetMessageFcnInfos())
             {
-                Console.WriteLine(fcninfo2);
+                if (verbose) Console.WriteLine(fcninfo2);
                 CheckMessageFcnInfo(fcninfo2, info);
                 count++;
             }
@@ -407,20 +378,17 @@ namespace Microsoft.ML.Probabilistic.Tests
         public void IsPositiveFactorInfo()
         {
             FactorManager.FactorInfo info = FactorManager.GetFactorInfo(new Func<double, bool>(Factor.IsPositive));
-            Console.WriteLine(info);
             Assert.True(info.IsDeterministicFactor);
-            IDictionary<string, Type> parameterTypes = new Dictionary<string, Type>();
-            parameterTypes["isPositive"] = typeof(bool);
-            parameterTypes["x"] = typeof(Gaussian);
+            var parameterTypes = new Dictionary<string, Type>
+            {
+                ["isPositive"] = typeof(bool),
+                ["x"] = typeof(Gaussian)
+            };
             MessageFcnInfo fcninfo = info.GetMessageFcnInfo(factorManager, "AverageConditional", "x", parameterTypes);
             Assert.True(fcninfo.NotSupportedMessage == null);
             CheckMessageFcnInfo(fcninfo, info);
 
             DependencyInformation depInfo = FactorManager.GetDependencyInfo(fcninfo.Method);
-            Console.WriteLine("Dependencies:");
-            Console.WriteLine(StringUtil.ToString(depInfo.Dependencies));
-            Console.WriteLine("Requirements:");
-            Console.WriteLine(StringUtil.ToString(depInfo.Requirements));
 
             Assert.Throws<NotSupportedException>(() =>
             {
@@ -444,14 +412,15 @@ namespace Microsoft.ML.Probabilistic.Tests
         internal void ToMessageTest()
         {
             FactorManager.FactorInfo info = FactorManager.GetFactorInfo(new Func<double, bool>(Factor.IsPositive));
-            IDictionary<string, Type> parameterTypes = new Dictionary<string, Type>();
-            parameterTypes["isPositive"] = typeof(bool);
-            parameterTypes["x"] = typeof(Gaussian);
+            var parameterTypes = new Dictionary<string, Type>
+            {
+                ["isPositive"] = typeof(bool),
+                ["x"] = typeof(Gaussian)
+            };
             MessageFcnInfo fcninfo;
             fcninfo = info.GetMessageFcnInfo(factorManager, "LogEvidenceRatio2", "", parameterTypes);
             CheckMessageFcnInfo(fcninfo, info);
             DependencyInformation depInfo = FactorManager.GetDependencyInfo(fcninfo.Method);
-            Console.WriteLine(depInfo);
         }
 
         internal void CheckMessageFcnInfo(MessageFcnInfo fcninfo, FactorManager.FactorInfo info)
@@ -479,9 +448,11 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             FactorManager.FactorInfo info = FactorManager.GetFactorInfo(new MethodReference(typeof(ShiftAlpha), "ToFactor<>").GetMethodInfo());
             Console.WriteLine(info);
-            Dictionary<string, Type> parameterTypes = new Dictionary<string, Type>();
-            parameterTypes["factor"] = typeof(double);
-            parameterTypes["result"] = typeof(double);
+            Dictionary<string, Type> parameterTypes = new Dictionary<string, Type>
+            {
+                ["factor"] = typeof(double),
+                ["result"] = typeof(double)
+            };
             Assert.Throws<ArgumentException>(() =>
             {
                 MessageFcnInfo fcninfo = info.GetMessageFcnInfo(factorManager, "AverageConditional", "Variable", parameterTypes);
@@ -492,10 +463,12 @@ namespace Microsoft.ML.Probabilistic.Tests
         public void MissingMethodFailure()
         {
             FactorManager.FactorInfo info = FactorManager.GetFactorInfo(new Func<double, double, double>(Factor.Gaussian));
-            Dictionary<string, Type> parameterTypes = new Dictionary<string, Type>();
-            parameterTypes["sample"] = typeof(Gaussian);
-            parameterTypes["mean"] = typeof(Gaussian);
-            parameterTypes["precision"] = typeof(Gaussian);
+            Dictionary<string, Type> parameterTypes = new Dictionary<string, Type>
+            {
+                ["sample"] = typeof(Gaussian),
+                ["mean"] = typeof(Gaussian),
+                ["precision"] = typeof(Gaussian)
+            };
             Assert.Throws<ArgumentException>(() =>
             {
                 MessageFcnInfo fcninfo = info.GetMessageFcnInfo(factorManager, "AverageConditional", "Sample", parameterTypes);

--- a/test/Tests/StringFormatTests.cs
+++ b/test/Tests/StringFormatTests.cs
@@ -1,0 +1,291 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    using Xunit;
+    using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;
+
+    using Microsoft.ML.Probabilistic.Distributions;
+    using Microsoft.ML.Probabilistic.Factors.Attributes;
+    using Microsoft.ML.Probabilistic.Factors;
+    using Microsoft.ML.Probabilistic.Math;
+    using Microsoft.ML.Probabilistic.Models;
+
+    public class StringFormatTests
+    {
+        [Fact]
+        [Trait("Category", "OpenBug")]
+        public void HelloWorld()
+        {
+            var a = Variable.Random(WordString()).Named("a");
+            var b = Variable.Random(WordString()).Named("b");
+            var template = Variable.Random(TemplateArgString() + StringDistribution.Char(' ') + TemplateArgString()).Named("template");
+            var c = Variable.StringFormat(template, a, b).Named("c");
+            var c2 = Variable.StringFormat(template, a, b).Named("c2");
+
+            var engine = new InferenceEngine();
+            engine.Compiler.RecommendedQuality = QualityBand.Experimental;
+            engine.Compiler.GivePriorityTo(typeof(ReplicateOp_NoDivide));
+            //engine.Compiler.BrowserMode = BrowserMode.Always;
+            engine.NumberOfIterations = 5;
+            //Console.WriteLine("c="+engine.Infer(c)); // expect Uniform(*)
+
+            c.ObservedValue = "Hello World";
+            Test("a", engine.Infer<IDistribution<string>>(a), "Hello", "World");
+            Test("b", engine.Infer<IDistribution<string>>(b), "Hello", "World");
+            Test("t", engine.Infer<IDistribution<string>>(template), "{0} {1}", "{1} {0}");
+            Test("c2", engine.Infer<IDistribution<string>>(c2), "Hello World", "Hello Hello", "World Hello", "World World");
+
+            b.ObservedValue = "World";
+            TestUnif("a", engine.Infer<IDistribution<string>>(a), "Hello");
+            TestUnif("t", engine.Infer<IDistribution<string>>(template), "{0} {1}");
+            TestUnif("c2", engine.Infer<IDistribution<string>>(c2), "Hello World");
+            b.ClearObservedValue();
+            a.ObservedValue = "Hello";
+            TestUnif("b", engine.Infer<IDistribution<string>>(b), "World");
+            TestUnif("t", engine.Infer<IDistribution<string>>(template), "{0} {1}");
+            TestUnif("c2", engine.Infer<IDistribution<string>>(c2), "Hello World");
+            b.ObservedValue = "World";
+            TestUnif("t", engine.Infer<IDistribution<string>>(template), "{0} {1}");
+            TestUnif("c2", engine.Infer<IDistribution<string>>(c2), "Hello World");
+
+            template.ObservedValue = "{0} {1}";
+            a.ClearObservedValue();
+            b.ClearObservedValue();
+            Test("a", engine.Infer<IDistribution<string>>(a), "Hello");
+            Test("b", engine.Infer<IDistribution<string>>(b), "World");
+            Test("c2", engine.Infer<IDistribution<string>>(c2), "Hello World");
+
+            b.ObservedValue = "World";
+            Test("a", engine.Infer<IDistribution<string>>(a), "Hello");
+            Test("c2", engine.Infer<IDistribution<string>>(c2), "Hello World");
+
+            b.ClearObservedValue();
+            a.ObservedValue = "Hello";
+            Test("b", engine.Infer<IDistribution<string>>(b), "World");
+            Test("c2", engine.Infer<IDistribution<string>>(c2), "Hello World");
+        }
+
+        private static void Test(string name, IDistribution<string> dist, params string[] vals)
+        {
+            var sa = (StringDistribution)dist;
+            Console.Write(name + "=" + sa);
+            double sum = 0;
+            foreach (var s in vals)
+            {
+                var logProb = dist.GetLogProb(s);
+                sum += Math.Exp(logProb);
+            }
+
+            var ok = Math.Abs(sum - 1.0) < 1E-8;
+            var valstr = string.Join("|", vals.Select(s => s + "$").ToArray());
+            Assert.True(ok, $"Result was {sa} should be ({valstr})");
+        }
+
+        private static void TestUnif(string name, IDistribution<string> dist, params string[] vals)
+        {
+            var sa = (StringDistribution)dist;
+            Console.WriteLine(name + "=" + sa);
+            var unifLogProb = -Math.Log(vals.Length);
+            foreach (var s in vals)
+            {
+                StringInferenceTestUtilities.TestLogProbability(sa, unifLogProb, s);
+            }
+        }
+
+        [Fact]
+        public void StringFormatTest1()
+        {
+            var a = Variable.Random(StringDistribution.OneOf("World", "Universe"));
+            var b = Variable.StringFormat("Hello {0}!!", a);
+
+            var engine = new InferenceEngine();
+            engine.Compiler.RecommendedQuality = QualityBand.Experimental;
+            Test("a", engine.Infer<IDistribution<string>>(a), "World", "Universe");
+            Test("b", engine.Infer<IDistribution<string>>(b), "Hello World!!", "Hello Universe!!");
+            a.ObservedValue = "World";
+            Test("b", engine.Infer<IDistribution<string>>(b), "Hello World!!");
+            a.ClearObservedValue();
+            b.ObservedValue = "Hello World!!";
+            Test("a", engine.Infer<IDistribution<string>>(a), "World");
+
+            var a2 = Variable.Random(WordString());
+            var template = Variable.Random(WordStrings.WordPrefix() + StringDistribution.String("{0}") + WordStrings.WordSuffix());
+            var b2 = Variable.StringFormat(template, a2);
+            b2.ObservedValue = "Hello World!!";
+            Test("t", engine.Infer<IDistribution<string>>(template), "Hello {0}!!", "{0}!!", "{0} World!!");
+            Test("a2", engine.Infer<IDistribution<string>>(a2), "Hello", "World", "Hello World");
+            a2.ObservedValue = "World";
+            Test("t", engine.Infer<IDistribution<string>>(template), "Hello {0}!!");
+        }
+
+        [Fact]
+        public void StringFormatTest2()
+        {
+            var templates = Variable.Observed(new string[] { "My name is {0}.", "I'm {0}." });
+            templates.Name = nameof(templates);
+            var a = Variable.Random(StringDistribution.OneOf("John", "Tom"));
+            a.Name = nameof(a);
+            var templateNumber = Variable.DiscreteUniform(templates.Range);
+            templateNumber.Name = nameof(templateNumber);
+            var b = Variable.New<string>().Named("b");
+            using (Variable.Switch(templateNumber))
+            {
+                b.SetTo(Variable.StringFormat(templates[templateNumber], a));
+            }
+
+            var engine = new InferenceEngine();
+            engine.Compiler.GivePriorityTo(typeof(ReplicateOp_NoDivide));
+            engine.Compiler.RecommendedQuality = QualityBand.Experimental;
+            Test("a", engine.Infer<IDistribution<string>>(a), "John", "Tom");
+            Test("b", engine.Infer<IDistribution<string>>(b), "My name is John.", "My name is Tom.", "I'm John.", "I'm Tom.");
+            b.ObservedValue = "My name is John.";
+            var tempNum = engine.Infer<Discrete>(templateNumber);
+            Assert.Equal(new Discrete(1.0, 0.0), tempNum);
+            Test("a", engine.Infer<IDistribution<string>>(a), "John");
+        }
+
+        [Fact]
+        [Trait("Category", "OpenBug")]
+        public void StringFormatTest3()
+        {
+            var T = new Range(2).Named("T");
+            var templates = Variable.Array<string>(T).Named("templates");
+            //templates[T] = Variable.Random(WordStrings.WordPrefix() + StringAutomaton.String("{0}") + WordStrings.WordSuffix()).ForEach(T);
+            templates[T] = Variable.Random(StringDistribution.Any()).ForEach(T);
+            var a = Variable.Random(StringDistribution.OneOf("John", "Tom")).Named("a");
+            var N = new Range(2).Named("N");
+            var templateNumber = Variable.Array<int>(N).Named("templateNumber");
+            var templateNumberPrior = Variable.Observed(new Vector[] { Vector.FromArray(0.4, 0.6), Vector.FromArray(0.6, 0.4) }, N);
+            var b = Variable.Array<string>(N).Named("b");
+            using (Variable.ForEach(N))
+            {
+                templateNumber[N] = Variable.Discrete(T, templateNumberPrior[N]);
+                using (Variable.Switch(templateNumber[N]))
+                {
+                    b[N] = Variable.StringFormat(templates[templateNumber[N]], a);
+                }
+            }
+
+            Variable.ConstrainEqual(templateNumber[0], 0);
+
+            var engine = new InferenceEngine();
+            engine.NumberOfIterations = 5;
+            engine.Compiler.RecommendedQuality = QualityBand.Experimental;
+            engine.Compiler.GivePriorityTo(typeof(ReplicateOp_NoDivide));
+            engine.Compiler.UnrollLoops = true;
+
+            Test("a", engine.Infer<IDistribution<string>>(a), "John", "Tom");
+            Console.WriteLine(engine.Infer(b));
+            b.ObservedValue = new string[] { "My name is John.", "I'm John." };
+            Console.WriteLine(engine.Infer(templateNumber));
+            Console.WriteLine(engine.Infer(templates));
+            Test("a", engine.Infer<IDistribution<string>>(a), "John");
+        }
+
+        // not really a test, but an interesting experiment
+        [Fact]
+        public void StringFormatSimpleTest()
+        {
+            // number of objects
+            var J = new Range(2).Named("J");
+            var names = Variable.Array<string>(J).Named("names");
+            names[J] = Variable.Random(WordString()).ForEach(J);
+
+            Variable.ConstrainEqual(names[0], "John");
+            var i = Variable.DiscreteUniform(J);
+            var template = Variable.Random(StringDistribution.Any());
+            var s = Variable.New<string>();
+            using (Variable.Switch(i))
+            {
+                s.SetTo(Variable.StringFormat(template, names[i]));
+            }
+
+            s.ObservedValue = "John was here";
+
+            var engine = new InferenceEngine { NumberOfIterations = 10 };
+            engine.Compiler.RecommendedQuality = QualityBand.Experimental;
+            engine.Compiler.GivePriorityTo(typeof(ReplicateOp_NoDivide));
+            Console.WriteLine("posterior=" + engine.Infer(i));
+        }
+
+        [Fact]
+        [Trait("Category", "OpenBug")]
+        public void StringFormatTest4()
+        {
+            // number of templates
+            var T = new Range(2).Named("T");
+            var templates = Variable.Array<string>(T).Named("templates");
+            templates[T] = Variable.Random(StringDistribution.Any()).ForEach(T);
+
+            // number of objects
+            var J = new Range(2).Named("J");
+            var names = Variable.Array<string>(J).Named("names");
+            names[J] = Variable.Random(WordString()).ForEach(J);
+
+            // number of strings
+            var N = new Range(3).Named("N");
+            var objectNumber = Variable.Array<int>(N).Named("objectNumber");
+            var templateNumber = Variable.Array<int>(N).Named("templateNumber");
+            var texts = Variable.Array<string>(N).Named("b");
+
+            using (Variable.ForEach(N))
+            {
+                objectNumber[N] = Variable.DiscreteUniform(J);
+                var name = Variable.New<string>().Named("name");
+                using (Variable.Switch(objectNumber[N]))
+                {
+                    name.SetTo(Variable.Copy(names[objectNumber[N]]));
+                }
+
+                templateNumber[N] = Variable.DiscreteUniform(T);
+                using (Variable.Switch(templateNumber[N]))
+                {
+                    texts[N] = Variable.StringFormat(templates[templateNumber[N]], name);
+                }
+            }
+
+            Variable.ConstrainEqual(names[0], "John");
+            Variable.ConstrainEqual(templateNumber[0], 0); // break symmetry
+
+            // Initialise templateNumber to break symmetry
+            Rand.Restart(0);
+            var tempNumInit = new Discrete[N.SizeAsInt];
+            for (var i = 0; i < tempNumInit.Length; i++)
+            {
+                tempNumInit[i] = Discrete.PointMass(Rand.Int(T.SizeAsInt), T.SizeAsInt);
+            }
+
+            templateNumber.InitialiseTo(Distribution<int>.Array(tempNumInit));
+
+            var engine = new InferenceEngine();
+            engine.NumberOfIterations = 15;
+            engine.Compiler.RecommendedQuality = QualityBand.Experimental;
+            engine.Compiler.GivePriorityTo(typeof(ReplicateOp_NoDivide));
+            engine.Compiler.UnrollLoops = true;
+
+            texts.ObservedValue = new string[] { "My name is John", "I'm John", "I'm Tom" };
+            Console.WriteLine("templateNumber: \n" + engine.Infer(templateNumber));
+            Console.WriteLine("objectNumber: \n" + engine.Infer(objectNumber));
+            Console.WriteLine("templates: \n" + engine.Infer(templates));
+            Console.WriteLine("names: \n" + engine.Infer(names));
+        }
+
+        #region Helpers
+
+        private static StringDistribution WordString() => StringDistribution.OneOrMore(DiscreteChar.InRanges("azAZ09  __''\t\r"));
+
+        private static StringDistribution TemplateArgString() =>
+            StringDistribution.Char('{') + StringDistribution.Char(DiscreteChar.Digit()) + StringDistribution.Char('}');
+
+        #endregion
+    }
+}

--- a/test/Tests/Strings/StringFormatTests.cs
+++ b/test/Tests/Strings/StringFormatTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.ML.Probabilistic.Tests
     using Microsoft.ML.Probabilistic.Factors;
     using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Models;
+    using Range = Microsoft.ML.Probabilistic.Models.Range;
 
     public class StringFormatTests
     {

--- a/test/Tests/Strings/WordStringsTests.cs
+++ b/test/Tests/Strings/WordStringsTests.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Tests
+{
+    using System;
+
+    using Xunit;
+    using Assert = Microsoft.ML.Probabilistic.Tests.AssertHelper;
+
+    using Microsoft.ML.Probabilistic.Distributions;
+
+    /// <summary>
+    /// Tests for factory methods defined in the <see cref="WordStrings" /> class.
+    /// </summary>
+    public class WordStringsTests
+    {
+        [Fact]
+        public void WordPrefix()
+        {
+            var wordPrefix = WordStrings.WordPrefix();
+            StringInferenceTestUtilities.TestIfIncludes(wordPrefix, "hello ", string.Empty, "abc.");
+            StringInferenceTestUtilities.TestIfExcludes(wordPrefix, "hello", "hello world", "1 2");
+            Assert.Equal(wordPrefix.GetLogProb(string.Empty), wordPrefix.GetLogProb("hello "));
+            Assert.Equal(wordPrefix.GetLogProb(string.Empty), wordPrefix.GetLogProb("hello world and people in it."));
+        }
+
+        [Fact]
+        public void WordSuffix()
+        {
+            var wordSuffix = WordStrings.WordSuffix();
+            StringInferenceTestUtilities.TestIfIncludes(wordSuffix, " hello", string.Empty, ".abc");
+            StringInferenceTestUtilities.TestIfExcludes(wordSuffix, "hello", "hello world", "1 2");
+            Assert.Equal(wordSuffix.GetLogProb(string.Empty), wordSuffix.GetLogProb(" world"));
+            Assert.Equal(wordSuffix.GetLogProb(string.Empty), wordSuffix.GetLogProb(". and that's it"));
+        }
+
+        [Fact]
+        public void WordMiddle()
+        {
+            var wordMiddle = WordStrings.WordMiddle();
+            StringInferenceTestUtilities.TestIfIncludes(wordMiddle, " hello world ", ". abc.", ". abc. def gh. ", " ", "..");
+            StringInferenceTestUtilities.TestIfExcludes(wordMiddle, "hello", " world", "hi ", "1 2", string.Empty);
+            Assert.Equal(wordMiddle.GetLogProb(" "), wordMiddle.GetLogProb(" world "));
+        }
+
+        [Fact]
+        public void WordMiddleLimitedLength()
+        {
+            const double Eps = 1e-6;
+
+            var wordMiddleLimitedLength1 = WordStrings.WordMiddle(3, 5);
+            StringInferenceTestUtilities.TestIfIncludes(wordMiddleLimitedLength1, " h w ", ". ab.", "...");
+            StringInferenceTestUtilities.TestIfExcludes(
+                wordMiddleLimitedLength1,
+                "hello",
+                " w",
+                "hi ",
+                "1 2",
+                ".",
+                "..",
+                " hello world ",
+                string.Empty);
+            Assert.Equal(wordMiddleLimitedLength1.GetLogProb(" h w "), wordMiddleLimitedLength1.GetLogProb(" h "), Eps);
+
+            var wordMiddleLimitedLength2 = WordStrings.WordMiddle(1, 5);
+            StringInferenceTestUtilities.TestIfIncludes(wordMiddleLimitedLength2, " ", " h w ", ". ab.", "...");
+            StringInferenceTestUtilities.TestIfExcludes(wordMiddleLimitedLength2, "hello", " w", "hi ", "1 2", " hello world ", string.Empty);
+            Assert.Equal(wordMiddleLimitedLength2.GetLogProb("."), wordMiddleLimitedLength2.GetLogProb(" h "), Eps);
+
+            var wordMiddleLimitedLength3 = WordStrings.WordMiddle(1, 2);
+            StringInferenceTestUtilities.TestIfIncludes(wordMiddleLimitedLength3, " ", " .");
+            StringInferenceTestUtilities.TestIfExcludes(wordMiddleLimitedLength3, "hw", " w", "h ", "12", " hello world ", string.Empty);
+            Assert.Equal(wordMiddleLimitedLength3.GetLogProb("."), wordMiddleLimitedLength3.GetLogProb(".."), Eps);
+        }
+
+        [Fact]
+        public void OneOfTest()
+        {
+            var abc = StringDistribution.OneOf("a", "b", "c");
+            var s = abc.ToString();
+            Console.WriteLine("a or b or c:" + s);
+            Assert.Equal("[a|b|c]", s);
+        }
+    }
+}


### PR DESCRIPTION
FactorManager does not allow point mass conversion of the return value argument of EP evidence methods (previously handled by MessageTransform).
Added WordStrings and StringFormatTests.
Renamed IdentityComparer to ReferenceEqualityComparer.
Code cleanup.
