### PR TITLE
CopyPropagationTransform allows substituting a value of different type as long as the context allows it

### DIFF
--- a/src/Compiler/Dynamic/Conversion.cs
+++ b/src/Compiler/Dynamic/Conversion.cs
@@ -361,7 +361,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Reflection
         }
 
         // must be kept in sync with Binding.TypesAssignableFrom
-        public static bool IsAssignableFrom(Type toType, Type fromType, out int subclassCount)
+        private static bool IsAssignableFrom(Type toType, Type fromType, out int subclassCount)
         {
             bool isObject = false;
             subclassCount = 0;

--- a/src/Compiler/Infer/Transforms/ChannelAnalysisTransform.cs
+++ b/src/Compiler/Infer/Transforms/ChannelAnalysisTransform.cs
@@ -100,9 +100,10 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             VariableInformation vi = VariableInformation.GetVariableInformation(context, ivd);
             if (vi.IsStochastic)
             {
-                UsageInfo info = new UsageInfo();
-                info.containers = new Containers(context);
-                usageInfo[ivd] = info;
+                usageInfo[ivd] = new UsageInfo
+                {
+                    containers = new Containers(context)
+                };
             }
             if (Recognizer.GetAncestorIndexOfLoopBeingInitialized(context) != -1)
                 loopVars.Add(ivd);
@@ -139,8 +140,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             // Only register the full indexer expression, not its sub-expressions
             if (Recognizer.IsBeingIndexed(context) || Recognizer.IsBeingMutated(context, expr))
                 return expr;
-            IExpression target;
-            List<IList<IExpression>> indices = Recognizer.GetIndices(expr, out target);
+            List<IList<IExpression>> indices = Recognizer.GetIndices(expr, out IExpression target);
             if (target is IVariableReferenceExpression)
             {
                 IVariableDeclaration ivd = Recognizer.GetVariableDeclaration(target);
@@ -172,9 +172,11 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             // so that uses in disjoint deterministic conditions can get the same number.
             Set<ConditionBinding> bindings = new Set<ConditionBinding>();
             bindings.AddRange(conditionContext);
-            ExpressionWithBinding eb = new ExpressionWithBinding();
-            eb.Expression = expr;
-            eb.Binding = bindings;
+            ExpressionWithBinding eb = new ExpressionWithBinding
+            {
+                Expression = expr,
+                Binding = bindings
+            };
             return info.GetUseNumber(eb, loopVars);
         }
 
@@ -202,7 +204,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             /// Containers of the variable declaration
             /// </summary>
             public Containers containers;
-            public Microsoft.ML.Probabilistic.Collections.SortedSet<int> indexingDepths = new Microsoft.ML.Probabilistic.Collections.SortedSet<int>();
+            public Collections.SortedSet<int> indexingDepths = new Microsoft.ML.Probabilistic.Collections.SortedSet<int>();
             /// <summary>
             /// The set of all uses, organized into groups such that the members of each group are disjoint, i.e.
             /// they access different parts of the variable (such as different elements of an array) or they
@@ -482,10 +484,9 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
             public override bool Equals(object obj)
             {
-                ExpressionWithBinding that = obj as ExpressionWithBinding;
-                if (that == null)
-                    return false;
-                return Expression.Equals(that.Expression) && Binding.Equals(that.Binding);
+                return (obj is ExpressionWithBinding that) &&
+                    Expression.Equals(that.Expression) &&
+                    Binding.Equals(that.Binding);
             }
 
             public override int GetHashCode()

--- a/src/Compiler/Infer/Transforms/DependencyAnalysisTransform.cs
+++ b/src/Compiler/Infer/Transforms/DependencyAnalysisTransform.cs
@@ -865,15 +865,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             if (context.InputAttributes.Has<DeterministicConstraint>(imie))
                 dependencyInformation.IsOutput = true;
 
-            MethodBase method = null;
-            IMethodReferenceExpression imre = null;
-            if (imie.Method is IMethodReferenceExpression)
-            {
-                imre = (IMethodReferenceExpression)imie.Method;
-                IMethodReference imr = imre.Method;
-                method = Builder.ToMethod(imr) as MethodInfo;
-            }
-            if (method == null)
+            if (!(imie.Method is IMethodReferenceExpression imre) ||
+                !(Builder.ToMethod(imre.Method) is MethodInfo method))
             {
                 Error("Could not find method for : " + imie.Method);
                 return imie;

--- a/src/Compiler/Infer/Transforms/DependencyGraph.cs
+++ b/src/Compiler/Infer/Transforms/DependencyGraph.cs
@@ -159,26 +159,25 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         internal static IExpression TargetExpression(IStatement ist)
         {
-            if (ist is IForStatement)
-                return TargetExpression(((IForStatement)ist).Body.Statements[0]);
-            else if (ist is IConditionStatement)
-                return TargetExpression(((IConditionStatement)ist).Then.Statements[0]);
-            else if (ist is IBlockStatement)
-                return TargetExpression(((IBlockStatement)ist).Statements[0]);
-            else if (ist is ICommentStatement)
+            if (ist is IForStatement ifs)
+                return TargetExpression(ifs.Body.Statements[0]);
+            else if (ist is IConditionStatement ics)
+                return TargetExpression(ics.Then.Statements[0]);
+            else if (ist is IBlockStatement ibs)
+                return TargetExpression(ibs.Statements[0]);
+            else if (ist is ICommentStatement icms)
             {
-                ICommentStatement ics = (ICommentStatement)ist;
-                return CodeBuilder.Instance.LiteralExpr(ics.Comment.Text);
+                return CodeBuilder.Instance.LiteralExpr(icms.Comment.Text);
             }
-            else if (ist is IExpressionStatement)
+            else if (ist is IExpressionStatement ies)
             {
-                IExpression expr = ((IExpressionStatement)ist).Expression;
-                if (expr is IAssignExpression)
+                IExpression expr = ies.Expression;
+                if (expr is IAssignExpression iae)
                 {
-                    expr = ((IAssignExpression)expr).Target;
+                    expr = iae.Target;
                 }
-                if (expr is IVariableDeclarationExpression)
-                    return CodeBuilder.Instance.LiteralExpr(((IVariableDeclarationExpression)expr).Variable.Name);
+                if (expr is IVariableDeclarationExpression ivde)
+                    return CodeBuilder.Instance.LiteralExpr(ivde.Variable.Name);
                 else
                     return expr;
             }
@@ -536,8 +535,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 // label 'Cancels' edges
                 foreach (IStatement source in di.GetDependenciesOfType(DependencyType.Cancels))
                 {
-                    int sourceIndex;
-                    if (indexOfNode.TryGetValue(source, out sourceIndex))
+                    if (indexOfNode.TryGetValue(source, out int sourceIndex))
                     {
                         try
                         {
@@ -545,7 +543,11 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                             isCancels[edge] = true;
                             // TODO: this deletion should be done outside of the constructor.
                             if (deleteCancels)
+                            {
                                 isDeleted[edge] = true;
+                                if (debug)
+                                    Trace.WriteLine($"Deleted cancels edge ({sourceIndex},{targetIndex})");
+                            }
                         }
                         catch (AmbiguousEdgeException)
                         {

--- a/src/Compiler/Infer/Transforms/GateAnalysisTransform.cs
+++ b/src/Compiler/Infer/Transforms/GateAnalysisTransform.cs
@@ -33,29 +33,29 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         /// <summary>
         /// The list of bindings made by all conditional statements in the input stack
         /// </summary>
-        private List<ConditionBinding> conditionContext = new List<ConditionBinding>();
+        private readonly List<ConditionBinding> conditionContext = new List<ConditionBinding>();
 
         /// <summary>
         /// The list of open gate blocks.  gateBlockContext.Count &lt;= conditionContext.Count.
         /// </summary>
-        private List<GateBlock> gateBlockContext = new List<GateBlock>();
+        private readonly List<GateBlock> gateBlockContext = new List<GateBlock>();
 
         /// <summary>
         /// A dictionary mapping condition left-hand sides to GateBlocks.  Used to associate multiple conditional statements with the same GateBlock.
         /// </summary>
-        private Dictionary<Set<ConditionBinding>, Dictionary<IExpression, GateBlock>> gateBlocks =
+        private readonly Dictionary<Set<ConditionBinding>, Dictionary<IExpression, GateBlock>> gateBlocks =
             new Dictionary<Set<ConditionBinding>, Dictionary<IExpression, GateBlock>>();
 
         /// <summary>
         /// A dictionary storing the set of conditions in which a variable is declared.  Used for checking that a variable is defined in all conditions.
         /// </summary>
-        private Dictionary<IVariableDeclaration, ICollection<ConditionBinding>> declarationBindings =
+        private readonly Dictionary<IVariableDeclaration, ICollection<ConditionBinding>> declarationBindings =
             new Dictionary<IVariableDeclaration, ICollection<ConditionBinding>>();
 
         /// <summary>
         /// A dictionary storing the set of conditions in which a variable is defined.  Used for checking that a variable is defined in all conditions.
         /// </summary>
-        private Dictionary<IVariableDeclaration, Set<ICollection<ConditionBinding>>> definitionBindings =
+        private readonly Dictionary<IVariableDeclaration, Set<ICollection<ConditionBinding>>> definitionBindings =
             new Dictionary<IVariableDeclaration, Set<ICollection<ConditionBinding>>>();
 
         protected override IStatement ConvertCondition(IConditionStatement ics)
@@ -510,8 +510,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         {
             for (int i = 0; i < context.InputStack.Count; i++)
             {
-                IStatement st = context.InputStack[i].inputElement as IStatement;
-                if (st != null && context.InputAttributes.Get<GateBlock>(st) == gateBlock) return i;
+                if (context.InputStack[i].inputElement is IStatement st && 
+                    context.InputAttributes.Get<GateBlock>(st) == gateBlock) return i;
             }
             return -1;
         }
@@ -533,9 +533,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         /// <returns></returns>
         private IExpression ReplaceLocalIndices(GateBlock gateBlock, IExpression expr)
         {
-            if (expr is IArrayIndexerExpression)
+            if (expr is IArrayIndexerExpression iaie)
             {
-                IArrayIndexerExpression iaie = (IArrayIndexerExpression) expr;
                 IExpression target = ReplaceLocalIndices(gateBlock, iaie.Target);
                 List<IExpression> indices = new List<IExpression>();
                 bool replaced = !ReferenceEquals(target, iaie.Target);
@@ -566,8 +565,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             {
                 IVariableDeclaration ivd = entry.Key;
                 ExpressionWithBindings eb = entry.Value;
-                List<ExpressionWithBindings> ebs;
-                if (gateBlock.variablesUsed.TryGetValue(ivd, out ebs))
+                if (gateBlock.variablesUsed.TryGetValue(ivd, out List<ExpressionWithBindings> ebs))
                 {
                     List<ExpressionWithBindings> keep = new List<ExpressionWithBindings>();
                     foreach (ExpressionWithBindings eb2 in ebs)
@@ -725,12 +723,10 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             {
                 IExpression prefix1 = prefixes1[i];
                 IExpression prefix2 = prefixes2[i];
-                if (prefix1 is IArrayIndexerExpression)
+                if (prefix1 is IArrayIndexerExpression iaie1)
                 {
-                    IArrayIndexerExpression iaie1 = (IArrayIndexerExpression) prefix1;
-                    if (prefix2 is IArrayIndexerExpression)
+                    if (prefix2 is IArrayIndexerExpression iaie2)
                     {
-                        IArrayIndexerExpression iaie2 = (IArrayIndexerExpression) prefix2;
                         if (iaie1.Indices.Count != iaie2.Indices.Count) throw new Exception("Array rank mismatch: " + eb1 + "," + eb2);
                         IList<IExpression> indices = Builder.ExprCollection();
                         for (int ind = 0; ind < iaie1.Indices.Count; ind++)

--- a/src/Compiler/Infer/Transforms/IncrementPruningTransform.cs
+++ b/src/Compiler/Infer/Transforms/IncrementPruningTransform.cs
@@ -24,9 +24,9 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             }
         }
 
-        Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
-        HashSet<IncrementStatement> incrementStatements = new HashSet<IncrementStatement>();
-        HashSet<IStatement> visitedStatements = new HashSet<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
+        readonly Dictionary<IStatement, IStatement> replacements = new Dictionary<IStatement, IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
+        readonly HashSet<IncrementStatement> incrementStatements = new HashSet<IncrementStatement>();
+        readonly HashSet<IStatement> visitedStatements = new HashSet<IStatement>(ReferenceEqualityComparer<IStatement>.Instance);
         bool inWhileLoop;
         int ancestorIndexOfWhile;
 
@@ -97,8 +97,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         protected override IStatement DoConvertStatement(IStatement ist)
         {
-            if (ist is IWhileStatement)
-                return ConvertWhile((IWhileStatement)ist);
+            if (ist is IWhileStatement iws)
+                return ConvertWhile(iws);
             if (replacements.ContainsKey(ist))
                 return null;
             bool isIncrement = context.InputAttributes.Has<IncrementStatement>(ist);
@@ -125,8 +125,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                     // Add to the initializerSet (assuming the non-increment statement is hoisted).
                     // This will only work correctly if the non-increment is in DependencyInformation.Initializers.
                     // This code currently does nothing since InitializerSet is only attached later by SchedulingTransform.
-                    var iws = context.GetAncestor(ancestorIndexOfWhile);
-                    var initializerSet = context.GetAttribute<InitializerSet>(iws);
+                    var iws2 = context.GetAncestor(ancestorIndexOfWhile);
+                    var initializerSet = context.GetAttribute<InitializerSet>(iws2);
                     if (initializerSet != null)
                     {
                         initializerSet.initializers.Add(ist);

--- a/src/Compiler/Infer/Transforms/IncrementTransform.cs
+++ b/src/Compiler/Infer/Transforms/IncrementTransform.cs
@@ -18,7 +18,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
     /// </summary>
     internal class IncrementTransform : ShallowCopyTransform
     {
-        private IncrementAnalysisTransform analysis;
+        private readonly IncrementAnalysisTransform analysis;
         protected Dictionary<object, List<Containers>> containersOfUpdate = new Dictionary<object, List<Containers>>();
         bool isOperatorStatement;
 
@@ -114,7 +114,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
     internal class IncrementAnalysisTransform : ShallowCopyTransform
     {
-        private ModelCompiler compiler;
+        private readonly ModelCompiler compiler;
         /// <summary>
         /// Maps from variable/field declaration to increment statement, or null if loop ended before variable was updated.
         /// </summary>

--- a/src/Compiler/Infer/Transforms/IterationTransform.cs
+++ b/src/Compiler/Infer/Transforms/IterationTransform.cs
@@ -223,7 +223,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             IndexedProperty<NodeIndex, bool> isUniform = graph2.CreateNodeData<bool>(true);
             foreach (StatementBlock block in blocks)
             {
-                if (block is Loop)
+                if (block is Loop loop)
                 {
                     foreach (NodeIndex i in block.indices)
                     {
@@ -255,9 +255,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                             // add all statements in sc3 to whileBody, but remove while loops around a single statement.
                             foreach (IStatement ist in sc3)
                             {
-                                if (ist is IWhileStatement)
+                                if (ist is IWhileStatement iws2)
                                 {
-                                    IWhileStatement iws2 = (IWhileStatement)ist;
                                     if (iws2.Body.Statements.Count == 1)
                                     {
                                         whileBody.AddRange(iws2.Body.Statements);
@@ -280,7 +279,6 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                         }
                         RegisterUnchangedStatements(whileBody);
                     }
-                    Loop loop = (Loop)block;
                     if (firstIterPostprocessing != null && firstIterPostprocessing.ContainsKey(loop))
                     {
                         var thenBlock = firstIterPostprocessing[loop];

--- a/src/Compiler/Infer/Transforms/LocalAllocationTransform.cs
+++ b/src/Compiler/Infer/Transforms/LocalAllocationTransform.cs
@@ -11,7 +11,6 @@ using Microsoft.ML.Probabilistic.Collections;
 using Microsoft.ML.Probabilistic.Compiler.Attributes;
 using Microsoft.ML.Probabilistic.Compiler.Graphs;
 using Microsoft.ML.Probabilistic.Utilities;
-using Microsoft.ML.Probabilistic.Compiler;
 using Microsoft.ML.Probabilistic.Compiler.CodeModel;
 using NodeIndex = System.Int32;
 using EdgeIndex = System.Int32;
@@ -38,7 +37,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         }
 
         internal static bool debug;
-        private ModelCompiler compiler;
+        private readonly ModelCompiler compiler;
         private LoopMergingInfo loopMergingInfo;
         private DependencyGraph2 g;
         private IndexedGraph dependencyGraph;

--- a/src/Compiler/Infer/Transforms/LocalTransform.cs
+++ b/src/Compiler/Infer/Transforms/LocalTransform.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.ML.Probabilistic.Compiler.Attributes;
-using Microsoft.ML.Probabilistic.Compiler;
 using Microsoft.ML.Probabilistic.Collections;
 using Microsoft.ML.Probabilistic.Utilities;
 using Microsoft.ML.Probabilistic.Compiler.CodeModel;
@@ -41,8 +40,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 
         internal static bool debug;
         private Dictionary<IStatement, Dictionary<IExpression, LocalAnalysisTransform.LocalInfo>> localInfoOfStmt;
-        private Stack<IStatement> openContainers = new Stack<IStatement>();
-        private ModelCompiler compiler;
+        private readonly Stack<IStatement> openContainers = new Stack<IStatement>();
+        private readonly ModelCompiler compiler;
         private bool isTransformingContainer;
 
         internal LocalTransform(ModelCompiler compiler)

--- a/src/Compiler/Infer/Transforms/LoggingTransform.cs
+++ b/src/Compiler/Infer/Transforms/LoggingTransform.cs
@@ -5,13 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Microsoft.ML.Probabilistic.Collections;
-using Microsoft.ML.Probabilistic.Compiler.Attributes;
-using Microsoft.ML.Probabilistic.Utilities;
-using Microsoft.ML.Probabilistic.Compiler;
 using Microsoft.ML.Probabilistic.Compiler.CodeModel;
-using System.IO;
-using System.Reflection;
 
 namespace Microsoft.ML.Probabilistic.Compiler.Transforms
 {

--- a/src/Compiler/Infer/Transforms/SchedulingTransform.cs
+++ b/src/Compiler/Infer/Transforms/SchedulingTransform.cs
@@ -297,8 +297,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                     }
                 }
             }
-            List<NodeIndex> initSchedule;
-            List<NodeIndex> schedule = Schedule(g, inputStmts, offsetVarsToDelete, out initSchedule, out bool isCyclic, groupOf2);
+            List<NodeIndex> schedule = Schedule(g, inputStmts, offsetVarsToDelete, out List<int> initSchedule, out bool isCyclic, groupOf2);
             if (schedule == null)
             {
                 schedule = new List<NodeIndex>(new Range(0, inputStmts.Count));
@@ -382,9 +381,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 // if a DependencyInformation refers to an inner statement of a block, make it refer to the block instead
                 foreach (IStatement stmt in inputStmts)
                 {
-                    if (stmt is IWhileStatement)
+                    if (stmt is IWhileStatement iws)
                     {
-                        IWhileStatement iws = (IWhileStatement)stmt;
                         ForEachStatement(iws.Body.Statements, ist => replacements[ist] = iws);
                     }
                 }

--- a/src/Compiler/Infer/Transforms/StocAnalysisTransform.cs
+++ b/src/Compiler/Infer/Transforms/StocAnalysisTransform.cs
@@ -35,12 +35,12 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             get { return "StocAnalysisTransform"; }
         }
 
-        private Set<IVariableDeclaration> varsWithConstantDefinition = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
-        private Dictionary<IVariableDeclaration, int> stochasticConditionsOf = new Dictionary<IVariableDeclaration, int>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
+        private readonly Set<IVariableDeclaration> varsWithConstantDefinition = new Set<IVariableDeclaration>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
+        private readonly Dictionary<IVariableDeclaration, int> stochasticConditionsOf = new Dictionary<IVariableDeclaration, int>(ReferenceEqualityComparer<IVariableDeclaration>.Instance);
         private int numberOfStochasticConditions;
-        private bool convertConstants;
+        private readonly bool convertConstants;
         // for DistributionAnalysis
-        private Set<IVariableDeclaration> loopVars = new Set<IVariableDeclaration>();
+        private readonly Set<IVariableDeclaration> loopVars = new Set<IVariableDeclaration>();
         private bool inPartialLoop;
 
         internal StocAnalysisTransform(bool convertConstants = false)
@@ -53,9 +53,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             for (int argIndex = 0; argIndex < imie.Arguments.Count; argIndex++)
             {
                 IExpression arg = imie.Arguments[argIndex];
-                if (arg is IAddressOutExpression)
+                if (arg is IAddressOutExpression iaoe)
                 {
-                    IAddressOutExpression iaoe = (IAddressOutExpression)arg;
                     IExpression target = iaoe.Expression;
                     bool targetHasLiteralIndices = inPartialLoop;
                     object targetDecl = Recognizer.GetDeclaration(target);
@@ -65,8 +64,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                     {
                         SetMarginalPrototype(target, targetDecl, mpa, mpa2, targetHasLiteralIndices);
                     }
-                    IVariableDeclaration ivd = targetDecl as IVariableDeclaration;
-                    if (ivd != null)
+                    if (targetDecl is IVariableDeclaration ivd)
                     {
                         SetStoch(target, CodeRecognizer.IsStochastic(context, imie) || IsStochContext(ivd));
                     }
@@ -128,11 +126,10 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 else if (domainType.Equals(typeof(int)))
                 {
                     Type distType = typeof(Discrete);
-                    Exception exception;
-                    MethodInfo method = (MethodInfo)Microsoft.ML.Probabilistic.Compiler.Reflection.Invoker.GetBestMethod(distType, "PointMass",
-                                                                                             BindingFlags.Public | BindingFlags.Static | BindingFlags.InvokeMethod |
-                                                                                             BindingFlags.FlattenHierarchy,
-                                                                                             null, new Type[] { domainType, typeof(int) }, out exception);
+                    MethodInfo method = (MethodInfo)Reflection.Invoker.GetBestMethod(distType, "PointMass",
+                        BindingFlags.Public | BindingFlags.Static | BindingFlags.InvokeMethod |
+                        BindingFlags.FlattenHierarchy,
+                        null, new Type[] { domainType, typeof(int) }, out Exception exception);
                     if (method != null)
                     {
                         IExpression cardinalityExpression = GetIntCardinalityExpression(rhs, ae.Target, targetHasLiteralIndices);
@@ -153,9 +150,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             if (ipd == null)
             {
                 bool setStoch = true;
-                if (ae.Expression is IArrayCreateExpression)
+                if (ae.Expression is IArrayCreateExpression iace)
                 {
-                    IArrayCreateExpression iace = (IArrayCreateExpression)ae.Expression;
                     // Array creation with no initialiser can be either for stochastic or deterministic
                     // variables, so just return without marking the variable.
                     if (iace.Initializer == null) setStoch = false;
@@ -195,9 +191,9 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         protected void SetStoch(IExpression expr, bool stoch)
         {
             if (expr is IArgumentReferenceExpression) return;
-            if (expr is IArrayIndexerExpression)
+            if (expr is IArrayIndexerExpression iaie)
             {
-                SetStoch(((IArrayIndexerExpression)expr).Target, stoch);
+                SetStoch(iaie.Target, stoch);
                 return;
             }
             IVariableDeclaration ivd = Recognizer.GetVariableDeclaration(expr);
@@ -601,7 +597,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                     }
 
                     Type tp = CodeBuilder.MakeJaggedArrayType(sourceType, sizes2);
-                    string name = (targetDecl is IParameterDeclaration) ? ((IParameterDeclaration)targetDecl).Name : ((IVariableDeclaration)targetDecl).Name;
+                    string name = (targetDecl is IParameterDeclaration ipd) ? ipd.Name : ((IVariableDeclaration)targetDecl).Name;
                     name = VariableInformation.GenerateName(context, name + "_mp");
                     mpVar = Builder.VarDecl(name, tp);
                     IList<IStatement> stmts = Builder.StmtCollection();
@@ -1367,8 +1363,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 else if ((mp.prototype is GammaPower) || typeof(GammaPower).IsAssignableFrom(mp.prototypeExpression.GetExpressionType()))
                 {
                     IExpression powerExpression;
-                    if (mp.prototype is GammaPower)
-                        powerExpression = Builder.LiteralExpr(((GammaPower)mp.prototype).Power);
+                    if (mp.prototype is GammaPower gp)
+                        powerExpression = Builder.LiteralExpr(gp.Power);
                     else
                         powerExpression = GetGammaPowerExpression(mp.prototypeExpression);
                     powerExpression = Builder.BinaryExpr(BinaryOperator.Multiply, powerExpression, imie.Arguments[1]);
@@ -1457,16 +1453,14 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 (mpa2.prototypeExpression != null && mpa2.prototypeExpression.Equals(mpa.prototypeExpression));
             if (compatible && mpa2.prototype != mpa.prototype)
             {
-                SettableToUniform prototype = mpa.prototype as SettableToUniform;
-                SettableToUniform prototype2 = mpa2.prototype as SettableToUniform;
-                if (prototype == null || prototype2 == null)
-                    compatible = false;
-                else
+                if (mpa.prototype is SettableToUniform prototype && mpa2.prototype is SettableToUniform prototype2)
                 {
                     prototype.SetToUniform();
                     prototype2.SetToUniform();
                     compatible = prototype.Equals(prototype2);
                 }
+                else
+                    compatible = false;
             }
             return compatible;
         }
@@ -1612,14 +1606,12 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
         /// <returns></returns>
         protected IExpression ReplaceIndices(Containers containers, Set<IVariableDeclaration> keepVars, IExpression expr)
         {
-            if (expr is ICastExpression)
+            if (expr is ICastExpression ice)
             {
-                ICastExpression ice = (ICastExpression)expr;
                 return Builder.CastExpr(ReplaceIndices(containers, keepVars, ice.Expression), ice.TargetType);
             }
-            else if (expr is IArrayIndexerExpression)
+            else if (expr is IArrayIndexerExpression iaie)
             {
-                IArrayIndexerExpression iaie = (IArrayIndexerExpression)expr;
                 IExpression[] newIndices = new IExpression[iaie.Indices.Count];
                 for (int i = 0; i < newIndices.Length; i++)
                 {
@@ -1627,9 +1619,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 }
                 return Builder.ArrayIndex(ReplaceIndices(containers, keepVars, iaie.Target), newIndices);
             }
-            else if (expr is IMethodInvokeExpression)
+            else if (expr is IMethodInvokeExpression imie)
             {
-                IMethodInvokeExpression imie = (IMethodInvokeExpression)expr;
                 IMethodInvokeExpression imie2 = Builder.MethodInvkExpr();
                 imie2.Method = imie.Method;
                 if (imie.Method.Method.Name.Equals("get_Item"))
@@ -1648,9 +1639,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 }
                 return imie2;
             }
-            else if (expr is IPropertyReferenceExpression)
+            else if (expr is IPropertyReferenceExpression ipre)
             {
-                IPropertyReferenceExpression ipre = (IPropertyReferenceExpression)expr;
                 return Builder.PropRefExpr(ReplaceIndices(containers, keepVars, ipre.Target), ipre.Property);
             }
             return expr;
@@ -1682,11 +1672,10 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                     return Builder.LiteralExpr(0);
                 }
             }
-            else if (expr is IArrayIndexerExpression)
+            else if (expr is IArrayIndexerExpression iaie)
             {
-                IArrayIndexerExpression iaie = (IArrayIndexerExpression)expr;
                 IExpression target = ReplaceVarsNotContained(containers, keepVars, iaie.Target);
-                if (target is ILiteralExpression && ((ILiteralExpression)target).Value.Equals(0))
+                if (target is ILiteralExpression ile && ile.Value.Equals(0))
                     return Builder.LiteralExpr(0);
                 else
                 {
@@ -1786,20 +1775,17 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             MarginalPrototype mpa = GetMarginalPrototype(source, targetDecl);
             if (mpa != null)
             {
-                if (mpa.prototype is Microsoft.ML.Probabilistic.Distributions.Dirichlet)
+                if (mpa.prototype is Dirichlet d)
                 {
-                    Microsoft.ML.Probabilistic.Distributions.Dirichlet d = (Microsoft.ML.Probabilistic.Distributions.Dirichlet)mpa.prototype;
                     return Builder.LiteralExpr(d.Dimension);
                 }
-                else if (mpa.prototype is Microsoft.ML.Probabilistic.Distributions.VectorGaussian)
+                else if (mpa.prototype is VectorGaussian vg)
                 {
-                    Microsoft.ML.Probabilistic.Distributions.VectorGaussian d = (Microsoft.ML.Probabilistic.Distributions.VectorGaussian)mpa.prototype;
-                    return Builder.LiteralExpr(d.Dimension);
+                    return Builder.LiteralExpr(vg.Dimension);
                 }
-                else if (mpa.prototype is Microsoft.ML.Probabilistic.Distributions.SparseGaussianList)
+                else if (mpa.prototype is SparseGaussianList sgl)
                 {
-                    Microsoft.ML.Probabilistic.Distributions.SparseGaussianList d = (Microsoft.ML.Probabilistic.Distributions.SparseGaussianList)mpa.prototype;
-                    return Builder.LiteralExpr(d.Dimension);
+                    return Builder.LiteralExpr(sgl.Dimension);
                 }
                 else if (mpa.prototype == null && mpa.prototypeExpression != null)
                 {
@@ -1809,15 +1795,15 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                     if (lengthExpr == null)
                         lengthExpr = GetVectorGaussianLengthExpression(mpe);
                     if (lengthExpr == null)
-                        lengthExpr = GetSparseListLengthExpression(mpe, new Func<int, Microsoft.ML.Probabilistic.Distributions.SparseGaussianList>(Microsoft.ML.Probabilistic.Distributions.SparseGaussianList.FromSize));
+                        lengthExpr = GetSparseListLengthExpression(mpe, new Func<int, SparseGaussianList>(SparseGaussianList.FromSize));
                     if (lengthExpr == null)
-                        lengthExpr = GetSparseListLengthExpression(mpe, new Func<int, Microsoft.ML.Probabilistic.Distributions.SparseGammaList>(Microsoft.ML.Probabilistic.Distributions.SparseGammaList.FromSize));
+                        lengthExpr = GetSparseListLengthExpression(mpe, new Func<int, SparseGammaList>(SparseGammaList.FromSize));
                     if (lengthExpr == null)
-                        lengthExpr = GetSparseListLengthExpression(mpe, new Func<int, Microsoft.ML.Probabilistic.Distributions.SparseBernoulliList>(Microsoft.ML.Probabilistic.Distributions.SparseBernoulliList.FromSize));
+                        lengthExpr = GetSparseListLengthExpression(mpe, new Func<int, SparseBernoulliList>(SparseBernoulliList.FromSize));
                     if (lengthExpr == null)
-                        lengthExpr = GetSparseListLengthExpression(mpe, new Func<int, Microsoft.ML.Probabilistic.Distributions.SparseBetaList>(Microsoft.ML.Probabilistic.Distributions.SparseBetaList.FromSize));
+                        lengthExpr = GetSparseListLengthExpression(mpe, new Func<int, SparseBetaList>(SparseBetaList.FromSize));
                     if (lengthExpr == null)
-                        lengthExpr = GetSparseListLengthExpression(mpe, new Func<int, Microsoft.ML.Probabilistic.Distributions.BernoulliIntegerSubset>(Microsoft.ML.Probabilistic.Distributions.BernoulliIntegerSubset.FromSize));
+                        lengthExpr = GetSparseListLengthExpression(mpe, new Func<int, BernoulliIntegerSubset>(BernoulliIntegerSubset.FromSize));
                     if (lengthExpr != null && !HasExtraIndices(lengthExpr, targetDecl))
                     {
                         return lengthExpr;
@@ -1858,25 +1844,24 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             MarginalPrototype mpa = GetMarginalPrototype(source, targetDecl);
             if (mpa != null)
             {
-                if (mpa.prototype is Microsoft.ML.Probabilistic.Distributions.Discrete)
+                if (mpa.prototype is Discrete d)
                 {
-                    Microsoft.ML.Probabilistic.Distributions.Discrete d = (Microsoft.ML.Probabilistic.Distributions.Discrete)mpa.prototype;
                     return Builder.LiteralExpr(d.Dimension);
                 }
                 else if (mpa.prototype == null && mpa.prototypeExpression != null)
                 {
                     IExpression discreteExpression = mpa.prototypeExpression;
-                    if (Recognizer.IsStaticMethod(discreteExpression, typeof(Microsoft.ML.Probabilistic.Distributions.Discrete), "Uniform"))
+                    if (Recognizer.IsStaticMethod(discreteExpression, typeof(Discrete), "Uniform"))
                     {
                         IMethodInvokeExpression imie = (IMethodInvokeExpression)discreteExpression;
                         return imie.Arguments[0];
                     }
-                    if (Recognizer.IsStaticMethod(discreteExpression, typeof(Microsoft.ML.Probabilistic.Distributions.Discrete), "PointMass"))
+                    if (Recognizer.IsStaticMethod(discreteExpression, typeof(Discrete), "PointMass"))
                     {
                         IMethodInvokeExpression imie = (IMethodInvokeExpression)discreteExpression;
                         return imie.Arguments[1];
                     }
-                    return Builder.PropRefExpr(discreteExpression, typeof(Microsoft.ML.Probabilistic.Distributions.Discrete), "Dimension", typeof(int));
+                    return Builder.PropRefExpr(discreteExpression, typeof(Discrete), "Dimension", typeof(int));
                 }
             }
             if (!CodeRecognizer.IsStochastic(context, source) && !ReferenceEquals(source, targetDecl))
@@ -1899,22 +1884,21 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                 MarginalPrototype mpa = GetMarginalPrototype(source, targetDecl);
                 if (mpa != null)
                 {
-                    if (mpa.prototype is Microsoft.ML.Probabilistic.Distributions.Wishart)
+                    if (mpa.prototype is Wishart w)
                     {
-                        Microsoft.ML.Probabilistic.Distributions.Wishart d = (Microsoft.ML.Probabilistic.Distributions.Wishart)mpa.prototype;
-                        return Builder.LiteralExpr(d.Dimension);
+                        return Builder.LiteralExpr(w.Dimension);
                     }
                     else if (mpa.prototype == null && mpa.prototypeExpression != null)
                     {
                         IExpression wishartExpression = mpa.prototypeExpression;
                         if (typeof(Wishart).IsAssignableFrom(wishartExpression.GetExpressionType()))
                         {
-                            if (Recognizer.IsStaticMethod(wishartExpression, typeof(Microsoft.ML.Probabilistic.Distributions.Wishart), "Uniform"))
+                            if (Recognizer.IsStaticMethod(wishartExpression, typeof(Wishart), "Uniform"))
                             {
                                 IMethodInvokeExpression imie = (IMethodInvokeExpression)wishartExpression;
                                 return imie.Arguments[0];
                             }
-                            return Builder.PropRefExpr(wishartExpression, typeof(Microsoft.ML.Probabilistic.Distributions.Wishart), "Dimension", typeof(int));
+                            return Builder.PropRefExpr(wishartExpression, typeof(Wishart), "Dimension", typeof(int));
                         }
                     }
                 }
@@ -1954,7 +1938,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                     return ReplaceIndices(size, targetDecl);
                 }
                 // fall through
-                arrayType = (sourceDecl is IVariableDeclaration) ? ((IVariableDeclaration)sourceDecl).VariableType.DotNetType : ((IParameterDeclaration)sourceDecl).ParameterType.DotNetType;
+                arrayType = (sourceDecl is IVariableDeclaration ivd) ? ivd.VariableType.DotNetType : ((IParameterDeclaration)sourceDecl).ParameterType.DotNetType;
                 for (int bracket = 0; bracket < depth; bracket++)
                 {
                     arrayType = arrayType.GetElementType();

--- a/src/Compiler/TransformFramework/CodeModel/ArrayIndexerExpression.cs
+++ b/src/Compiler/TransformFramework/CodeModel/ArrayIndexerExpression.cs
@@ -85,7 +85,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.CodeModel.Concrete
             if (arrayType.IsArray)
                 return arrayType.GetElementType();
             else
-                return Microsoft.ML.Probabilistic.Utilities.Util.GetElementType(arrayType);
+                return Utilities.Util.GetElementType(arrayType);
         }
     }
 }

--- a/src/Compiler/TransformFramework/CodeModel/MethodInstanceReference.cs
+++ b/src/Compiler/TransformFramework/CodeModel/MethodInstanceReference.cs
@@ -183,10 +183,10 @@ namespace Microsoft.ML.Probabilistic.Compiler.CodeModel.Concrete
             if (GenericArguments.Count > 0)
             {
                 genericArgString.Append("<");
-                genericArgString.Append(GenericArguments);
+                genericArgString.Append(StringUtil.CollectionToString(GenericArguments, ","));
                 genericArgString.Append(">");
             }
-            return "MethodInstanceReference: " + GenericMethod + genericArgString + "(" + Parameters + ")";
+            return "MethodInstanceReference: " + GenericMethod + genericArgString + Util.CollectionToString(Parameters);
         }
 
         public override bool Equals(object obj)

--- a/src/Compiler/TransformFramework/CodeModel/MethodInvokeExpression.cs
+++ b/src/Compiler/TransformFramework/CodeModel/MethodInvokeExpression.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Microsoft.ML.Probabilistic.Compiler.CodeModel;
 
 namespace Microsoft.ML.Probabilistic.Compiler.CodeModel.Concrete
 {

--- a/src/Compiler/TransformFramework/CodeModel/ParameterDeclaration.cs
+++ b/src/Compiler/TransformFramework/CodeModel/ParameterDeclaration.cs
@@ -89,7 +89,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.CodeModel.Concrete
         /// <returns></returns>
         public override string ToString()
         {
-            ILanguageWriter writer = new CSharpWriter() as ILanguageWriter;
+            var writer = new CSharpWriter();
             return writer.ParameterDeclarationSource(this);
         }
 

--- a/src/Compiler/TransformFramework/CodeRecognizer.cs
+++ b/src/Compiler/TransformFramework/CodeRecognizer.cs
@@ -81,15 +81,13 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns></returns>
         public bool IsStaticGenericMethod(IExpression expr, Type type, string methodName)
         {
-            if (!(expr is IMethodInvokeExpression))
+            if (!(expr is IMethodInvokeExpression imie))
                 return false;
-            IMethodInvokeExpression imie = (IMethodInvokeExpression)expr;
-            if (!(imie.Method is IMethodReferenceExpression))
+            if (!(imie.Method is IMethodReferenceExpression imre))
                 return false;
-            IMethodReferenceExpression imre = (IMethodReferenceExpression)imie.Method;
-            if (!(imre.Target is ITypeReferenceExpression))
+            if (!(imre.Target is ITypeReferenceExpression itre))
                 return false;
-            ITypeReference itr = ((ITypeReferenceExpression)imre.Target).Type;
+            ITypeReference itr = itre.Type;
             if (itr.Namespace != type.Namespace)
                 return false;
             if (itr.GenericType is ITypeReference)
@@ -107,15 +105,12 @@ namespace Microsoft.ML.Probabilistic.Compiler
 
         public string GetStaticMethodOfType(IExpression expr, Type type)
         {
-            if (!(expr is IMethodInvokeExpression))
+            if (!(expr is IMethodInvokeExpression imie))
                 return null;
-            IMethodInvokeExpression mie = (IMethodInvokeExpression)expr;
-            if (!(mie.Method is IMethodReferenceExpression))
+            if (!(imie.Method is IMethodReferenceExpression imre))
                 return null;
-            IMethodReferenceExpression imre = (IMethodReferenceExpression)mie.Method;
-            if (!(imre.Target is ITypeReferenceExpression))
+            if (!(imre.Target is ITypeReferenceExpression itre))
                 return null;
-            ITypeReferenceExpression itre = (ITypeReferenceExpression)imre.Target;
             if (!IsTypeReferenceTo(itre, type))
                 return null;
             return imre.Method.Name;
@@ -123,23 +118,20 @@ namespace Microsoft.ML.Probabilistic.Compiler
 
         public ITypeReference GetStaticMethodType(IExpression expr)
         {
-            if (!(expr is IMethodInvokeExpression))
+            if (!(expr is IMethodInvokeExpression imie))
                 return null;
-            IMethodInvokeExpression mie = (IMethodInvokeExpression)expr;
-            if (!(mie.Method is IMethodReferenceExpression))
+            if (!(imie.Method is IMethodReferenceExpression imre))
                 return null;
-            IMethodReferenceExpression imre = (IMethodReferenceExpression)mie.Method;
-            if (!(imre.Target is ITypeReferenceExpression))
+            if (!(imre.Target is ITypeReferenceExpression itre))
                 return null;
-            ITypeReferenceExpression itre = (ITypeReferenceExpression)imre.Target;
             return itre.Type;
         }
 
         public IMethodReference GetMethodReference(IExpression expr)
         {
-            if (!(expr is IMethodInvokeExpression mie))
+            if (!(expr is IMethodInvokeExpression imie))
                 return null;
-            if (!(mie.Method is IMethodReferenceExpression imre))
+            if (!(imie.Method is IMethodReferenceExpression imre))
                 return null;
             return imre.Method;
         }
@@ -181,8 +173,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
             if (expr is IVariableReferenceExpression && bounds != null)
             {
                 IVariableDeclaration ivd = GetVariableDeclaration(expr);
-                Bounds b;
-                if (bounds.TryGetValue(ivd, out b))
+                if (bounds.TryGetValue(ivd, out Bounds b))
                     return b;
             }
             else if (expr is IBinaryExpression ibe)
@@ -225,8 +216,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
 
         private IVariableDeclaration GetOffsetVariable(IExpression expr)
         {
-            int offset;
-            return GetOffsetVariable(expr, out offset);
+            return GetOffsetVariable(expr, out int offset);
         }
 
         private IVariableDeclaration GetOffsetVariable(IExpression expr, out int offset)
@@ -238,8 +228,9 @@ namespace Microsoft.ML.Probabilistic.Compiler
             }
             else if (expr is IBinaryExpression indexBinaryExpr)
             {
-                ILiteralExpression offsetExpr = indexBinaryExpr.Right as ILiteralExpression;
-                if (indexBinaryExpr.Left is IVariableReferenceExpression ivre && offsetExpr != null && offsetExpr.Value is int)
+                if (indexBinaryExpr.Left is IVariableReferenceExpression ivre && 
+                    indexBinaryExpr.Right is ILiteralExpression offsetExpr && 
+                    offsetExpr.Value is int)
                 {
                     offset = (int)offsetExpr.Value;
                     if (indexBinaryExpr.Operator == BinaryOperator.Subtract)
@@ -291,7 +282,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 }
                 if (IsStaticMethod(affected_index, AnyIndexMethod))
                     continue;
-                if (affected_index is ILiteralExpression)
+                if (affected_index is ILiteralExpression affected_literal)
                 {
                     if (mutated_index is ILiteralExpression)
                     {
@@ -302,7 +293,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
                     {
                         if (mutatesWithinOnly)
                             return false; // mutated_index is more general
-                        int affected_value = (int)((ILiteralExpression)affected_index).Value;
+                        int affected_value = (int)affected_literal.Value;
                         Bounds mutatedBounds = GetBounds(mutated_index, boundsInMutated);
                         if (mutatedBounds != null)
                         {
@@ -320,7 +311,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
                                 int minOffset = affected_value - affectedBounds.upperBound;
                                 int maxOffset = affected_value - affectedBounds.lowerBound;
                                 if (System.Math.Sign(minOffset) != System.Math.Sign(maxOffset))
-                                    throw new Exception("Inconsistent offset between array indexer expressions: " + mutated_index + " and " + affected_index);
+                                    throw new Exception($"Inconsistent offset between array indexer expressions: {mutated_index} and {affected_index}");
                                 int offset = (minOffset > 0) ? minOffset : maxOffset;
                                 if (offset != 0)
                                 {
@@ -339,9 +330,9 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 }
                 else if (mutatesWithinOnly)
                     return false;  // expressions are incomparable
-                else if (mutated_index is ILiteralExpression)
+                else if (mutated_index is ILiteralExpression mutated_literal)
                 {
-                    int mutated_value = (int)((ILiteralExpression)mutated_index).Value;
+                    int mutated_value = (int)mutated_literal.Value;
                     Bounds affectedBounds = GetBounds(affected_index, boundsInAffected);
                     if (affectedBounds != null)
                     {
@@ -373,9 +364,8 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 {
                     // neither affected nor mutated is literal
                     // check for offsetting
-                    int mutated_offset, affected_offset;
-                    IVariableDeclaration mutatedVar = GetOffsetVariable(mutated_index, out mutated_offset);
-                    IVariableDeclaration affectedVar = GetOffsetVariable(affected_index, out affected_offset);
+                    IVariableDeclaration mutatedVar = GetOffsetVariable(mutated_index, out int mutated_offset);
+                    IVariableDeclaration affectedVar = GetOffsetVariable(affected_index, out int affected_offset);
                     if (mutatedVar != null)
                     {
                         if (mutatedVar.Equals(affectedVar))
@@ -833,7 +823,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 {
                     if (!IsValid(binding))
                         return null;
-                    bool containsLhs = (predicate == null) ? true : predicate(binding.lhs);
+                    bool containsLhs = (predicate == null) || predicate(binding.lhs);
                     if (containsLhs)
                     {
                         int depthLhs = GetExpressionDepth(binding.lhs);
@@ -845,7 +835,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
                             exprReplace = binding.rhs;
                         }
                     }
-                    bool containsRhs = (predicate == null) ? true : predicate(binding.rhs);
+                    bool containsRhs = (predicate == null) || predicate(binding.rhs);
                     if (containsRhs)
                     {
                         int depthRhs = GetExpressionDepth(binding.rhs);
@@ -961,8 +951,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
 
         private bool IsValid(ConditionBinding binding)
         {
-            object value;
-            if (TryEvaluate<object>(binding.GetExpression(), null, out value))
+            if (TryEvaluate<object>(binding.GetExpression(), null, out object value))
                 return (bool)value;
             else
                 return true;
@@ -1093,8 +1082,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
                         }
                     }
                 }
-                T left, right;
-                if (TryEvaluate(ibe.Left, bindings, out left) && TryEvaluate(ibe.Right, bindings, out right))
+                if (TryEvaluate(ibe.Left, bindings, out T left) && TryEvaluate(ibe.Right, bindings, out T right))
                 {
                     // must use runtime type here, not T
                     Type type = left.GetType();
@@ -1104,8 +1092,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
             }
             else if (expr is IUnaryExpression iue)
             {
-                T target;
-                if (TryEvaluate(iue.Expression, bindings, out target))
+                if (TryEvaluate(iue.Expression, bindings, out T target))
                 {
                     // must use runtime type here, not T
                     Type type = target.GetType();
@@ -1133,13 +1120,13 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <returns></returns>
         public bool IsOnLHSOfAssignment(BasicTransformContext context, IExpression expr)
         {
-            int assignIndex = context.FindAncestorIndex<IAssignExpression>();
+            int assignIndex = context.FindAncestorNotSelfIndex<IAssignExpression>();
             if (assignIndex == -1)
                 return false;
-            IAssignExpression iae = context.GetAncestor(assignIndex) as IAssignExpression;
-            if (!(iae.Target == context.GetAncestor(assignIndex + 1)))
-                return false;
-            return IsPartOf(iae.Target, expr);
+            IAssignExpression iae = (IAssignExpression)context.GetAncestor(assignIndex);
+            if (iae.Target == context.GetAncestor(assignIndex + 1))
+                return IsPartOf(iae.Target, expr);
+            return false;
         }
 
         public int GetAncestorIndexOfLoopBeingInitialized(BasicTransformContext context)
@@ -1174,18 +1161,18 @@ namespace Microsoft.ML.Probabilistic.Compiler
 
         public bool IsLiteral(IExpression expr, object val)
         {
-            if (expr is ILiteralExpression)
+            if (expr is ILiteralExpression ile)
             {
-                return ((ILiteralExpression)expr).Value.Equals(val);
+                return ile.Value.Equals(val);
             }
             return false;
         }
 
         public T GetLiteral<T>(IExpression expr)
         {
-            if (expr is ILiteralExpression)
+            if (expr is ILiteralExpression ile)
             {
-                return (T)((ILiteralExpression)expr).Value;
+                return (T)ile.Value;
             }
             return default(T);
         }
@@ -1193,11 +1180,11 @@ namespace Microsoft.ML.Probabilistic.Compiler
         public IVariableDeclaration LoopVariable(IForStatement ifs)
         {
             IStatement ist = ifs.Initializer;
-            if (ist is IBlockStatement)
+            if (ist is IBlockStatement ibs)
             {
-                if (((IBlockStatement)ist).Statements.Count != 1)
+                if (ibs.Statements.Count != 1)
                     throw new NotSupportedException("For statement has multi-statement initializer:" + ifs);
-                ist = ((IBlockStatement)ist).Statements[0];
+                ist = ibs.Statements[0];
             }
             IExpressionStatement init = (IExpressionStatement)ist;
             IAssignExpression iae = (IAssignExpression)init.Expression;
@@ -1297,15 +1284,15 @@ namespace Microsoft.ML.Probabilistic.Compiler
                     bounds[loopVar] = b;
                 }
                 IExpression start = LoopStartExpression(ifs);
-                if (start is ILiteralExpression)
+                if (start is ILiteralExpression startLiteral)
                 {
-                    int startValue = (int)((ILiteralExpression)start).Value;
+                    int startValue = (int)startLiteral.Value;
                     b.lowerBound = System.Math.Max(b.lowerBound, startValue);
                 }
                 IExpression size = LoopSizeExpression(ifs);
-                if (size is ILiteralExpression)
+                if (size is ILiteralExpression sizeLiteral)
                 {
-                    int endValue = (int)((ILiteralExpression)size).Value - 1;
+                    int endValue = (int)sizeLiteral.Value - 1;
                     b.upperBound = System.Math.Min(b.upperBound, endValue);
                 }
                 if (ifs.Body.Statements.Count == 1)
@@ -1325,9 +1312,9 @@ namespace Microsoft.ML.Probabilistic.Compiler
                             b = new Bounds();
                             bounds[loopVar] = b;
                         }
-                        if (ibe.Left.GetExpressionType().Equals(typeof(int)) && ibe.Right is ILiteralExpression)
+                        if (ibe.Left.GetExpressionType().Equals(typeof(int)) && ibe.Right is ILiteralExpression right)
                         {
-                            int value = (int)((ILiteralExpression)ibe.Right).Value;
+                            int value = (int)right.Value;
                             if (ibe.Operator == BinaryOperator.GreaterThan)
                             {
                                 b.lowerBound = System.Math.Max(b.lowerBound, value + 1);
@@ -1367,9 +1354,9 @@ namespace Microsoft.ML.Probabilistic.Compiler
                             b = new Bounds();
                             bounds[loopVar] = b;
                         }
-                        if (ibe.Right.GetExpressionType().Equals(typeof(int)) && ibe.Left is ILiteralExpression)
+                        if (ibe.Right.GetExpressionType().Equals(typeof(int)) && ibe.Left is ILiteralExpression left)
                         {
-                            int value = (int)((ILiteralExpression)ibe.Left).Value;
+                            int value = (int)left.Value;
                             if (ibe.Operator == BinaryOperator.GreaterThan)
                             {
                                 b.upperBound = System.Math.Min(b.upperBound, value - 1);
@@ -2064,16 +2051,16 @@ namespace Microsoft.ML.Probabilistic.Compiler
                         {
                             if (ibe.Right is ILiteralExpression ile)
                             {
-                                if (ile.Value is int)
-                                    return ((int)ile.Value >= 0);
+                                if (ile.Value is int i)
+                                    return (i >= 0);
                             }
                         }
                         else if (ibe.Operator == BinaryOperator.Subtract)
                         {
                             if (ibe.Right is ILiteralExpression ile)
                             {
-                                if (ile.Value is int)
-                                    return ((int)ile.Value < 0);
+                                if (ile.Value is int i)
+                                    return (i < 0);
                             }
                         }
                     }
@@ -2301,8 +2288,8 @@ namespace Microsoft.ML.Probabilistic.Compiler
             {
                 return IsStochastic(context, iaie.Target) || IsAnyStochastic(context, iaie.Indices);
             }
-            if (expr is ICastExpression) return IsStochastic(context, ((ICastExpression)expr).Expression);
-            if (expr is ICheckedExpression) return IsStochastic(context, ((ICheckedExpression)expr).Expression);
+            if (expr is ICastExpression ice) return IsStochastic(context, ice.Expression);
+            if (expr is ICheckedExpression ichecked) return IsStochastic(context, ichecked.Expression);
             if (expr is IPropertyIndexerExpression ipie)
             {
                 return IsStochastic(context, ipie.Target) || IsAnyStochastic(context, ipie.Indices);
@@ -2330,9 +2317,9 @@ namespace Microsoft.ML.Probabilistic.Compiler
 
         internal static bool IsInfer(IExpression expr)
         {
-            return Instance.IsStaticMethod(expr, new Action<object>(InferNet.Infer)) ||
-                   Instance.IsStaticMethod(expr, new Action<object, string>(InferNet.Infer)) ||
-                   Instance.IsStaticMethod(expr, new Action<object, string, QueryType>(InferNet.Infer));
+            return Instance.IsStaticGenericMethod(expr, new Action<object>(InferNet.Infer)) ||
+                   Instance.IsStaticGenericMethod(expr, new Action<object, string>(InferNet.Infer)) ||
+                   Instance.IsStaticGenericMethod(expr, new Action<object, string, QueryType>(InferNet.Infer));
         }
 
         internal static bool IsIsIncreasing(IExpression expr)

--- a/src/Compiler/TransformFramework/InferNet.cs
+++ b/src/Compiler/TransformFramework/InferNet.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.Probabilistic.Factors
         /// Used in MSL to indicate that a variable will be inferred.
         /// </summary>
         /// <param name="obj">A variable reference expression</param>
-        public static void Infer(object obj)
+        public static void Infer<T>(T obj)
         {
         }
 
@@ -23,7 +23,7 @@ namespace Microsoft.ML.Probabilistic.Factors
         /// </summary>
         /// <param name="obj">A variable reference expression</param>
         /// <param name="name">The external name of the variable</param>
-        public static void Infer(object obj, string name)
+        public static void Infer<T>(T obj, string name)
         {
         }
 
@@ -33,7 +33,7 @@ namespace Microsoft.ML.Probabilistic.Factors
         /// <param name="obj">A variable reference expression</param>
         /// <param name="name">The external name of the variable</param>
         /// <param name="query">The query type</param>
-        public static void Infer(object obj, string name, QueryType query)
+        public static void Infer<T>(T obj, string name, QueryType query)
         {
         }
 

--- a/src/Compiler/TransformFramework/StackContext.cs
+++ b/src/Compiler/TransformFramework/StackContext.cs
@@ -18,6 +18,14 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// </summary>
         public List<TransformInfo> InputStack = new List<TransformInfo>();
 
+        /// <summary>
+        /// The depth of the current point in the transformation
+        /// </summary>
+        public int Depth
+        {
+            get { return InputStack.Count; }
+        }
+
         # region Methods for finding ancestors
 
         /// <summary>
@@ -121,7 +129,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
         public List<T> FindAncestors<T>()
         {
             List<T> list = new List<T>();
-            foreach (TransformInfo ti in InputStack) if (ti.inputElement is T) list.Add((T) ti.inputElement);
+            foreach (TransformInfo ti in InputStack) if (ti.inputElement is T ancestor) list.Add(ancestor);
             return list;
         }
 
@@ -136,7 +144,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
             for (int i = 0; i < ancIndex; i++)
             {
                 TransformInfo ti = InputStack[i];
-                if (ti.inputElement is T) list.Add((T) ti.inputElement);
+                if (ti.inputElement is T ancestor) list.Add(ancestor);
             }
             return list;
         }
@@ -152,7 +160,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
             for (int i = ancIndex + 1; i < InputStack.Count; i++)
             {
                 TransformInfo ti = InputStack[i];
-                if (ti.inputElement is T) list.Add((T) ti.inputElement);
+                if (ti.inputElement is T ancestor) list.Add(ancestor);
             }
             return list;
         }
@@ -167,7 +175,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
             for (int i = 0; i < InputStack.Count; i++)
             {
                 TransformInfo ti = InputStack[i];
-                if (ti.inputElement is T) return (T) ti.inputElement;
+                if (ti.inputElement is T ancestor) return ancestor;
             }
             return default(T);
         }
@@ -204,14 +212,6 @@ namespace Microsoft.ML.Probabilistic.Compiler
         }
 
         # endregion Methods for finding output
-
-        /// <summary>
-        /// The depth of the current point in the transformation
-        /// </summary>
-        public int Depth
-        {
-            get { return InputStack.Count; }
-        }
 
         # region Methods for adding statements
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/CompoundSparseBinaryBpmTrainingEvidence_EP.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/CompoundSparseBinaryBpmTrainingEvidence_EP.cs
@@ -165,8 +165,8 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				if (this.featureCount!=value) {
 					this.featureCount = value;
 					this.numberOfIterationsDone = 0;
-					this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 					this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount_FeatureInd5_isInitialised = false;
+					this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 					this.Changed_FeatureCount_isDone = false;
 					this.Changed_FeatureCount_WeightPrecisionRateConstraints_isDone = false;
 					this.Changed_FeatureCount_ZeroFeatureValueInstanceCounts_isDone = false;
@@ -190,8 +190,8 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.featureIndexes = value;
 				this.numberOfIterationsDone = 0;
-				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount_FeatureInd5_isInitialised = false;
+				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_InstanceCount_Ins2_isInitialised = false;
 				this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isDone = false;
 				this.Changed_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_Labels_numberO12_isDone = false;
@@ -210,9 +210,9 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.featureValues = value;
 				this.numberOfIterationsDone = 0;
-				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_FeatureValues_InstanceCount_InstanceFeatureCounts_isDone = false;
 				this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount_FeatureInd5_isInitialised = false;
+				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_InstanceCount_Ins2_isInitialised = false;
 				this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isInitialised = false;
 				this.Changed_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_Labels_numberO12_isDone = false;
@@ -229,11 +229,11 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				if (this.instanceCount!=value) {
 					this.instanceCount = value;
 					this.numberOfIterationsDone = 0;
-					this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 					this.Changed_InstanceCount_isDone = false;
 					this.Changed_InstanceCount_InstanceFeatureCounts_isDone = false;
 					this.Changed_FeatureValues_InstanceCount_InstanceFeatureCounts_isDone = false;
 					this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount_FeatureInd5_isDone = false;
+					this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 					this.Changed_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_InstanceCount_Ins2_isInitialised = false;
 					this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isDone = false;
 					this.Changed_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_Labels_numberO12_isDone = false;
@@ -253,10 +253,10 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.instanceFeatureCounts = value;
 				this.numberOfIterationsDone = 0;
-				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_InstanceCount_InstanceFeatureCounts_isDone = false;
 				this.Changed_FeatureValues_InstanceCount_InstanceFeatureCounts_isDone = false;
 				this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount_FeatureInd5_isDone = false;
+				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_InstanceCount_Ins2_isInitialised = false;
 				this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isDone = false;
 				this.Changed_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_Labels_numberO12_isDone = false;
@@ -275,8 +275,8 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.labels = value;
 				this.numberOfIterationsDone = 0;
-				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount_FeatureInd5_isInitialised = false;
+				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_InstanceCount_Ins2_isInitialised = false;
 				this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isInitialised = false;
 				this.Changed_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_Labels_numberO12_isDone = false;
@@ -300,8 +300,8 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			set {
 				this.weightConstraints = value;
 				this.numberOfIterationsDone = 0;
-				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount_FeatureInd5_isInitialised = false;
+				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_FeatureCount_WeightConstraints_isDone = false;
 				this.Changed_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_InstanceCount_Ins2_isInitialised = false;
 				this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isInitialised = false;
@@ -318,8 +318,8 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			set {
 				this.weightPrecisionRateConstraints = value;
 				this.numberOfIterationsDone = 0;
-				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount_FeatureInd5_isInitialised = false;
+				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_FeatureCount_WeightPrecisionRateConstraints_isDone = false;
 				this.Changed_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_InstanceCount_Ins2_isInitialised = false;
 				this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isInitialised = false;
@@ -339,8 +339,8 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.zeroFeatureValueInstanceCounts = value;
 				this.numberOfIterationsDone = 0;
-				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount_FeatureInd5_isInitialised = false;
+				this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isInitialised = false;
 				this.Changed_FeatureCount_ZeroFeatureValueInstanceCounts_isDone = false;
 				this.Changed_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_InstanceCount_Ins2_isInitialised = false;
 				this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isInitialised = false;
@@ -474,9 +474,9 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			}
 			this.ModelSelector_selector_cases_0_rep6_uses_B = new Bernoulli[this.featureCount][];
 			this.ModelSelector_selector_cases_0_rep10_B = new Bernoulli[this.featureCount];
-			this.ModelSelector_selector_cases_0_rep10_uses_B = new Bernoulli[this.featureCount][];
-			this.WeightPrecisionRates_rpt_F = new Gamma[this.featureCount];
 			this.ModelSelector_selector_cases_0_rep10_rpt_B = new Bernoulli[this.featureCount];
+			this.WeightPrecisionRates_rpt_F = new Gamma[this.featureCount];
+			this.ModelSelector_selector_cases_0_rep10_uses_B = new Bernoulli[this.featureCount][];
 			this.ModelSelector_selector_cases_0_rep6_B = new Bernoulli[this.featureCount];
 			for(int FeatureRange = 0; FeatureRange<this.featureCount; FeatureRange++) {
 				this.ModelSelector_selector_cases_0_rep6_uses_B[FeatureRange] = new Bernoulli[3];
@@ -577,9 +577,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.OnProgressChanged(new ProgressChangedEventArgs(iteration));
 			}
-			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
-				this.Weights_FeatureIndexes_B[InstanceRange] = ArrayHelper.SetTo<DistributionStructArray<Gaussian,double>>(this.Weights_FeatureIndexes_B[InstanceRange], this.IndexedWeights_B[InstanceRange]);
-			}
 			this.WeightPrecisionRates_depth0_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalIncrementArray<DistributionStructArray<Gamma,double>>(this.WeightPrecisionRates_depth0_uses_F[1], this.WeightPrecisionRates_depth0_uses_B[1], this.WeightPrecisionRates_depth0_marginal_F);
 			for(int FeatureRange = 0; FeatureRange<this.featureCount; FeatureRange++) {
 				this.ModelSelector_selector_cases_0_rep3_uses_B[FeatureRange][0] = Bernoulli.FromLogOdds(GammaFromShapeAndRateOp_Laplace.LogEvidenceRatio(this.SharedWeightPrecisionRates_use_B[FeatureRange], 1.0, this.WeightPrecisionRateRates_F_reduced, this.SharedWeightPrecisionRates_F[FeatureRange], this.SharedWeightPrecisionRates_B_FeatureRange__Q[FeatureRange]));
@@ -625,6 +622,9 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			}
 			this.ModelSelector_selector_cases_0_uses_B[39] = ReplicateOp_NoDivide.DefAverageConditional<Bernoulli>(this.ModelSelector_selector_cases_0_rep8_B, this.ModelSelector_selector_cases_0_uses_B[39]);
 			this.ModelSelector_selector_cases_0_uses_B[41] = ReplicateOp_NoDivide.DefAverageConditional<Bernoulli>(this.ModelSelector_selector_cases_0_rep10_B, this.ModelSelector_selector_cases_0_uses_B[41]);
+			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
+				this.Weights_FeatureIndexes_B[InstanceRange] = ArrayHelper.SetTo<DistributionStructArray<Gaussian,double>>(this.Weights_FeatureIndexes_B[InstanceRange], this.IndexedWeights_B[InstanceRange]);
+			}
 			this.ModelSelector_selector_cases_0_uses_B[46] = Bernoulli.FromLogOdds(JaggedSubarrayWithMarginalOp<double>.LogEvidenceRatio<Gaussian,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>,DistributionStructArray<Gaussian,double>>(this.Weights_FeatureIndexes_B, this.Weights_uses_F[1], this.featureIndexes, this.Weights_FeatureIndexes_F));
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
 				this.ModelSelector_selector_cases_0_rep20_B[InstanceRange] = Bernoulli.FromLogOdds(IsPositiveOp.LogEvidenceRatio(this.labels[InstanceRange], this.NoisyScore_F[InstanceRange]));
@@ -647,7 +647,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			if (this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isDone&&((!initialise)||this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isInitialised)) {
 				return ;
 			}
-			this.Weights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.Weights_uses_F[1], this.Weights_FeatureIndexes_B, this.featureIndexes, this.Weights_marginal_F);
+			this.Weights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.Weights_uses_F[1], this.IndexedWeights_B, this.featureIndexes, this.Weights_marginal_F);
 			this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isDone = true;
 			this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isInitialised = true;
 		}
@@ -727,9 +727,8 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			if (this.Changed_InstanceCount_isDone) {
 				return ;
 			}
-			this.Weights_FeatureIndexes_B = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.instanceCount);
-			this.Weights_FeatureIndexes_F = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.instanceCount);
 			this.IndexedWeights_B = new DistributionStructArray<Gaussian,double>[this.instanceCount];
+			this.Weights_FeatureIndexes_F = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.instanceCount);
 			this.FeatureScores_F = new DistributionStructArray<Gaussian,double>[this.instanceCount];
 			this.Score_F = new Gaussian[this.instanceCount];
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
@@ -755,6 +754,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
 				this.ModelSelector_selector_cases_0_rep8_B[InstanceRange] = Bernoulli.Uniform();
 			}
+			this.Weights_FeatureIndexes_B = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.instanceCount);
 			this.ModelSelector_selector_cases_0_rep20_B = new Bernoulli[this.instanceCount];
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
 				this.ModelSelector_selector_cases_0_rep20_B[InstanceRange] = Bernoulli.Uniform();
@@ -769,12 +769,11 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				return ;
 			}
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
-				this.Weights_FeatureIndexes_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
+				this.IndexedWeights_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
 				this.Weights_FeatureIndexes_F[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
 				for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
 					this.Weights_FeatureIndexes_F[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
 				}
-				this.IndexedWeights_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
 				this.FeatureScores_F[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
 				for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
 					this.FeatureScores_F[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
@@ -795,6 +794,10 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
 					this.ModelSelector_selector_cases_0_rep8_rep_B[InstanceRange][InstanceFeatureRanges] = Bernoulli.Uniform();
 				}
+				this.Weights_FeatureIndexes_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
+				for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
+					this.Weights_FeatureIndexes_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
+				}
 			}
 			this.Changed_InstanceCount_InstanceFeatureCounts_isDone = true;
 		}
@@ -808,7 +811,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			}
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
 				for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
-					this.Weights_FeatureIndexes_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
 					this.IndexedWeights_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
 				}
 			}
@@ -915,19 +917,19 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			if (numberOfIterations!=this.numberOfIterationsDone) {
 				if (numberOfIterations<this.numberOfIterationsDone) {
 					this.numberOfIterationsDone = 0;
-					this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isDone = false;
 					this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount_FeatureInd5_isDone = false;
+					this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8_isDone = false;
 					this.Changed_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_InstanceCount_Ins2_isDone = false;
 					this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_6_isDone = false;
 				}
 				this.Changed_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_Labels_numberO12_isDone = false;
 			}
 			this.Constant();
-			this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8(initialise);
 			this.Changed_InstanceCount();
 			this.Changed_InstanceCount_InstanceFeatureCounts();
 			this.Changed_FeatureValues_InstanceCount_InstanceFeatureCounts();
 			this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount_FeatureInd5(initialise);
+			this.Changed_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_Ins8(initialise);
 			this.Changed_FeatureCount();
 			this.Changed_FeatureCount_WeightPrecisionRateConstraints();
 			this.Changed_FeatureCount_ZeroFeatureValueInstanceCounts();

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/CompoundSparseBinaryBpmTraining_EP.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/CompoundSparseBinaryBpmTraining_EP.cs
@@ -111,7 +111,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 		public DistributionStructArray<Gamma,double> WeightPrecisions_F;
 		public DistributionStructArray<Gaussian,double> Weights_B;
 		public DistributionStructArray<Gaussian,double> Weights_F;
-		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> Weights_FeatureIndexes_B;
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> Weights_FeatureIndexes_F;
 		/// <summary>Message to marginal of 'Weights'</summary>
 		public DistributionStructArray<Gaussian,double> Weights_marginal_F;
@@ -500,7 +499,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			if (this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_11_isDone&&((!initialise)||this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_11_isInitialised)) {
 				return ;
 			}
-			this.Weights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.Weights_uses_F[1], this.Weights_FeatureIndexes_B, this.featureIndexes, this.Weights_marginal_F);
+			this.Weights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.Weights_uses_F[1], this.IndexedWeights_B, this.featureIndexes, this.Weights_marginal_F);
 			this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_11_isDone = true;
 			this.Changed_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_11_isInitialised = true;
 		}
@@ -599,7 +598,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			}
 			this.FeatureScores_B = new DistributionStructArray<Gaussian,double>[this.instanceCount];
 			this.IndexedWeights_B = new DistributionStructArray<Gaussian,double>[this.instanceCount];
-			this.Weights_FeatureIndexes_B = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.instanceCount);
 			this.Changed_InstanceCount_isDone = true;
 		}
 
@@ -627,7 +625,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 					this.FeatureScores_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
 				}
 				this.IndexedWeights_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
-				this.Weights_FeatureIndexes_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
 			}
 			this.Changed_InstanceCount_InstanceFeatureCounts_isDone = true;
 		}
@@ -642,7 +639,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
 				for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
 					this.IndexedWeights_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
-					this.Weights_FeatureIndexes_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
 				}
 			}
 			this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount_FeatureInd10_isDone = true;

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianDenseBinaryBpmTrainingEvidence_EP.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianDenseBinaryBpmTrainingEvidence_EP.cs
@@ -68,7 +68,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 		private DistributionStructArray<Gaussian,double> weightConstraints;
 		/// <summary>Field backing the WeightPriors property</summary>
 		private DistributionStructArray<Gaussian,double> weightPriors;
-		public DistributionStructArray<Gaussian,double> Weights_depth1_B;
 		public Gaussian[][] Weights_depth1_rep_B;
 		/// <summary>Buffer for ReplicateOp_Divide.Marginal&lt;Gaussian&gt;</summary>
 		public Gaussian[] Weights_depth1_rep_B_toDef;
@@ -256,11 +255,8 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.OnProgressChanged(new ProgressChangedEventArgs(iteration));
 			}
-			for(int FeatureRange = 0; FeatureRange<this.featureCount; FeatureRange++) {
-				this.Weights_depth1_B[FeatureRange] = ArrayHelper.SetTo<Gaussian>(this.Weights_depth1_B[FeatureRange], this.Weights_depth1_rep_B_toDef[FeatureRange]);
-			}
 			for(int _iv = 0; _iv<this.featureCount; _iv++) {
-				this.Weights_uses_B[1][_iv] = ArrayHelper.SetTo<Gaussian>(this.Weights_uses_B[1][_iv], this.Weights_depth1_B[_iv]);
+				this.Weights_uses_B[1][_iv] = ArrayHelper.SetTo<Gaussian>(this.Weights_uses_B[1][_iv], this.Weights_depth1_rep_B_toDef[_iv]);
 			}
 			this.Weights_uses_F[0] = ReplicateOp_NoDivide.UsesAverageConditional<DistributionStructArray<Gaussian,double>>(this.Weights_uses_B, this.weightPriors, 0, this.Weights_uses_F[0]);
 			this.ModelSelector_selector_cases_0_uses_B[6] = Bernoulli.FromLogOdds(ReplicateOp.LogEvidenceRatio<DistributionStructArray<Gaussian,double>>(this.Weights_uses_B, this.weightPriors, this.Weights_uses_F));
@@ -391,7 +387,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				return ;
 			}
 			this.Weights_uses_B[1] = ArrayHelper.MakeUniform<DistributionStructArray<Gaussian,double>>(this.weightPriors);
-			this.Weights_depth1_B = ArrayHelper.MakeUniform<DistributionStructArray<Gaussian,double>>(this.weightPriors);
 			this.Weights_uses_B[0] = ArrayHelper.MakeUniform<DistributionStructArray<Gaussian,double>>(this.weightPriors);
 			this.Weights_uses_F[1] = ArrayHelper.MakeUniform<DistributionStructArray<Gaussian,double>>(this.weightPriors);
 			this.Weights_uses_F[0] = ArrayHelper.MakeUniform<DistributionStructArray<Gaussian,double>>(this.weightPriors);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianDenseBinaryBpmTraining_EP.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianDenseBinaryBpmTraining_EP.cs
@@ -55,7 +55,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 		private DistributionStructArray<Gaussian,double> weightConstraints;
 		/// <summary>Field backing the WeightPriors property</summary>
 		private DistributionStructArray<Gaussian,double> weightPriors;
-		public DistributionStructArray<Gaussian,double> Weights_depth1_B;
 		public Gaussian[][] Weights_depth1_rep_B;
 		/// <summary>Buffer for ReplicateOp_Divide.Marginal&lt;Gaussian&gt;</summary>
 		public Gaussian[] Weights_depth1_rep_B_toDef;
@@ -235,11 +234,8 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.OnProgressChanged(new ProgressChangedEventArgs(iteration));
 			}
-			for(int FeatureRange = 0; FeatureRange<this.featureCount; FeatureRange++) {
-				this.Weights_depth1_B[FeatureRange] = ArrayHelper.SetTo<Gaussian>(this.Weights_depth1_B[FeatureRange], this.Weights_depth1_rep_B_toDef[FeatureRange]);
-			}
 			for(int _iv = 0; _iv<this.featureCount; _iv++) {
-				this.Weights_uses_B[1][_iv] = ArrayHelper.SetTo<Gaussian>(this.Weights_uses_B[1][_iv], this.Weights_depth1_B[_iv]);
+				this.Weights_uses_B[1][_iv] = ArrayHelper.SetTo<Gaussian>(this.Weights_uses_B[1][_iv], this.Weights_depth1_rep_B_toDef[_iv]);
 			}
 			this.Weights_use_B = ReplicateOp_NoDivide.DefAverageConditional<DistributionStructArray<Gaussian,double>>(this.Weights_uses_B, this.Weights_use_B);
 			this.Weights_marginal_F = VariableOp.MarginalAverageConditional<DistributionStructArray<Gaussian,double>>(this.Weights_use_B, this.weightPriors, this.Weights_marginal_F);
@@ -354,7 +350,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			this.Weights_uses_B[1] = ArrayHelper.MakeUniform<DistributionStructArray<Gaussian,double>>(this.weightPriors);
 			this.Weights_uses_B[0] = ArrayHelper.MakeUniform<DistributionStructArray<Gaussian,double>>(this.weightPriors);
 			this.Weights_uses_F[1] = ArrayHelper.MakeUniform<DistributionStructArray<Gaussian,double>>(this.weightPriors);
-			this.Weights_depth1_B = ArrayHelper.MakeUniform<DistributionStructArray<Gaussian,double>>(this.weightPriors);
 			this.Changed_WeightPriors_isDone = true;
 		}
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianDenseMulticlassBpmPrediction_EP.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianDenseMulticlassBpmPrediction_EP.cs
@@ -91,8 +91,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 		public Gaussian[][][] NoisyScoreDeltas_B;
 		public Gaussian[][][] NoisyScoreDeltas_F;
 		public Gaussian[][][] NoisyScores__B;
-		public DistributionStructArray<Gaussian,double>[][] NoisyScores__ClassMaxNoisyScore_B;
-		public Gaussian[][][] NoisyScores__ClassMaxNoisyScore_ClassRange_0__B;
+		public Gaussian[][] NoisyScores__B_reduced;
 		public DistributionStructArray<Gaussian,double>[] NoisyScores_F;
 		/// <summary>Message from use of 'NoisyScores'</summary>
 		public DistributionStructArray<Gaussian,double>[] NoisyScores_use_B;
@@ -264,9 +263,9 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			}
 			this.Weights_F = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.classCount);
 			this.Weights_rep_B_toDef = new Gaussian[this.classCount][];
-			this.Weights_rep_F_marginal = new Gaussian[this.classCount][];
-			this.Weights_uses_B = new Gaussian[this.classCount][][];
 			this.Weights_uses_F = new Gaussian[this.classCount][][];
+			this.Weights_uses_B = new Gaussian[this.classCount][][];
+			this.Weights_rep_F_marginal = new Gaussian[this.classCount][];
 			this.Weights_rep_F = new Gaussian[this.classCount][][];
 			this.Weights_rep_B = new Gaussian[this.classCount][][];
 			this.Changed_ClassCount_isDone = true;
@@ -336,10 +335,10 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 							if (ClassMaxNoisyScore!=ClassRange) {
 								this.NoisyScoreDeltas_F[InstanceRange][ClassMaxNoisyScore][ClassRange] = DoublePlusOp.AAverageConditional(this.MaxNoisyScore_rep_F[InstanceRange][ClassMaxNoisyScore][ClassRange], this.NoisyScores_F[InstanceRange][ClassRange]);
 								this.NoisyScoreDeltas_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = IsPositiveOp_Proper.XAverageConditional(Bernoulli.PointMass(true), this.NoisyScoreDeltas_F[InstanceRange][ClassMaxNoisyScore][ClassRange]);
-								this.Labels_InstanceRange__selector_cases_rep7_uses_B[InstanceRange][ClassMaxNoisyScore][ClassRange][0] = Bernoulli.FromLogOdds(IsPositiveOp.LogEvidenceRatio(true, this.NoisyScoreDeltas_F[InstanceRange][ClassMaxNoisyScore][ClassRange]));
 								this.vdouble710_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = DoublePlusOp.SumAverageConditional(this.NoisyScoreDeltas_B[InstanceRange][ClassMaxNoisyScore][ClassRange], this.NoisyScores_F[InstanceRange][ClassRange]);
 								this.MaxNoisyScore_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange] = LowPriorityBackwardOp.ValueAverageConditional<Gaussian>(this.vdouble710_B[InstanceRange][ClassMaxNoisyScore][ClassRange]);
 								this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = ArrayHelper.SetTo<Gaussian>(this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore][ClassRange], this.MaxNoisyScore_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange]);
+								this.Labels_InstanceRange__selector_cases_rep7_uses_B[InstanceRange][ClassMaxNoisyScore][ClassRange][0] = Bernoulli.FromLogOdds(IsPositiveOp.LogEvidenceRatio(true, this.NoisyScoreDeltas_F[InstanceRange][ClassMaxNoisyScore][ClassRange]));
 							}
 						}
 					}
@@ -359,22 +358,20 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 						}
 						this.Labels_InstanceRange__selector_cases_uses_B[InstanceRange][ClassMaxNoisyScore][11] = ReplicateOp_NoDivide.DefAverageConditional<Bernoulli>(this.Labels_InstanceRange__selector_cases_rep7_B[InstanceRange][ClassMaxNoisyScore], this.Labels_InstanceRange__selector_cases_uses_B[InstanceRange][ClassMaxNoisyScore][11]);
 						this.MaxNoisyScore_rep_B_toDef[InstanceRange][ClassMaxNoisyScore] = ReplicateOp_Divide.ToDef<Gaussian>(this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore], this.MaxNoisyScore_rep_B_toDef[InstanceRange][ClassMaxNoisyScore]);
-						this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore][ClassMaxNoisyScore] = ArrayHelper.SetTo<Gaussian>(this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore][ClassMaxNoisyScore], this.MaxNoisyScore_rep_B_toDef[InstanceRange][ClassMaxNoisyScore]);
 					}
 					for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
-						for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-							if (ClassMaxNoisyScore!=ClassRange) {
-								this.NoisyScores__ClassMaxNoisyScore_ClassRange_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange] = DoublePlusOp.BAverageConditional(this.MaxNoisyScore_rep_F[InstanceRange][ClassMaxNoisyScore][ClassRange], this.NoisyScoreDeltas_B[InstanceRange][ClassMaxNoisyScore][ClassRange]);
-								this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = ArrayHelper.SetTo<Gaussian>(this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore][ClassRange], this.NoisyScores__ClassMaxNoisyScore_ClassRange_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange]);
-							}
-							this.NoisyScores__B[InstanceRange][ClassRange][ClassMaxNoisyScore] = ArrayHelper.SetTo<Gaussian>(this.NoisyScores__B[InstanceRange][ClassRange][ClassMaxNoisyScore], this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore][ClassRange]);
-						}
 						this.Labels_InstanceRange__selector_cases_B[InstanceRange][ClassRange] = ReplicateOp_NoDivide.DefAverageConditional<Bernoulli>(this.Labels_InstanceRange__selector_cases_uses_B[InstanceRange][ClassRange], this.Labels_InstanceRange__selector_cases_B[InstanceRange][ClassRange]);
 					}
 					this.Labels_InstanceRange__selector_uses_B[InstanceRange][0] = IntCasesOp.IAverageConditional(this.Labels_InstanceRange__selector_cases_B[InstanceRange], this.Labels_InstanceRange__selector_uses_B[InstanceRange][0]);
 					this.Labels_InstanceRange__selector_uses_F[InstanceRange][1] = ReplicateOp_NoDivide.UsesAverageConditional<Discrete>(this.Labels_InstanceRange__selector_uses_B[InstanceRange], this.Labels_uses_F[InstanceRange][1], 1, this.Labels_InstanceRange__selector_uses_F[InstanceRange][1]);
 					this.Labels_InstanceRange__selector_rep_F_marginal[InstanceRange] = ReplicateOp_Divide.Marginal<Discrete>(this.Labels_InstanceRange__selector_rep_B_toDef[InstanceRange], this.Labels_InstanceRange__selector_uses_F[InstanceRange][1], this.Labels_InstanceRange__selector_rep_F_marginal[InstanceRange]);
 					for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
+						if (this.classCount>0) {
+							this.NoisyScores__B_reduced[InstanceRange][ClassRange] = ArrayHelper.SetTo<Gaussian>(this.NoisyScores__B_reduced[InstanceRange][ClassRange], this.MaxNoisyScore_rep_B_toDef[InstanceRange][ClassRange]);
+						}
+						for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
+							this.NoisyScores__B[InstanceRange][ClassRange][ClassMaxNoisyScore] = this.NoisyScores__B_reduced[InstanceRange][ClassRange];
+						}
 						this.Labels_InstanceRange__selector_rep_F[InstanceRange][ClassRange] = ReplicateOp_Divide.UsesAverageConditional<Discrete>(this.Labels_InstanceRange__selector_rep_B_reduced, this.Labels_InstanceRange__selector_rep_F_marginal[InstanceRange], ClassRange, this.Labels_InstanceRange__selector_rep_F[InstanceRange][ClassRange]);
 						this.NoisyScores_use_B[InstanceRange][ClassRange] = GateEnterOp<double>.ValueAverageConditional<Gaussian>(this.NoisyScores__B[InstanceRange][ClassRange], this.Labels_InstanceRange__selector_rep_F[InstanceRange][ClassRange], this.NoisyScores_F[InstanceRange][ClassRange], this.NoisyScores_use_B[InstanceRange][ClassRange]);
 						this.Scores_B[InstanceRange][ClassRange] = GaussianFromMeanAndVarianceOp.MeanAverageConditional(this.NoisyScores_use_B[InstanceRange][ClassRange], 1.0);
@@ -659,7 +656,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 					this.Labels_InstanceRange__selector_cases_B[InstanceRange][ClassRange] = Bernoulli.Uniform();
 				}
 				this.Labels_InstanceRange__selector_uses_B[InstanceRange][0] = ArrayHelper.MakeUniform<Discrete>(Discrete.Uniform(this.classCount));
-				this.Labels_InstanceRange__selector_uses_B[InstanceRange][1] = ArrayHelper.MakeUniform<Discrete>(Discrete.Uniform(this.classCount));
 				this.Labels_InstanceRange__selector_uses_F[InstanceRange][1] = ArrayHelper.MakeUniform<Discrete>(Discrete.Uniform(this.classCount));
 				this.Labels_InstanceRange__selector_rep_F_marginal[InstanceRange] = ReplicateOp_Divide.MarginalInit<Discrete>(this.Labels_InstanceRange__selector_uses_F[InstanceRange][1]);
 				this.Labels_InstanceRange__selector_rep_B_toDef[InstanceRange] = ReplicateOp_Divide.ToDefInit<Discrete>(this.Labels_InstanceRange__selector_uses_F[InstanceRange][1]);
@@ -667,31 +663,18 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
 					this.Labels_InstanceRange__selector_rep_F[InstanceRange][ClassRange] = ArrayHelper.MakeUniform<Discrete>(Discrete.Uniform(this.classCount));
 				}
-				this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange] = new DistributionStructArray<Gaussian,double>[this.classCount];
-				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-					this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore] = new DistributionStructArray<Gaussian,double>(this.classCount);
-				}
+				this.NoisyScores__B_reduced[InstanceRange] = new Gaussian[this.classCount];
 				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
-					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-						this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
-					}
-				}
-				this.NoisyScores__ClassMaxNoisyScore_ClassRange_0__B[InstanceRange] = new Gaussian[this.classCount][];
-				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-					this.NoisyScores__ClassMaxNoisyScore_ClassRange_0__B[InstanceRange][ClassMaxNoisyScore] = new Gaussian[this.classCount];
-				}
-				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
-					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-						if (ClassMaxNoisyScore!=ClassRange) {
-							this.NoisyScores__ClassMaxNoisyScore_ClassRange_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
-						}
+					this.NoisyScores__B_reduced[InstanceRange][ClassRange] = default(Gaussian);
+					if (this.classCount>0) {
+						this.NoisyScores__B_reduced[InstanceRange][ClassRange] = Gaussian.Uniform();
 					}
 				}
 				this.NoisyScores__B[InstanceRange] = new Gaussian[this.classCount][];
 				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
 					this.NoisyScores__B[InstanceRange][ClassRange] = new Gaussian[this.classCount];
 					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-						this.NoisyScores__B[InstanceRange][ClassRange][ClassMaxNoisyScore] = Gaussian.Uniform();
+						this.NoisyScores__B[InstanceRange][ClassRange][ClassMaxNoisyScore] = this.NoisyScores__B_reduced[InstanceRange][ClassRange];
 					}
 				}
 				this.NoisyScores_use_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.classCount);
@@ -702,6 +685,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				this.Labels_use_B[InstanceRange] = ArrayHelper.MakeUniform<Discrete>(Discrete.Uniform(this.classCount));
 				this.Labels_uses_B[InstanceRange][1] = ArrayHelper.MakeUniform<Discrete>(Discrete.Uniform(this.classCount));
 				this.Labels_uses_B[InstanceRange][0] = ArrayHelper.MakeUniform<Discrete>(Discrete.Uniform(this.classCount));
+				this.Labels_InstanceRange__selector_uses_B[InstanceRange][1] = ArrayHelper.MakeUniform<Discrete>(Discrete.Uniform(this.classCount));
 				this.Labels_InstanceRange__selector_B[InstanceRange] = ArrayHelper.MakeUniform<Discrete>(Discrete.Uniform(this.classCount));
 			}
 			this.Changed_ClassCount_InstanceCount_isDone = true;
@@ -782,8 +766,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			this.Labels_InstanceRange__selector_rep_F_marginal = new Discrete[this.instanceCount];
 			this.Labels_InstanceRange__selector_rep_B_toDef = new Discrete[this.instanceCount];
 			this.Labels_InstanceRange__selector_rep_F = new Discrete[this.instanceCount][];
-			this.NoisyScores__ClassMaxNoisyScore_B = new DistributionStructArray<Gaussian,double>[this.instanceCount][];
-			this.NoisyScores__ClassMaxNoisyScore_ClassRange_0__B = new Gaussian[this.instanceCount][][];
+			this.NoisyScores__B_reduced = new Gaussian[this.instanceCount][];
 			this.NoisyScores__B = new Gaussian[this.instanceCount][][];
 			this.NoisyScores_use_B = new DistributionStructArray<Gaussian,double>[this.instanceCount];
 			this.Labels_marginal_F = new DistributionRefArray<Discrete,int>(this.instanceCount);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianSparseBinaryBpmPrediction_EP.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianSparseBinaryBpmPrediction_EP.cs
@@ -50,7 +50,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 		private DistributionStructArray<Gaussian,double> weightConstraints;
 		/// <summary>Field backing the WeightPriors property</summary>
 		private DistributionStructArray<Gaussian,double> weightPriors;
-		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> Weights_FeatureIndexes_B;
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> Weights_FeatureIndexes_F;
 		/// <summary>Message to marginal of 'Weights'</summary>
 		public DistributionStructArray<Gaussian,double> Weights_marginal_F;
@@ -210,7 +209,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			if (this.Changed_FeatureIndexes_InstanceCount_InstanceFeatureCounts_WeightConstraints_WeightPriors_isDone) {
 				return ;
 			}
-			this.Weights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.Weights_uses_F[1], this.Weights_FeatureIndexes_B, this.featureIndexes, this.Weights_marginal_F);
+			this.Weights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.Weights_uses_F[1], this.IndexedWeights_B, this.featureIndexes, this.Weights_marginal_F);
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
 				this.Weights_FeatureIndexes_F[InstanceRange] = JaggedSubarrayWithMarginalOp<double>.ItemsAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.IndexedWeights_B[InstanceRange], this.Weights_uses_F[1], this.Weights_marginal_F, this.featureIndexes, InstanceRange, this.Weights_FeatureIndexes_F[InstanceRange]);
 			}
@@ -224,12 +223,11 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				return ;
 			}
 			this.Labels_F = new DistributionStructArray<Bernoulli,bool>(this.instanceCount);
-			this.IndexedWeights_B = new DistributionStructArray<Gaussian,double>[this.instanceCount];
+			this.NoisyScore_F = new Gaussian[this.instanceCount];
+			this.FeatureScores_F = new DistributionStructArray<Gaussian,double>[this.instanceCount];
 			this.Weights_FeatureIndexes_F = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.instanceCount);
 			this.Score_F = new Gaussian[this.instanceCount];
-			this.Weights_FeatureIndexes_B = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.instanceCount);
-			this.FeatureScores_F = new DistributionStructArray<Gaussian,double>[this.instanceCount];
-			this.NoisyScore_F = new Gaussian[this.instanceCount];
+			this.IndexedWeights_B = new DistributionStructArray<Gaussian,double>[this.instanceCount];
 			this.Labels_marginal_F = new DistributionStructArray<Bernoulli,bool>(this.instanceCount);
 			this.Labels_use_B_reduced = default(Bernoulli);
 			if (this.instanceCount>0) {
@@ -251,10 +249,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				return ;
 			}
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
-				this.Weights_FeatureIndexes_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
-				for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
-					this.Weights_FeatureIndexes_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
-				}
 				this.IndexedWeights_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
 				for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
 					this.IndexedWeights_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianSparseBinaryBpmTrainingEvidence_EP.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianSparseBinaryBpmTrainingEvidence_EP.cs
@@ -255,13 +255,13 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.OnProgressChanged(new ProgressChangedEventArgs(iteration));
 			}
-			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
-				this.Weights_FeatureIndexes_B[InstanceRange] = ArrayHelper.SetTo<DistributionStructArray<Gaussian,double>>(this.Weights_FeatureIndexes_B[InstanceRange], this.IndexedWeights_B[InstanceRange]);
-			}
 			this.Weights_uses_B[1] = JaggedSubarrayWithMarginalOp<double>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>>(this.Weights_uses_F[1], this.Weights_marginal_F, this.Weights_uses_B[1]);
 			this.Weights_uses_F[0] = ReplicateOp_NoDivide.UsesAverageConditional<DistributionStructArray<Gaussian,double>>(this.Weights_uses_B, this.weightPriors, 0, this.Weights_uses_F[0]);
 			this.ModelSelector_selector_cases_0_uses_B[3] = Bernoulli.FromLogOdds(ReplicateOp.LogEvidenceRatio<DistributionStructArray<Gaussian,double>>(this.Weights_uses_B, this.weightPriors, this.Weights_uses_F));
 			this.ModelSelector_selector_cases_0_uses_B[4] = Bernoulli.FromLogOdds(ConstrainEqualRandomOp<double[]>.LogEvidenceRatio<DistributionStructArray<Gaussian,double>>(this.Weights_uses_F[0], this.weightConstraints));
+			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
+				this.Weights_FeatureIndexes_B[InstanceRange] = ArrayHelper.SetTo<DistributionStructArray<Gaussian,double>>(this.Weights_FeatureIndexes_B[InstanceRange], this.IndexedWeights_B[InstanceRange]);
+			}
 			this.ModelSelector_selector_cases_0_uses_B[8] = Bernoulli.FromLogOdds(JaggedSubarrayWithMarginalOp<double>.LogEvidenceRatio<Gaussian,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>,DistributionStructArray<Gaussian,double>>(this.Weights_FeatureIndexes_B, this.Weights_uses_F[1], this.featureIndexes, this.Weights_FeatureIndexes_F));
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
 				this.ModelSelector_selector_cases_0_rep9_B[InstanceRange] = Bernoulli.FromLogOdds(IsPositiveOp.LogEvidenceRatio(this.labels[InstanceRange], this.NoisyScore_F[InstanceRange]));
@@ -282,7 +282,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			if (this.Changed_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_WeightConstra6_isDone&&((!initialise)||this.Changed_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_WeightConstra6_isInitialised)) {
 				return ;
 			}
-			this.Weights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.Weights_uses_F[1], this.Weights_FeatureIndexes_B, this.featureIndexes, this.Weights_marginal_F);
+			this.Weights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.Weights_uses_F[1], this.IndexedWeights_B, this.featureIndexes, this.Weights_marginal_F);
 			this.Changed_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_WeightConstra6_isDone = true;
 			this.Changed_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_WeightConstra6_isInitialised = true;
 		}
@@ -342,6 +342,9 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.IndexedWeights_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
 				this.Weights_FeatureIndexes_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
+				for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
+					this.Weights_FeatureIndexes_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
+				}
 			}
 			this.Changed_InstanceCount_InstanceFeatureCounts_isDone = true;
 		}
@@ -356,7 +359,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
 				for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
 					this.IndexedWeights_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
-					this.Weights_FeatureIndexes_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
 				}
 			}
 			this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureV5_isDone = true;

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianSparseBinaryBpmTraining_EP.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianSparseBinaryBpmTraining_EP.cs
@@ -59,7 +59,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 		/// <summary>Field backing the WeightPriors property</summary>
 		private DistributionStructArray<Gaussian,double> weightPriors;
 		public DistributionStructArray<Gaussian,double> Weights_B;
-		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> Weights_FeatureIndexes_B;
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> Weights_FeatureIndexes_F;
 		/// <summary>Message to marginal of 'Weights'</summary>
 		public DistributionStructArray<Gaussian,double> Weights_marginal_F;
@@ -257,7 +256,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			if (this.Changed_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_WeightConstra6_isDone&&((!initialise)||this.Changed_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_WeightConstra6_isInitialised)) {
 				return ;
 			}
-			this.Weights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.Weights_uses_F[1], this.Weights_FeatureIndexes_B, this.featureIndexes, this.Weights_marginal_F);
+			this.Weights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.Weights_uses_F[1], this.IndexedWeights_B, this.featureIndexes, this.Weights_marginal_F);
 			this.Changed_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_WeightConstra6_isDone = true;
 			this.Changed_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_WeightConstra6_isInitialised = true;
 		}
@@ -288,7 +287,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			}
 			this.FeatureScores_B = new DistributionStructArray<Gaussian,double>[this.instanceCount];
 			this.IndexedWeights_B = new DistributionStructArray<Gaussian,double>[this.instanceCount];
-			this.Weights_FeatureIndexes_B = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.instanceCount);
 			this.Changed_InstanceCount_isDone = true;
 		}
 
@@ -312,7 +310,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 					this.FeatureScores_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
 				}
 				this.IndexedWeights_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
-				this.Weights_FeatureIndexes_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
 			}
 			this.Changed_InstanceCount_InstanceFeatureCounts_isDone = true;
 		}
@@ -327,7 +324,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
 				for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
 					this.IndexedWeights_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
-					this.Weights_FeatureIndexes_B[InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
 				}
 			}
 			this.Changed_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureV5_isDone = true;

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianSparseMulticlassBpmPrediction_EP.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/GeneratedAlgorithms/GaussianSparseMulticlassBpmPrediction_EP.cs
@@ -12,20 +12,14 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 	public partial class GaussianSparseMulticlassBpmPrediction_EP : IGeneratedAlgorithm
 	{
 		#region Fields
-		/// <summary>True if Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13 has executed. Set this to false to force re-execution of Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13</summary>
-		public bool Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13_isDone;
-		/// <summary>True if Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14 has executed. Set this to false to force re-execution of Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14</summary>
-		public bool Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14_isDone;
-		/// <summary>True if Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12 has executed. Set this to false to force re-execution of Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12</summary>
-		public bool Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isDone;
-		/// <summary>True if Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12 has performed initialisation. Set this to false to force re-execution of Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12</summary>
-		public bool Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isInitialised;
+		/// <summary>True if Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12 has executed. Set this to false to force re-execution of Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12</summary>
+		public bool Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12_isDone;
 		/// <summary>True if Changed_ClassCount_FeatureCount has executed. Set this to false to force re-execution of Changed_ClassCount_FeatureCount</summary>
 		public bool Changed_ClassCount_FeatureCount_isDone;
-		/// <summary>True if Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11 has executed. Set this to false to force re-execution of Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11</summary>
-		public bool Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isDone;
-		/// <summary>True if Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11 has performed initialisation. Set this to false to force re-execution of Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11</summary>
-		public bool Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isInitialised;
+		/// <summary>True if Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10 has executed. Set this to false to force re-execution of Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10</summary>
+		public bool Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isDone;
+		/// <summary>True if Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10 has performed initialisation. Set this to false to force re-execution of Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10</summary>
+		public bool Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isInitialised;
 		/// <summary>True if Changed_ClassCount_FeatureCount_WeightConstraints has executed. Set this to false to force re-execution of Changed_ClassCount_FeatureCount_WeightConstraints</summary>
 		public bool Changed_ClassCount_FeatureCount_WeightConstraints_isDone;
 		/// <summary>True if Changed_ClassCount_FeatureCount_WeightConstraints_WeightPriors has executed. Set this to false to force re-execution of Changed_ClassCount_FeatureCount_WeightConstraints_WeightPriors</summary>
@@ -40,10 +34,10 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 		public bool Changed_ClassCount_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount9_isInitialised;
 		/// <summary>True if Changed_ClassCount_InstanceCount has executed. Set this to false to force re-execution of Changed_ClassCount_InstanceCount</summary>
 		public bool Changed_ClassCount_InstanceCount_isDone;
-		/// <summary>True if Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10 has executed. Set this to false to force re-execution of Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10</summary>
-		public bool Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isDone;
-		/// <summary>True if Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10 has performed initialisation. Set this to false to force re-execution of Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10</summary>
-		public bool Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isInitialised;
+		/// <summary>True if Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11 has executed. Set this to false to force re-execution of Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11</summary>
+		public bool Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isDone;
+		/// <summary>True if Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11 has performed initialisation. Set this to false to force re-execution of Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11</summary>
+		public bool Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isInitialised;
 		/// <summary>True if Changed_ClassCount has executed. Set this to false to force re-execution of Changed_ClassCount</summary>
 		public bool Changed_ClassCount_isDone;
 		/// <summary>True if Changed_InstanceCount has executed. Set this to false to force re-execution of Changed_InstanceCount</summary>
@@ -102,8 +96,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 		public Gaussian[][][] NoisyScoreDeltas_B;
 		public Gaussian[][][] NoisyScoreDeltas_F;
 		public Gaussian[][][] NoisyScores__B;
-		public DistributionStructArray<Gaussian,double>[][] NoisyScores__ClassMaxNoisyScore_B;
-		public Gaussian[][][] NoisyScores__ClassMaxNoisyScore_ClassRange_0__B;
+		public Gaussian[][] NoisyScores__B_reduced;
 		public DistributionStructArray<Gaussian,double>[] NoisyScores_F;
 		/// <summary>Message from use of 'NoisyScores'</summary>
 		public DistributionStructArray<Gaussian,double>[] NoisyScores_use_B;
@@ -143,17 +136,15 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 					this.numberOfIterationsDone = 0;
 					this.Changed_ClassCount_isDone = false;
 					this.Changed_ClassCount_InstanceCount_isDone = false;
-					this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isDone = false;
+					this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isDone = false;
 					this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_isDone = false;
 					this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount9_isDone = false;
 					this.Changed_ClassCount_FeatureCount_isDone = false;
-					this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isDone = false;
+					this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isDone = false;
 					this.Changed_ClassCount_FeatureCount_WeightPriors_isDone = false;
 					this.Changed_ClassCount_FeatureCount_WeightConstraints_isDone = false;
 					this.Changed_ClassCount_FeatureCount_WeightConstraints_WeightPriors_isDone = false;
-					this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isDone = false;
-					this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13_isDone = false;
-					this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14_isDone = false;
+					this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12_isDone = false;
 				}
 			}
 		}
@@ -168,16 +159,14 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				if (this.featureCount!=value) {
 					this.featureCount = value;
 					this.numberOfIterationsDone = 0;
-					this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isInitialised = false;
+					this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isInitialised = false;
 					this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount9_isInitialised = false;
 					this.Changed_ClassCount_FeatureCount_isDone = false;
-					this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isDone = false;
+					this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isDone = false;
 					this.Changed_ClassCount_FeatureCount_WeightPriors_isDone = false;
 					this.Changed_ClassCount_FeatureCount_WeightConstraints_isDone = false;
 					this.Changed_ClassCount_FeatureCount_WeightConstraints_WeightPriors_isDone = false;
-					this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isDone = false;
-					this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13_isDone = false;
-					this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14_isDone = false;
+					this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12_isDone = false;
 				}
 			}
 		}
@@ -194,12 +183,10 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.featureIndexes = value;
 				this.numberOfIterationsDone = 0;
-				this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isInitialised = false;
+				this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isInitialised = false;
 				this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount9_isInitialised = false;
-				this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isInitialised = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isDone = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13_isDone = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14_isDone = false;
+				this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isInitialised = false;
+				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12_isDone = false;
 			}
 		}
 
@@ -215,12 +202,10 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.featureValues = value;
 				this.numberOfIterationsDone = 0;
-				this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isInitialised = false;
+				this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isInitialised = false;
 				this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount9_isInitialised = false;
-				this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isInitialised = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isInitialised = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13_isDone = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14_isDone = false;
+				this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isInitialised = false;
+				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12_isDone = false;
 			}
 		}
 
@@ -236,13 +221,11 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 					this.numberOfIterationsDone = 0;
 					this.Changed_InstanceCount_isDone = false;
 					this.Changed_ClassCount_InstanceCount_isDone = false;
-					this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isDone = false;
+					this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isDone = false;
 					this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_isDone = false;
 					this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount9_isDone = false;
-					this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isInitialised = false;
-					this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isDone = false;
-					this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13_isDone = false;
-					this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14_isDone = false;
+					this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isInitialised = false;
+					this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12_isDone = false;
 				}
 			}
 		}
@@ -259,13 +242,11 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				}
 				this.instanceFeatureCounts = value;
 				this.numberOfIterationsDone = 0;
-				this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isInitialised = false;
+				this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isInitialised = false;
 				this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_isDone = false;
 				this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount9_isDone = false;
-				this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isInitialised = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isDone = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13_isDone = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14_isDone = false;
+				this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isInitialised = false;
+				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12_isDone = false;
 			}
 		}
 
@@ -286,14 +267,12 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			set {
 				this.weightConstraints = value;
 				this.numberOfIterationsDone = 0;
-				this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isInitialised = false;
+				this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isInitialised = false;
 				this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount9_isInitialised = false;
-				this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isInitialised = false;
+				this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isInitialised = false;
 				this.Changed_ClassCount_FeatureCount_WeightConstraints_isDone = false;
 				this.Changed_ClassCount_FeatureCount_WeightConstraints_WeightPriors_isDone = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isDone = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13_isDone = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14_isDone = false;
+				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12_isDone = false;
 			}
 		}
 
@@ -306,14 +285,12 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			set {
 				this.weightPriors = value;
 				this.numberOfIterationsDone = 0;
-				this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isInitialised = false;
+				this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isInitialised = false;
 				this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount9_isInitialised = false;
-				this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isInitialised = false;
+				this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isInitialised = false;
 				this.Changed_ClassCount_FeatureCount_WeightPriors_isDone = false;
 				this.Changed_ClassCount_FeatureCount_WeightConstraints_WeightPriors_isDone = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isDone = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13_isDone = false;
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14_isDone = false;
+				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12_isDone = false;
 			}
 		}
 
@@ -369,41 +346,11 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			this.Changed_ClassCount_FeatureCount_isDone = true;
 		}
 
-		/// <summary>Computations that depend on the observed value of ClassCount and FeatureCount and FeatureIndexes and FeatureValues and InstanceCount and InstanceFeatureCounts and numberOfIterationsDecreased and WeightConstraints and WeightPriors</summary>
-		private void Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13()
-		{
-			if (this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13_isDone) {
-				return ;
-			}
-			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
-				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
-					for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
-						this.FeatureScores_F[InstanceRange][ClassRange][InstanceFeatureRanges] = GaussianProductOpBase.ProductAverageConditional(this.featureValues[InstanceRange][InstanceFeatureRanges], this.Weights_FeatureIndexes_F[ClassRange][InstanceRange][InstanceFeatureRanges]);
-					}
-					this.Scores_F[InstanceRange][ClassRange] = FastSumOp.SumAverageConditional(this.FeatureScores_F[InstanceRange][ClassRange]);
-					this.NoisyScores_F[InstanceRange][ClassRange] = GaussianFromMeanAndVarianceOp.SampleAverageConditional(this.Scores_F[InstanceRange][ClassRange], 1.0);
-				}
-				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-					this.MaxNoisyScore_rep_F_marginal[InstanceRange][ClassMaxNoisyScore] = ReplicateOp_Divide.Marginal<Gaussian>(this.MaxNoisyScore_rep_B_toDef[InstanceRange][ClassMaxNoisyScore], this.NoisyScores_F[InstanceRange][ClassMaxNoisyScore], this.MaxNoisyScore_rep_F_marginal[InstanceRange][ClassMaxNoisyScore]);
-				}
-				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
-					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-						this.MaxNoisyScore_rep_F[InstanceRange][ClassMaxNoisyScore][ClassRange] = ReplicateOp_Divide.UsesAverageConditional<Gaussian>(this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore][ClassRange], this.MaxNoisyScore_rep_F_marginal[InstanceRange][ClassMaxNoisyScore], ClassRange, this.MaxNoisyScore_rep_F[InstanceRange][ClassMaxNoisyScore][ClassRange]);
-						if (ClassMaxNoisyScore!=ClassRange) {
-							this.NoisyScoreDeltas_F[InstanceRange][ClassMaxNoisyScore][ClassRange] = DoublePlusOp.AAverageConditional(this.MaxNoisyScore_rep_F[InstanceRange][ClassMaxNoisyScore][ClassRange], this.NoisyScores_F[InstanceRange][ClassRange]);
-							this.NoisyScoreDeltas_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = IsPositiveOp_Proper.XAverageConditional(Bernoulli.PointMass(true), this.NoisyScoreDeltas_F[InstanceRange][ClassMaxNoisyScore][ClassRange]);
-						}
-					}
-				}
-			}
-			this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13_isDone = true;
-		}
-
 		/// <summary>Computations that depend on the observed value of ClassCount and FeatureCount and FeatureIndexes and FeatureValues and InstanceCount and InstanceFeatureCounts and numberOfIterations and WeightConstraints and WeightPriors</summary>
 		/// <param name="numberOfIterations">The number of times to iterate each loop</param>
-		private void Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14(int numberOfIterations)
+		private void Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12(int numberOfIterations)
 		{
-			if (this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14_isDone) {
+			if (this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12_isDone) {
 				return ;
 			}
 			for(int iteration = this.numberOfIterationsDone; iteration<numberOfIterations; iteration++) {
@@ -420,7 +367,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 						this.NoisyScores_F[InstanceRange][ClassRange] = GaussianFromMeanAndVarianceOp.SampleAverageConditional(this.Scores_F[InstanceRange][ClassRange], 1.0);
 						for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
 							if (ClassMaxNoisyScore!=ClassRange) {
-								this.vdouble740_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = DoublePlusOp.SumAverageConditional(this.NoisyScoreDeltas_B[InstanceRange][ClassMaxNoisyScore][ClassRange], this.NoisyScores_F[InstanceRange][ClassRange]);
 								this.MaxNoisyScore_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange] = LowPriorityBackwardOp.ValueAverageConditional<Gaussian>(this.vdouble740_B[InstanceRange][ClassMaxNoisyScore][ClassRange]);
 								this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = ArrayHelper.SetTo<Gaussian>(this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore][ClassRange], this.MaxNoisyScore_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange]);
 							}
@@ -437,7 +383,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 					}
 					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
 						this.Labels_InstanceRange__selector_cases_uses_B[InstanceRange][ClassMaxNoisyScore][7] = Bernoulli.FromLogOdds(ReplicateOp.LogEvidenceRatio<Gaussian>(this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore], this.NoisyScores_F[InstanceRange][ClassMaxNoisyScore], this.MaxNoisyScore_rep_F[InstanceRange][ClassMaxNoisyScore]));
-						this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore][ClassMaxNoisyScore] = ArrayHelper.SetTo<Gaussian>(this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore][ClassMaxNoisyScore], this.MaxNoisyScore_rep_B_toDef[InstanceRange][ClassMaxNoisyScore]);
 					}
 					for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
 						for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
@@ -445,10 +390,8 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 								this.NoisyScoreDeltas_F[InstanceRange][ClassMaxNoisyScore][ClassRange] = DoublePlusOp.AAverageConditional(this.MaxNoisyScore_rep_F[InstanceRange][ClassMaxNoisyScore][ClassRange], this.NoisyScores_F[InstanceRange][ClassRange]);
 								this.Labels_InstanceRange__selector_cases_rep7_uses_B[InstanceRange][ClassMaxNoisyScore][ClassRange][0] = Bernoulli.FromLogOdds(IsPositiveOp.LogEvidenceRatio(true, this.NoisyScoreDeltas_F[InstanceRange][ClassMaxNoisyScore][ClassRange]));
 								this.NoisyScoreDeltas_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = IsPositiveOp_Proper.XAverageConditional(Bernoulli.PointMass(true), this.NoisyScoreDeltas_F[InstanceRange][ClassMaxNoisyScore][ClassRange]);
-								this.NoisyScores__ClassMaxNoisyScore_ClassRange_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange] = DoublePlusOp.BAverageConditional(this.MaxNoisyScore_rep_F[InstanceRange][ClassMaxNoisyScore][ClassRange], this.NoisyScoreDeltas_B[InstanceRange][ClassMaxNoisyScore][ClassRange]);
-								this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = ArrayHelper.SetTo<Gaussian>(this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore][ClassRange], this.NoisyScores__ClassMaxNoisyScore_ClassRange_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange]);
+								this.vdouble740_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = DoublePlusOp.SumAverageConditional(this.NoisyScoreDeltas_B[InstanceRange][ClassMaxNoisyScore][ClassRange], this.NoisyScores_F[InstanceRange][ClassRange]);
 							}
-							this.NoisyScores__B[InstanceRange][ClassRange][ClassMaxNoisyScore] = ArrayHelper.SetTo<Gaussian>(this.NoisyScores__B[InstanceRange][ClassRange][ClassMaxNoisyScore], this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore][ClassRange]);
 						}
 					}
 					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
@@ -464,6 +407,12 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 					this.Labels_InstanceRange__selector_uses_F[InstanceRange][1] = ReplicateOp_NoDivide.UsesAverageConditional<Discrete>(this.Labels_InstanceRange__selector_uses_B[InstanceRange], this.Labels_uses_F[InstanceRange][1], 1, this.Labels_InstanceRange__selector_uses_F[InstanceRange][1]);
 					this.Labels_InstanceRange__selector_rep_F_marginal[InstanceRange] = ReplicateOp_Divide.Marginal<Discrete>(this.Labels_InstanceRange__selector_rep_B_toDef[InstanceRange], this.Labels_InstanceRange__selector_uses_F[InstanceRange][1], this.Labels_InstanceRange__selector_rep_F_marginal[InstanceRange]);
 					for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
+						if (this.classCount>0) {
+							this.NoisyScores__B_reduced[InstanceRange][ClassRange] = ArrayHelper.SetTo<Gaussian>(this.NoisyScores__B_reduced[InstanceRange][ClassRange], this.MaxNoisyScore_rep_B_toDef[InstanceRange][ClassRange]);
+						}
+						for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
+							this.NoisyScores__B[InstanceRange][ClassRange][ClassMaxNoisyScore] = this.NoisyScores__B_reduced[InstanceRange][ClassRange];
+						}
 						this.Labels_InstanceRange__selector_rep_F[InstanceRange][ClassRange] = ReplicateOp_Divide.UsesAverageConditional<Discrete>(this.Labels_InstanceRange__selector_rep_B_reduced, this.Labels_InstanceRange__selector_rep_F_marginal[InstanceRange], ClassRange, this.Labels_InstanceRange__selector_rep_F[InstanceRange][ClassRange]);
 						this.NoisyScores_use_B[InstanceRange][ClassRange] = GateEnterOp<double>.ValueAverageConditional<Gaussian>(this.NoisyScores__B[InstanceRange][ClassRange], this.Labels_InstanceRange__selector_rep_F[InstanceRange][ClassRange], this.NoisyScores_F[InstanceRange][ClassRange], this.NoisyScores_use_B[InstanceRange][ClassRange]);
 						this.Scores_B[InstanceRange][ClassRange] = GaussianFromMeanAndVarianceOp.MeanAverageConditional(this.NoisyScores_use_B[InstanceRange][ClassRange], 1.0);
@@ -483,40 +432,21 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				this.Labels_use_B[InstanceRange] = ReplicateOp_NoDivide.DefAverageConditional<Discrete>(this.Labels_uses_B[InstanceRange], this.Labels_use_B[InstanceRange]);
 				this.Labels_marginal_F[InstanceRange] = VariableOp.MarginalAverageConditional<Discrete>(this.Labels_use_B[InstanceRange], this.Labels_F_reduced, this.Labels_marginal_F[InstanceRange]);
 			}
-			this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14_isDone = true;
-		}
-
-		/// <summary>Computations that depend on the observed value of ClassCount and FeatureCount and FeatureIndexes and InstanceCount and InstanceFeatureCounts and numberOfIterationsDecreased and WeightConstraints and WeightPriors and must reset on changes to FeatureValues</summary>
-		/// <param name="initialise">If true, reset messages that initialise loops</param>
-		private void Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12(bool initialise)
-		{
-			if (this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isDone&&((!initialise)||this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isInitialised)) {
-				return ;
-			}
-			for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
-				this.Weights_depth1_F_ClassRange__marginal[ClassRange] = JaggedSubarrayOp<double>.Marginal<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.Weights_depth1_F[ClassRange], this.Weights_FeatureIndexes_B[ClassRange], this.featureIndexes, this.Weights_depth1_F_ClassRange__marginal[ClassRange]);
-			}
-			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
-				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
-					this.Weights_FeatureIndexes_F[ClassRange][InstanceRange] = JaggedSubarrayOp<double>.ItemsAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.IndexedWeights_B[InstanceRange][ClassRange], this.Weights_depth1_F[ClassRange], this.Weights_depth1_F_ClassRange__marginal[ClassRange], this.featureIndexes, InstanceRange, this.Weights_FeatureIndexes_F[ClassRange][InstanceRange]);
-				}
-			}
-			this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isDone = true;
-			this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isInitialised = true;
+			this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12_isDone = true;
 		}
 
 		/// <summary>Computations that depend on the observed value of ClassCount and FeatureCount and numberOfIterationsDecreased and must reset on changes to FeatureIndexes and FeatureValues and InstanceCount and InstanceFeatureCounts and WeightConstraints and WeightPriors</summary>
 		/// <param name="initialise">If true, reset messages that initialise loops</param>
-		private void Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11(bool initialise)
+		private void Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10(bool initialise)
 		{
-			if (this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isDone&&((!initialise)||this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isInitialised)) {
+			if (this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isDone&&((!initialise)||this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isInitialised)) {
 				return ;
 			}
 			for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
 				this.Weights_depth1_F_ClassRange__marginal[ClassRange] = JaggedSubarrayOp<double>.MarginalInit<DistributionStructArray<Gaussian,double>>(this.Weights_depth1_F[ClassRange]);
 			}
-			this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isDone = true;
-			this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isInitialised = true;
+			this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isDone = true;
+			this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isInitialised = true;
 		}
 
 		/// <summary>Computations that depend on the observed value of ClassCount and FeatureCount and WeightConstraints</summary>
@@ -578,11 +508,17 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				this.FeatureScores_F[InstanceRange] = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.classCount);
 				this.FeatureScores_B[InstanceRange] = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.classCount);
 				this.Scores_F[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.classCount);
+				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
+					this.Scores_F[InstanceRange][ClassRange] = Gaussian.Uniform();
+				}
 				this.Scores_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.classCount);
 				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
 					this.Scores_B[InstanceRange][ClassRange] = Gaussian.Uniform();
 				}
 				this.NoisyScores_F[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.classCount);
+				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
+					this.NoisyScores_F[InstanceRange][ClassRange] = Gaussian.Uniform();
+				}
 			}
 			for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
 				this.Weights_FeatureIndexes_F[ClassRange] = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.instanceCount);
@@ -590,7 +526,13 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			}
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
 				this.MaxNoisyScore_rep_F_marginal[InstanceRange] = new Gaussian[this.classCount];
+				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
+					this.MaxNoisyScore_rep_F_marginal[InstanceRange][ClassMaxNoisyScore] = ReplicateOp_Divide.MarginalInit<Gaussian>(this.NoisyScores_F[InstanceRange][ClassMaxNoisyScore]);
+				}
 				this.MaxNoisyScore_rep_B_toDef[InstanceRange] = new Gaussian[this.classCount];
+				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
+					this.MaxNoisyScore_rep_B_toDef[InstanceRange][ClassMaxNoisyScore] = ReplicateOp_Divide.ToDefInit<Gaussian>(this.NoisyScores_F[InstanceRange][ClassMaxNoisyScore]);
+				}
 			}
 			this.Labels_InstanceRange__selector_rep_B_reduced = default(Discrete);
 			if (this.instanceCount>0) {
@@ -653,9 +595,23 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
 					this.NoisyScoreDeltas_F[InstanceRange][ClassMaxNoisyScore] = new Gaussian[this.classCount];
 				}
+				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
+					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
+						if (ClassMaxNoisyScore!=ClassRange) {
+							this.NoisyScoreDeltas_F[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
+						}
+					}
+				}
 				this.NoisyScoreDeltas_B[InstanceRange] = new Gaussian[this.classCount][];
 				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
 					this.NoisyScoreDeltas_B[InstanceRange][ClassMaxNoisyScore] = new Gaussian[this.classCount];
+				}
+				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
+					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
+						if (ClassMaxNoisyScore!=ClassRange) {
+							this.NoisyScoreDeltas_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
+						}
+					}
 				}
 				this.vdouble740_B[InstanceRange] = new Gaussian[this.classCount][];
 				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
@@ -665,13 +621,30 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
 					this.MaxNoisyScore_0__B[InstanceRange][ClassMaxNoisyScore] = new Gaussian[this.classCount];
 				}
+				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
+					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
+						if (ClassMaxNoisyScore!=ClassRange) {
+							this.MaxNoisyScore_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
+						}
+					}
+				}
 				this.MaxNoisyScore_rep_B[InstanceRange] = new Gaussian[this.classCount][];
 				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
 					this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore] = new Gaussian[this.classCount];
 				}
+				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
+					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
+						this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
+					}
+				}
 				this.MaxNoisyScore_rep_F[InstanceRange] = new Gaussian[this.classCount][];
 				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
 					this.MaxNoisyScore_rep_F[InstanceRange][ClassMaxNoisyScore] = new Gaussian[this.classCount];
+				}
+				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
+					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
+						this.MaxNoisyScore_rep_F[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
+					}
 				}
 				this.Labels_InstanceRange__selector_cases_rep7_uses_B[InstanceRange] = new Bernoulli[this.classCount][][];
 				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
@@ -701,31 +674,18 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
 					this.Labels_InstanceRange__selector_rep_F[InstanceRange][ClassRange] = ArrayHelper.MakeUniform<Discrete>(Discrete.Uniform(this.classCount));
 				}
-				this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange] = new DistributionStructArray<Gaussian,double>[this.classCount];
-				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-					this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore] = new DistributionStructArray<Gaussian,double>(this.classCount);
-				}
+				this.NoisyScores__B_reduced[InstanceRange] = new Gaussian[this.classCount];
 				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
-					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-						this.NoisyScores__ClassMaxNoisyScore_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
-					}
-				}
-				this.NoisyScores__ClassMaxNoisyScore_ClassRange_0__B[InstanceRange] = new Gaussian[this.classCount][];
-				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-					this.NoisyScores__ClassMaxNoisyScore_ClassRange_0__B[InstanceRange][ClassMaxNoisyScore] = new Gaussian[this.classCount];
-				}
-				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
-					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-						if (ClassMaxNoisyScore!=ClassRange) {
-							this.NoisyScores__ClassMaxNoisyScore_ClassRange_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
-						}
+					this.NoisyScores__B_reduced[InstanceRange][ClassRange] = default(Gaussian);
+					if (this.classCount>0) {
+						this.NoisyScores__B_reduced[InstanceRange][ClassRange] = Gaussian.Uniform();
 					}
 				}
 				this.NoisyScores__B[InstanceRange] = new Gaussian[this.classCount][];
 				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
 					this.NoisyScores__B[InstanceRange][ClassRange] = new Gaussian[this.classCount];
 					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-						this.NoisyScores__B[InstanceRange][ClassRange][ClassMaxNoisyScore] = Gaussian.Uniform();
+						this.NoisyScores__B[InstanceRange][ClassRange][ClassMaxNoisyScore] = this.NoisyScores__B_reduced[InstanceRange][ClassRange];
 					}
 				}
 				this.NoisyScores_use_B[InstanceRange] = new DistributionStructArray<Gaussian,double>(this.classCount);
@@ -752,11 +712,17 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
 					this.IndexedWeights_B[InstanceRange][ClassRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
 					this.FeatureScores_F[InstanceRange][ClassRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
+					for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
+						this.FeatureScores_F[InstanceRange][ClassRange][InstanceFeatureRanges] = Gaussian.Uniform();
+					}
 					this.FeatureScores_B[InstanceRange][ClassRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
 					for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
 						this.FeatureScores_B[InstanceRange][ClassRange][InstanceFeatureRanges] = Gaussian.Uniform();
 					}
 					this.Weights_FeatureIndexes_F[ClassRange][InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
+					for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
+						this.Weights_FeatureIndexes_F[ClassRange][InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
+					}
 					this.Weights_FeatureIndexes_B[ClassRange][InstanceRange] = new DistributionStructArray<Gaussian,double>(this.instanceFeatureCounts[InstanceRange]);
 				}
 			}
@@ -774,8 +740,6 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
 					for(int InstanceFeatureRanges = 0; InstanceFeatureRanges<this.instanceFeatureCounts[InstanceRange]; InstanceFeatureRanges++) {
 						this.IndexedWeights_B[InstanceRange][ClassRange][InstanceFeatureRanges] = Gaussian.Uniform();
-						this.FeatureScores_F[InstanceRange][ClassRange][InstanceFeatureRanges] = Gaussian.Uniform();
-						this.Weights_FeatureIndexes_F[ClassRange][InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
 						this.Weights_FeatureIndexes_B[ClassRange][InstanceRange][InstanceFeatureRanges] = Gaussian.Uniform();
 					}
 				}
@@ -786,42 +750,22 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 
 		/// <summary>Computations that depend on the observed value of ClassCount and InstanceCount and numberOfIterationsDecreased and must reset on changes to FeatureCount and FeatureIndexes and FeatureValues and InstanceFeatureCounts and WeightConstraints and WeightPriors</summary>
 		/// <param name="initialise">If true, reset messages that initialise loops</param>
-		private void Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10(bool initialise)
+		private void Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11(bool initialise)
 		{
-			if (this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isDone&&((!initialise)||this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isInitialised)) {
+			if (this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isDone&&((!initialise)||this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isInitialised)) {
 				return ;
 			}
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
 				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
-					this.Scores_F[InstanceRange][ClassRange] = Gaussian.Uniform();
-					this.NoisyScores_F[InstanceRange][ClassRange] = Gaussian.Uniform();
-				}
-				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-					this.MaxNoisyScore_rep_F_marginal[InstanceRange][ClassMaxNoisyScore] = ReplicateOp_Divide.MarginalInit<Gaussian>(this.NoisyScores_F[InstanceRange][ClassMaxNoisyScore]);
-					this.MaxNoisyScore_rep_B_toDef[InstanceRange][ClassMaxNoisyScore] = ReplicateOp_Divide.ToDefInit<Gaussian>(this.NoisyScores_F[InstanceRange][ClassMaxNoisyScore]);
-				}
-				for(int ClassRange = 0; ClassRange<this.classCount; ClassRange++) {
 					for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
 						if (ClassMaxNoisyScore!=ClassRange) {
-							this.NoisyScoreDeltas_F[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
-							this.NoisyScoreDeltas_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
 							this.vdouble740_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
-							this.MaxNoisyScore_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
-						}
-						this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
-						this.MaxNoisyScore_rep_F[InstanceRange][ClassMaxNoisyScore][ClassRange] = Gaussian.Uniform();
-						if (ClassMaxNoisyScore!=ClassRange) {
-							this.MaxNoisyScore_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange] = LowPriorityBackwardOp.ValueAverageConditional<Gaussian>(this.vdouble740_B[InstanceRange][ClassMaxNoisyScore][ClassRange]);
-							this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore][ClassRange] = ArrayHelper.SetTo<Gaussian>(this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore][ClassRange], this.MaxNoisyScore_0__B[InstanceRange][ClassMaxNoisyScore][ClassRange]);
 						}
 					}
 				}
-				for(int ClassMaxNoisyScore = 0; ClassMaxNoisyScore<this.classCount; ClassMaxNoisyScore++) {
-					this.MaxNoisyScore_rep_B_toDef[InstanceRange][ClassMaxNoisyScore] = ReplicateOp_Divide.ToDef<Gaussian>(this.MaxNoisyScore_rep_B[InstanceRange][ClassMaxNoisyScore], this.MaxNoisyScore_rep_B_toDef[InstanceRange][ClassMaxNoisyScore]);
-				}
 			}
-			this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isDone = true;
-			this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isInitialised = true;
+			this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isDone = true;
+			this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isInitialised = true;
 		}
 
 		/// <summary>Computations that depend on the observed value of InstanceCount</summary>
@@ -866,13 +810,12 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			this.Labels_InstanceRange__selector_rep_F_marginal = new Discrete[this.instanceCount];
 			this.Labels_InstanceRange__selector_rep_B_toDef = new Discrete[this.instanceCount];
 			this.Labels_InstanceRange__selector_rep_F = new Discrete[this.instanceCount][];
-			this.NoisyScores__ClassMaxNoisyScore_B = new DistributionStructArray<Gaussian,double>[this.instanceCount][];
-			this.NoisyScores__ClassMaxNoisyScore_ClassRange_0__B = new Gaussian[this.instanceCount][][];
+			this.NoisyScores__B_reduced = new Gaussian[this.instanceCount][];
 			this.NoisyScores__B = new Gaussian[this.instanceCount][][];
 			this.NoisyScores_use_B = new DistributionStructArray<Gaussian,double>[this.instanceCount];
 			this.Labels_marginal_F = new DistributionRefArray<Discrete,int>(this.instanceCount);
-			this.Labels_use_B = new DistributionRefArray<Discrete,int>(this.instanceCount);
 			this.Labels_uses_B = new Discrete[this.instanceCount][];
+			this.Labels_use_B = new DistributionRefArray<Discrete,int>(this.instanceCount);
 			this.Labels_InstanceRange__selector_B = new Discrete[this.instanceCount];
 			for(int InstanceRange = 0; InstanceRange<this.instanceCount; InstanceRange++) {
 				this.Labels_uses_B[InstanceRange] = new Discrete[2];
@@ -897,29 +840,25 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
 			if (numberOfIterations!=this.numberOfIterationsDone) {
 				if (numberOfIterations<this.numberOfIterationsDone) {
 					this.numberOfIterationsDone = 0;
-					this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10_isDone = false;
+					this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11_isDone = false;
 					this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount9_isDone = false;
-					this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11_isDone = false;
-					this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12_isDone = false;
-					this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13_isDone = false;
+					this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10_isDone = false;
 				}
-				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14_isDone = false;
+				this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12_isDone = false;
 			}
 			this.Constant();
 			this.Changed_InstanceCount();
 			this.Changed_ClassCount();
 			this.Changed_ClassCount_InstanceCount();
-			this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur10(initialise);
+			this.Changed_ClassCount_InstanceCount_numberOfIterationsDecreased_Init_FeatureCount_FeatureIndexes_Featur11(initialise);
 			this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts();
 			this.Changed_ClassCount_InstanceCount_InstanceFeatureCounts_numberOfIterationsDecreased_Init_FeatureCount9(initialise);
 			this.Changed_ClassCount_FeatureCount();
-			this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan11(initialise);
+			this.Changed_ClassCount_FeatureCount_numberOfIterationsDecreased_Init_FeatureIndexes_FeatureValues_Instan10(initialise);
 			this.Changed_ClassCount_FeatureCount_WeightPriors();
 			this.Changed_ClassCount_FeatureCount_WeightConstraints();
 			this.Changed_ClassCount_FeatureCount_WeightConstraints_WeightPriors();
-			this.Changed_ClassCount_FeatureCount_FeatureIndexes_InstanceCount_InstanceFeatureCounts_numberOfIteration12(initialise);
-			this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num13();
-			this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num14(numberOfIterations);
+			this.Changed_ClassCount_FeatureCount_FeatureIndexes_FeatureValues_InstanceCount_InstanceFeatureCounts_num12(numberOfIterations);
 			this.numberOfIterationsDone = numberOfIterations;
 		}
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/GeneratedAlgorithms/MatchboxCommunityTraining_EP.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/GeneratedAlgorithms/MatchboxCommunityTraining_EP.cs
@@ -198,7 +198,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 		/// <summary>The constant 'CurrentRating'</summary>
 		public int[] CurrentRating;
 		public DistributionStructArray<Gaussian,double> ItemBias_F;
-		public DistributionStructArray<Gaussian,double> ItemBias_itemItemIds_observation__B;
 		public DistributionStructArray<Gaussian,double> ItemBias_itemItemIds_observation__F;
 		/// <summary>Message to marginal of 'ItemBias'</summary>
 		public DistributionStructArray<Gaussian,double> ItemBias_marginal_F;
@@ -218,7 +217,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 		public Gaussian ItemBiasFeatureWeights_F_reduced;
 		/// <summary>Message to marginal of 'ItemBiasFeatureWeights'</summary>
 		public DistributionStructArray<Gaussian,double> ItemBiasFeatureWeights_marginal_F;
-		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> ItemBiasFeatureWeights_NonZeroItemFeatureIndices_B;
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> ItemBiasFeatureWeights_NonZeroItemFeatureIndices_F;
 		/// <summary>Field backing the ItemBiasInitializer property</summary>
 		private DistributionStructArray<Gaussian,double> itemBiasInitializer;
@@ -260,7 +258,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> ItemTraits_depth0_uses_F_1__marginal;
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> ItemTraits_F;
 		public Gaussian[][] ItemTraits_index10_index10_0__index10__B;
-		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> ItemTraits_itemItemIds_observation__B;
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> ItemTraits_itemItemIds_observation__F;
 		/// <summary>Message to marginal of 'ItemTraits'</summary>
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> ItemTraits_marginal_F;
@@ -317,7 +314,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 		/// <summary>Buffer for DoubleIsBetweenOp.XAverageConditional</summary>
 		public double[] true_logZ;
 		public DistributionStructArray<Gaussian,double> UserBias_F;
-		public DistributionStructArray<Gaussian,double> UserBias_itemUserIds_observation__B;
 		public DistributionStructArray<Gaussian,double> UserBias_itemUserIds_observation__F;
 		/// <summary>Message to marginal of 'UserBias'</summary>
 		public DistributionStructArray<Gaussian,double> UserBias_marginal_F;
@@ -337,7 +333,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 		public Gaussian UserBiasFeatureWeights_F_reduced;
 		/// <summary>Message to marginal of 'UserBiasFeatureWeights'</summary>
 		public DistributionStructArray<Gaussian,double> UserBiasFeatureWeights_marginal_F;
-		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> UserBiasFeatureWeights_NonZeroUserFeatureIndices_B;
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> UserBiasFeatureWeights_NonZeroUserFeatureIndices_F;
 		/// <summary>Field backing the UserBiasInitializer property</summary>
 		private DistributionStructArray<Gaussian,double> userBiasInitializer;
@@ -373,7 +368,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 		/// <summary>Buffer for GetItemsOp&lt;double[]&gt;.ItemsAverageConditional&lt;DistributionRefArray&lt;DistributionStructArray&lt;Gaussian, double&gt;, double[]&gt;, DistributionStructArray&lt;Gaussian, double&gt;&gt;</summary>
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> UserThresholds_depth0_uses_F_1__marginal;
 		public DistributionStructArray<Gaussian,double> UserThresholds_F_reduced;
-		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> UserThresholds_itemUserIds_observation__B;
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> UserThresholds_itemUserIds_observation__F;
 		/// <summary>Message to marginal of 'UserThresholds'</summary>
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> UserThresholds_marginal_F;
@@ -414,7 +408,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 		public DistributionStructArray<Gaussian,double>[] userTraitMean_B;
 		public DistributionStructArray<Gaussian,double>[] userTraitMean_F;
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> UserTraits_F;
-		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> UserTraits_itemUserIds_observation__B;
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> UserTraits_itemUserIds_observation__F;
 		/// <summary>Message to marginal of 'UserTraits'</summary>
 		public DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]> UserTraits_marginal_F;
@@ -2264,11 +2257,8 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 					this.vdouble__61_B[observation][userThreshold] = GaussianFromMeanAndVarianceOp.MeanAverageConditional(this.NoisyUserThresholds_use_B[observation][userThreshold], this.userThresholdNoiseVariance);
 					this.UserThresholdsObs_B[observation][userThreshold] = GaussianProductOp_SHG09.AAverageConditional(this.vdouble__61_B[observation][userThreshold], 1.0);
 				}
-				for(int trait = 0; trait<this.traitCount; trait++) {
-					this.UserTraits_itemUserIds_observation__B[observation][trait] = ArrayHelper.SetTo<Gaussian>(this.UserTraits_itemUserIds_observation__B[observation][trait], this.userTrait_B[observation][trait]);
-				}
 			}
-			this.UserTraits_uses_B[1] = GetItemsOp<double[]>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.UserTraits_itemUserIds_observation__B, this.userIds, this.UserTraits_uses_B[1]);
+			this.UserTraits_uses_B[1] = GetItemsOp<double[]>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.userTrait_B, this.userIds, this.UserTraits_uses_B[1]);
 			this.UserTraits_use_B = ReplicateOp_NoDivide.DefAverageConditional<DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.UserTraits_uses_B, this.UserTraits_use_B);
 			for(int user = 0; user<this.userCount; user++) {
 				for(int trait = 0; trait<this.traitCount; trait++) {
@@ -2292,10 +2282,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 					this.UserTraitFeatureWeights_use_F_trait__marginal[trait] = JaggedSubarrayOp<double>.MarginalIncrement<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.UserTraitFeatureWeights_use_F_trait__marginal[trait], this.UserTraitFeatureWeights_NonZeroUserFeatureIndices_F[trait][user], this.nonZeroUserTraitFeatureWeights_B[user][trait], this.nonZeroUserFeatureIndices, user);
 				}
 			}
-			for(int observation = 0; observation<this.observationCount; observation++) {
-				this.UserBias_itemUserIds_observation__B[observation] = ArrayHelper.SetTo<Gaussian>(this.UserBias_itemUserIds_observation__B[observation], this.userBiasObs_B[observation]);
-			}
-			this.UserBias_uses_B[1] = GetItemsOp<double>.ArrayAverageConditional<Gaussian,DistributionStructArray<Gaussian,double>>(this.UserBias_itemUserIds_observation__B, this.userIds, this.UserBias_uses_B[1]);
+			this.UserBias_uses_B[1] = GetItemsOp<double>.ArrayAverageConditional<Gaussian,DistributionStructArray<Gaussian,double>>(this.userBiasObs_B, this.userIds, this.UserBias_uses_B[1]);
 			this.UserBias_use_B = ReplicateOp_NoDivide.DefAverageConditional<DistributionStructArray<Gaussian,double>>(this.UserBias_uses_B, this.UserBias_use_B);
 			for(int user = 0; user<this.userCount; user++) {
 				this.userBiasMean_B[user] = GaussianFromMeanAndVarianceOp.MeanAverageConditional(this.UserBias_use_B[user], this.userBiasVariance);
@@ -2313,12 +2300,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 			for(int trait = 0; trait<this.traitCount; trait++) {
 				this.ItemTraitFeatureWeights_use_F_trait__marginal[trait] = JaggedSubarrayOp<double>.Marginal<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.ItemTraitFeatureWeights_F[trait], this.ItemTraitFeatureWeights_NonZeroItemFeatureIndices_B[trait], this.nonZeroItemFeatureIndices, this.ItemTraitFeatureWeights_use_F_trait__marginal[trait]);
 			}
-			for(int observation = 0; observation<this.observationCount; observation++) {
-				for(int trait = 0; trait<this.traitCount; trait++) {
-					this.ItemTraits_itemItemIds_observation__B[observation][trait] = ArrayHelper.SetTo<Gaussian>(this.ItemTraits_itemItemIds_observation__B[observation][trait], this.itemTrait_B[observation][trait]);
-				}
-			}
-			this.ItemTraits_depth0_uses_B[1] = GetItemsOp<double[]>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.ItemTraits_itemItemIds_observation__B, this.itemIds, this.ItemTraits_depth0_uses_B[1]);
+			this.ItemTraits_depth0_uses_B[1] = GetItemsOp<double[]>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.itemTrait_B, this.itemIds, this.ItemTraits_depth0_uses_B[1]);
 			this.ItemTraits_depth0_B = ReplicateOp_NoDivide.DefAverageConditional<DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.ItemTraits_depth0_uses_B, this.ItemTraits_depth0_B);
 			for(int item = 0; item<this.itemCount; item++) {
 				for(int trait = 0; trait<this.traitCount; trait++) {
@@ -2337,10 +2319,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 					this.ItemTraitFeatureWeights_use_F_trait__marginal[trait] = JaggedSubarrayOp<double>.MarginalIncrement<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.ItemTraitFeatureWeights_use_F_trait__marginal[trait], this.ItemTraitFeatureWeights_NonZeroItemFeatureIndices_F[trait][item], this.nonZeroItemTraitFeatureWeights_B[item][trait], this.nonZeroItemFeatureIndices, item);
 				}
 			}
-			for(int observation = 0; observation<this.observationCount; observation++) {
-				this.ItemBias_itemItemIds_observation__B[observation] = ArrayHelper.SetTo<Gaussian>(this.ItemBias_itemItemIds_observation__B[observation], this.itemBiasObs_B[observation]);
-			}
-			this.ItemBias_uses_B[1] = GetItemsOp<double>.ArrayAverageConditional<Gaussian,DistributionStructArray<Gaussian,double>>(this.ItemBias_itemItemIds_observation__B, this.itemIds, this.ItemBias_uses_B[1]);
+			this.ItemBias_uses_B[1] = GetItemsOp<double>.ArrayAverageConditional<Gaussian,DistributionStructArray<Gaussian,double>>(this.itemBiasObs_B, this.itemIds, this.ItemBias_uses_B[1]);
 			this.ItemBias_use_B = ReplicateOp_NoDivide.DefAverageConditional<DistributionStructArray<Gaussian,double>>(this.ItemBias_uses_B, this.ItemBias_use_B);
 			for(int item = 0; item<this.itemCount; item++) {
 				this.itemBiasMean_B[item] = GaussianFromMeanAndVarianceOp.MeanAverageConditional(this.ItemBias_use_B[item], this.itemBiasVariance);
@@ -2388,16 +2367,9 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 					this.UserThresholds_uses_B[0][userThreshold][1] = ArrayHelper.SetTo<Gaussian>(this.UserThresholds_uses_B[0][userThreshold][1], this.UserThresholds_rep_B_toDef[userThreshold]);
 				}
 			}
-			for(int observation = 0; observation<this.observationCount; observation++) {
-				for(int userThreshold = 0; userThreshold<this.userThresholdCount; userThreshold++) {
-					if (!this.useSharedUserThresholds) {
-						this.UserThresholds_itemUserIds_observation__B[observation][userThreshold] = ArrayHelper.SetTo<Gaussian>(this.UserThresholds_itemUserIds_observation__B[observation][userThreshold], this.UserThresholdsObs_B[observation][userThreshold]);
-					}
-				}
-			}
 			if (!this.useSharedUserThresholds) {
 				if (!this.useSharedUserThresholds) {
-					this.UserThresholds_depth0_uses_B[1] = GetItemsOp<double[]>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.UserThresholds_itemUserIds_observation__B, this.userIds, this.UserThresholds_depth0_uses_B[1]);
+					this.UserThresholds_depth0_uses_B[1] = GetItemsOp<double[]>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.UserThresholdsObs_B, this.userIds, this.UserThresholds_depth0_uses_B[1]);
 				}
 			}
 			for(int user = 0; user<this.userCount; user++) {
@@ -2522,24 +2494,8 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 						this.UserThresholds_depth0_uses_F_1__marginal = GetItemsOp<double[]>.MarginalIncrement<DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>,DistributionStructArray<Gaussian,double>>(this.UserThresholds_depth0_uses_F_1__marginal, this.UserThresholds_itemUserIds_observation__F[observation], this.UserThresholdsObs_B[observation], this.userIds, observation);
 					}
 					this.UserTraits_uses_F_1__marginal = GetItemsOp<double[]>.MarginalIncrement<DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>,DistributionStructArray<Gaussian,double>>(this.UserTraits_uses_F_1__marginal, this.UserTraits_itemUserIds_observation__F[observation], this.userTrait_B[observation], this.userIds, observation);
-					for(int trait = 0; trait<this.traitCount; trait++) {
-						this.UserTraits_itemUserIds_observation__B[observation][trait] = ArrayHelper.SetTo<Gaussian>(this.UserTraits_itemUserIds_observation__B[observation][trait], this.userTrait_B[observation][trait]);
-					}
-					this.UserBias_itemUserIds_observation__B[observation] = ArrayHelper.SetTo<Gaussian>(this.UserBias_itemUserIds_observation__B[observation], this.userBiasObs_B[observation]);
-					for(int trait = 0; trait<this.traitCount; trait++) {
-						this.ItemTraits_itemItemIds_observation__B[observation][trait] = ArrayHelper.SetTo<Gaussian>(this.ItemTraits_itemItemIds_observation__B[observation][trait], this.itemTrait_B[observation][trait]);
-					}
-					this.ItemBias_itemItemIds_observation__B[observation] = ArrayHelper.SetTo<Gaussian>(this.ItemBias_itemItemIds_observation__B[observation], this.itemBiasObs_B[observation]);
-					for(int userThreshold = 0; userThreshold<this.userThresholdCount; userThreshold++) {
-						if (this.useSharedUserThresholds) {
-							this.UserThresholds_rep_B[userThreshold][observation] = ArrayHelper.SetTo<Gaussian>(this.UserThresholds_rep_B[userThreshold][observation], this.UserThresholdsObs_B[observation][userThreshold]);
-						}
-						if (!this.useSharedUserThresholds) {
-							this.UserThresholds_itemUserIds_observation__B[observation][userThreshold] = ArrayHelper.SetTo<Gaussian>(this.UserThresholds_itemUserIds_observation__B[observation][userThreshold], this.UserThresholdsObs_B[observation][userThreshold]);
-						}
-					}
 				}
-				this.UserTraits_uses_B[1] = GetItemsOp<double[]>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.UserTraits_itemUserIds_observation__B, this.userIds, this.UserTraits_uses_B[1]);
+				this.UserTraits_uses_B[1] = GetItemsOp<double[]>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.userTrait_B, this.userIds, this.UserTraits_uses_B[1]);
 				this.UserTraits_use_B = ReplicateOp_NoDivide.DefAverageConditional<DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.UserTraits_uses_B, this.UserTraits_use_B);
 				for(int trait = 0; trait<this.traitCount; trait++) {
 					this.UserTraitFeatureWeights_use_F_trait__marginal[trait] = JaggedSubarrayOp<double>.Marginal<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.UserTraitFeatureWeights_F[trait], this.UserTraitFeatureWeights_NonZeroUserFeatureIndices_B[trait], this.nonZeroUserFeatureIndices, this.UserTraitFeatureWeights_use_F_trait__marginal[trait]);
@@ -2561,7 +2517,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 						this.UserTraits_F[user][trait] = GaussianFromMeanAndVarianceOp.SampleAverageConditional(this.userTraitMean_F[user][trait], this.userTraitVariance);
 					}
 				}
-				this.UserBias_uses_B[1] = GetItemsOp<double>.ArrayAverageConditional<Gaussian,DistributionStructArray<Gaussian,double>>(this.UserBias_itemUserIds_observation__B, this.userIds, this.UserBias_uses_B[1]);
+				this.UserBias_uses_B[1] = GetItemsOp<double>.ArrayAverageConditional<Gaussian,DistributionStructArray<Gaussian,double>>(this.userBiasObs_B, this.userIds, this.UserBias_uses_B[1]);
 				this.UserBias_use_B = ReplicateOp_NoDivide.DefAverageConditional<DistributionStructArray<Gaussian,double>>(this.UserBias_uses_B, this.UserBias_use_B);
 				for(int user = 0; user<this.userCount; user++) {
 					this.userBiasMean_B[user] = GaussianFromMeanAndVarianceOp.MeanAverageConditional(this.UserBias_use_B[user], this.userBiasVariance);
@@ -2580,7 +2536,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 				for(int trait = 0; trait<this.traitCount; trait++) {
 					this.ItemTraitFeatureWeights_use_F_trait__marginal[trait] = JaggedSubarrayOp<double>.Marginal<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.ItemTraitFeatureWeights_F[trait], this.ItemTraitFeatureWeights_NonZeroItemFeatureIndices_B[trait], this.nonZeroItemFeatureIndices, this.ItemTraitFeatureWeights_use_F_trait__marginal[trait]);
 				}
-				this.ItemTraits_depth0_uses_B[1] = GetItemsOp<double[]>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.ItemTraits_itemItemIds_observation__B, this.itemIds, this.ItemTraits_depth0_uses_B[1]);
+				this.ItemTraits_depth0_uses_B[1] = GetItemsOp<double[]>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.itemTrait_B, this.itemIds, this.ItemTraits_depth0_uses_B[1]);
 				this.ItemTraits_depth0_B = ReplicateOp_NoDivide.DefAverageConditional<DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.ItemTraits_depth0_uses_B, this.ItemTraits_depth0_B);
 				for(int item = 0; item<this.itemCount; item++) {
 					for(int trait = 0; trait<this.traitCount; trait++) {
@@ -2601,7 +2557,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 						this.ItemTraitFeatureWeights_NonZeroItemFeatureIndices_B[trait][item] = ArrayHelper.SetTo<DistributionStructArray<Gaussian,double>>(this.ItemTraitFeatureWeights_NonZeroItemFeatureIndices_B[trait][item], this.nonZeroItemTraitFeatureWeights_B[item][trait]);
 					}
 				}
-				this.ItemBias_uses_B[1] = GetItemsOp<double>.ArrayAverageConditional<Gaussian,DistributionStructArray<Gaussian,double>>(this.ItemBias_itemItemIds_observation__B, this.itemIds, this.ItemBias_uses_B[1]);
+				this.ItemBias_uses_B[1] = GetItemsOp<double>.ArrayAverageConditional<Gaussian,DistributionStructArray<Gaussian,double>>(this.itemBiasObs_B, this.itemIds, this.ItemBias_uses_B[1]);
 				this.ItemBias_use_B = ReplicateOp_NoDivide.DefAverageConditional<DistributionStructArray<Gaussian,double>>(this.ItemBias_uses_B, this.ItemBias_use_B);
 				for(int item = 0; item<this.itemCount; item++) {
 					this.itemBiasMean_B[item] = GaussianFromMeanAndVarianceOp.MeanAverageConditional(this.ItemBias_use_B[item], this.itemBiasVariance);
@@ -2626,6 +2582,13 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 				for(int item = 0; item<this.itemCount; item++) {
 					this.ItemBias_use_F[item] = ArrayHelper.SetTo<Gaussian>(this.ItemBias_use_F[item], this.ItemBias_F[item]);
 				}
+				for(int observation = 0; observation<this.observationCount; observation++) {
+					for(int userThreshold = 0; userThreshold<this.userThresholdCount; userThreshold++) {
+						if (this.useSharedUserThresholds) {
+							this.UserThresholds_rep_B[userThreshold][observation] = ArrayHelper.SetTo<Gaussian>(this.UserThresholds_rep_B[userThreshold][observation], this.UserThresholdsObs_B[observation][userThreshold]);
+						}
+					}
+				}
 				for(int userThreshold = 0; userThreshold<this.userThresholdCount; userThreshold++) {
 					if (this.useSharedUserThresholds) {
 						this.UserThresholds_rep_B_toDef[userThreshold] = ReplicateOp_Divide.ToDef<Gaussian>(this.UserThresholds_rep_B[userThreshold], this.UserThresholds_rep_B_toDef[userThreshold]);
@@ -2634,7 +2597,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 				}
 				if (!this.useSharedUserThresholds) {
 					if (!this.useSharedUserThresholds) {
-						this.UserThresholds_depth0_uses_B[1] = GetItemsOp<double[]>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.UserThresholds_itemUserIds_observation__B, this.userIds, this.UserThresholds_depth0_uses_B[1]);
+						this.UserThresholds_depth0_uses_B[1] = GetItemsOp<double[]>.ArrayAverageConditional<DistributionStructArray<Gaussian,double>,DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>>(this.UserThresholdsObs_B, this.userIds, this.UserThresholds_depth0_uses_B[1]);
 					}
 				}
 				for(int user = 0; user<this.userCount; user++) {
@@ -2682,7 +2645,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 			if (this.Changed_ItemBiasFeatureWeightPriorVariance_ItemCount_ItemFeatureCount_NonZeroItemFeatureCounts_NonZe55_isDone&&((!initialise)||this.Changed_ItemBiasFeatureWeightPriorVariance_ItemCount_ItemFeatureCount_NonZeroItemFeatureCounts_NonZe55_isInitialised)) {
 				return ;
 			}
-			this.ItemBiasFeatureWeights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.ItemBiasFeatureWeights_F, this.ItemBiasFeatureWeights_NonZeroItemFeatureIndices_B, this.nonZeroItemFeatureIndices, this.ItemBiasFeatureWeights_marginal_F);
+			this.ItemBiasFeatureWeights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.ItemBiasFeatureWeights_F, this.nonZeroItemBiasFeatureWeights_B, this.nonZeroItemFeatureIndices, this.ItemBiasFeatureWeights_marginal_F);
 			this.Changed_ItemBiasFeatureWeightPriorVariance_ItemCount_ItemFeatureCount_NonZeroItemFeatureCounts_NonZe55_isDone = true;
 			this.Changed_ItemBiasFeatureWeightPriorVariance_ItemCount_ItemFeatureCount_NonZeroItemFeatureCounts_NonZe55_isInitialised = true;
 		}
@@ -2770,7 +2733,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 			this.ItemBias_use_B = new DistributionStructArray<Gaussian,double>(this.itemCount);
 			this.itemBiasMean_B = new Gaussian[this.itemCount];
 			this.ItemBiasFeatureWeights_NonZeroItemFeatureIndices_F = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.itemCount);
-			this.ItemBiasFeatureWeights_NonZeroItemFeatureIndices_B = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.itemCount);
 			this.nonZeroItemBiasFeatureWeights_B = new DistributionStructArray<Gaussian,double>[this.itemCount];
 			this.vdouble__44_F = new DistributionStructArray<Gaussian,double>[this.itemCount];
 			this.itemBiasMean_F = new Gaussian[this.itemCount];
@@ -2828,7 +2790,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 			}
 			for(int item = 0; item<this.itemCount; item++) {
 				this.ItemBiasFeatureWeights_NonZeroItemFeatureIndices_F[item] = new DistributionStructArray<Gaussian,double>(this.nonZeroItemFeatureCounts[item]);
-				this.ItemBiasFeatureWeights_NonZeroItemFeatureIndices_B[item] = new DistributionStructArray<Gaussian,double>(this.nonZeroItemFeatureCounts[item]);
 				this.nonZeroItemBiasFeatureWeights_B[item] = new DistributionStructArray<Gaussian,double>(this.nonZeroItemFeatureCounts[item]);
 				this.vdouble__44_F[item] = new DistributionStructArray<Gaussian,double>(this.nonZeroItemFeatureCounts[item]);
 				this.vdouble__44_B[item] = new DistributionStructArray<Gaussian,double>(this.nonZeroItemFeatureCounts[item]);
@@ -2846,7 +2807,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 			for(int item = 0; item<this.itemCount; item++) {
 				for(int nonZeroItemFeature = 0; nonZeroItemFeature<this.nonZeroItemFeatureCounts[item]; nonZeroItemFeature++) {
 					this.ItemBiasFeatureWeights_NonZeroItemFeatureIndices_F[item][nonZeroItemFeature] = Gaussian.Uniform();
-					this.ItemBiasFeatureWeights_NonZeroItemFeatureIndices_B[item][nonZeroItemFeature] = Gaussian.Uniform();
 					this.nonZeroItemBiasFeatureWeights_B[item][nonZeroItemFeature] = Gaussian.Uniform();
 					this.vdouble__44_F[item][nonZeroItemFeature] = Gaussian.Uniform();
 					this.vdouble__44_B[item][nonZeroItemFeature] = Gaussian.Uniform();
@@ -3147,7 +3107,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 			if (this.Changed_NonZeroUserFeatureCounts_NonZeroUserFeatureIndices_numberOfIterationsDecreased_UserBiasFeatu45_isDone&&((!initialise)||this.Changed_NonZeroUserFeatureCounts_NonZeroUserFeatureIndices_numberOfIterationsDecreased_UserBiasFeatu45_isInitialised)) {
 				return ;
 			}
-			this.UserBiasFeatureWeights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.UserBiasFeatureWeights_F, this.UserBiasFeatureWeights_NonZeroUserFeatureIndices_B, this.nonZeroUserFeatureIndices, this.UserBiasFeatureWeights_marginal_F);
+			this.UserBiasFeatureWeights_marginal_F = JaggedSubarrayWithMarginalOp<double>.MarginalAverageConditional<DistributionStructArray<Gaussian,double>,Gaussian,DistributionStructArray<Gaussian,double>>(this.UserBiasFeatureWeights_F, this.nonZeroUserBiasFeatureWeights_B, this.nonZeroUserFeatureIndices, this.UserBiasFeatureWeights_marginal_F);
 			this.Changed_NonZeroUserFeatureCounts_NonZeroUserFeatureIndices_numberOfIterationsDecreased_UserBiasFeatu45_isDone = true;
 			this.Changed_NonZeroUserFeatureCounts_NonZeroUserFeatureIndices_numberOfIterationsDecreased_UserBiasFeatu45_isInitialised = true;
 		}
@@ -3184,7 +3144,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 			for(int user = 0; user<this.userCount; user++) {
 				for(int nonZeroUserFeature = 0; nonZeroUserFeature<this.nonZeroUserFeatureCounts[user]; nonZeroUserFeature++) {
 					this.UserBiasFeatureWeights_NonZeroUserFeatureIndices_F[user][nonZeroUserFeature] = Gaussian.Uniform();
-					this.UserBiasFeatureWeights_NonZeroUserFeatureIndices_B[user][nonZeroUserFeature] = Gaussian.Uniform();
 					this.nonZeroUserBiasFeatureWeights_B[user][nonZeroUserFeature] = Gaussian.Uniform();
 					this.nonZeroUserBiasFeatureWeightProducts_F[user][nonZeroUserFeature] = Gaussian.Uniform();
 					this.nonZeroUserBiasFeatureWeightProducts_B[user][nonZeroUserFeature] = Gaussian.Uniform();
@@ -3220,7 +3179,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 			}
 			for(int user = 0; user<this.userCount; user++) {
 				this.UserBiasFeatureWeights_NonZeroUserFeatureIndices_F[user] = new DistributionStructArray<Gaussian,double>(this.nonZeroUserFeatureCounts[user]);
-				this.UserBiasFeatureWeights_NonZeroUserFeatureIndices_B[user] = new DistributionStructArray<Gaussian,double>(this.nonZeroUserFeatureCounts[user]);
 				this.nonZeroUserBiasFeatureWeights_B[user] = new DistributionStructArray<Gaussian,double>(this.nonZeroUserFeatureCounts[user]);
 				this.nonZeroUserBiasFeatureWeightProducts_F[user] = new DistributionStructArray<Gaussian,double>(this.nonZeroUserFeatureCounts[user]);
 				this.nonZeroUserBiasFeatureWeightProducts_B[user] = new DistributionStructArray<Gaussian,double>(this.nonZeroUserFeatureCounts[user]);
@@ -3253,8 +3211,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 				this.vdouble112_B[observation] = Gaussian.Uniform();
 				this.vdouble109_B[observation] = Gaussian.Uniform();
 				this.vdouble111_B[observation] = Gaussian.Uniform();
-				this.UserBias_itemUserIds_observation__B[observation] = Gaussian.Uniform();
-				this.ItemBias_itemItemIds_observation__B[observation] = Gaussian.Uniform();
 			}
 			this.Changed_numberOfIterationsDecreased_ObservationCount_Init_AffinityNoiseVariance_ItemBiasFeatureWeigh31_isDone = true;
 			this.Changed_numberOfIterationsDecreased_ObservationCount_Init_AffinityNoiseVariance_ItemBiasFeatureWeigh31_isInitialised = true;
@@ -3294,12 +3250,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 				}
 			}
 			this.userTrait_B_new = ArrayHelper.CopyStorage<DistributionStructArray<Gaussian,double>[]>(this.userTrait_B);
-			for(int observation = 0; observation<this.observationCount; observation++) {
-				for(int trait = 0; trait<this.traitCount; trait++) {
-					this.UserTraits_itemUserIds_observation__B[observation][trait] = Gaussian.Uniform();
-					this.ItemTraits_itemItemIds_observation__B[observation][trait] = Gaussian.Uniform();
-				}
-			}
 			this.Changed_numberOfIterationsDecreased_ObservationCount_TraitCount_Init_AffinityNoiseVariance_ItemBiasF30_isDone = true;
 			this.Changed_numberOfIterationsDecreased_ObservationCount_TraitCount_Init_AffinityNoiseVariance_ItemBiasF30_isInitialised = true;
 		}
@@ -3343,11 +3293,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 					}
 					if (this.useSharedUserThresholds) {
 						this.UserThresholds_rep_B[userThreshold][observation] = Gaussian.Uniform();
-					}
-					if (!this.useSharedUserThresholds) {
-						if (!this.useSharedUserThresholds) {
-							this.UserThresholds_itemUserIds_observation__B[observation][userThreshold] = Gaussian.Uniform();
-						}
 					}
 				}
 			}
@@ -3549,10 +3494,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 			this.vdouble111_B = new Gaussian[this.observationCount];
 			this.NoisyUserThresholds_use_B = new DistributionStructArray<Gaussian,double>[this.observationCount];
 			this.vdouble__61_B = new DistributionStructArray<Gaussian,double>[this.observationCount];
-			this.UserTraits_itemUserIds_observation__B = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.observationCount);
-			this.UserBias_itemUserIds_observation__B = new DistributionStructArray<Gaussian,double>(this.observationCount);
-			this.ItemTraits_itemItemIds_observation__B = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.observationCount);
-			this.ItemBias_itemItemIds_observation__B = new DistributionStructArray<Gaussian,double>(this.observationCount);
 			if (this.observationCount>0) {
 				this.vbool6_reduced = true;
 				Constrain.Equal<bool>(true, this.vbool6_reduced);
@@ -3586,8 +3527,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 				this.userTrait_B[observation] = new DistributionStructArray<Gaussian,double>(this.traitCount);
 				this.vdouble__51_F[observation] = new DistributionStructArray<Gaussian,double>(this.traitCount);
 				this.vdouble__51_B[observation] = new DistributionStructArray<Gaussian,double>(this.traitCount);
-				this.UserTraits_itemUserIds_observation__B[observation] = new DistributionStructArray<Gaussian,double>(this.traitCount);
-				this.ItemTraits_itemItemIds_observation__B[observation] = new DistributionStructArray<Gaussian,double>(this.traitCount);
 			}
 			this.Changed_ObservationCount_TraitCount_isDone = true;
 		}
@@ -3632,13 +3571,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 					this.UserThresholds_rep_B[userThreshold] = new Gaussian[this.observationCount];
 				}
 			}
-			for(int observation = 0; observation<this.observationCount; observation++) {
-				if (!this.useSharedUserThresholds) {
-					if (!this.useSharedUserThresholds) {
-						this.UserThresholds_itemUserIds_observation__B[observation] = new DistributionStructArray<Gaussian,double>(this.userThresholdCount);
-					}
-				}
-			}
 			this.Changed_ObservationCount_UserThresholdCount_UseSharedUserThresholds_isDone = true;
 		}
 
@@ -3652,7 +3584,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 				if (!this.useSharedUserThresholds) {
 					this.UserThresholds_itemUserIds_observation__F = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.observationCount);
 				}
-				this.UserThresholds_itemUserIds_observation__B = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.observationCount);
 			}
 			this.Changed_ObservationCount_UseSharedUserThresholds_isDone = true;
 		}
@@ -3666,9 +3597,9 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 			this.UserTraitFeatureWeights_F = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.traitCount);
 			this.UserTraitFeatureWeights_marginal_F = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.traitCount);
 			this.UserTraitFeatureWeights_use_B = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.traitCount);
-			this.ItemTraits_trait_index10_0__0__B = new Gaussian[this.traitCount][];
-			this.ItemTraits_index10_index10_0__index10__B = new Gaussian[this.traitCount][];
 			this.vbool3 = new bool[this.traitCount][];
+			this.ItemTraits_index10_index10_0__index10__B = new Gaussian[this.traitCount][];
+			this.ItemTraits_trait_index10_0__0__B = new Gaussian[this.traitCount][];
 			for(int trait = 0; trait<this.traitCount; trait++) {
 				this.vbool3[trait] = new bool[this.traitCount];
 			}
@@ -3860,7 +3791,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 			this.UserBias_use_B = new DistributionStructArray<Gaussian,double>(this.userCount);
 			this.userBiasMean_B = new Gaussian[this.userCount];
 			this.UserBiasFeatureWeights_NonZeroUserFeatureIndices_F = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.userCount);
-			this.UserBiasFeatureWeights_NonZeroUserFeatureIndices_B = new DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>(this.userCount);
 			this.nonZeroUserBiasFeatureWeights_B = new DistributionStructArray<Gaussian,double>[this.userCount];
 			this.nonZeroUserBiasFeatureWeightProducts_F = new DistributionStructArray<Gaussian,double>[this.userCount];
 			this.userBiasMean_F = new Gaussian[this.userCount];
@@ -3985,7 +3915,6 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 			this.UserThresholds_rep_F = default(Gaussian[][]);
 			this.UserThresholds_itemUserIds_observation__F = default(DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>);
 			this.UserThresholds_rep_B = default(Gaussian[][]);
-			this.UserThresholds_itemUserIds_observation__B = default(DistributionRefArray<DistributionStructArray<Gaussian,double>,double[]>);
 			this.Changed_UseSharedUserThresholds_isDone = true;
 		}
 

--- a/src/Runtime/Core/Collections/FileArray.cs
+++ b/src/Runtime/Core/Collections/FileArray.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ML.Probabilistic.Collections
     /// </para>
     /// </remarks>
     [Serializable]
-    public class FileArray<T> : IArray<T>, IDisposable, ICloneable
+    public class FileArray<T> : IArray<T>, IReadOnlyList<T>, IDisposable, ICloneable
     {
         protected readonly int count;
         protected readonly string prefix;
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Probabilistic.Collections
             get { return prefix; }
         }
 
-        private static object folderLock = new object();
+        private static readonly object folderLock = new object();
 
         /// <summary>
         /// Create a file array

--- a/src/Runtime/Core/Utils/Util.cs
+++ b/src/Runtime/Core/Utils/Util.cs
@@ -187,23 +187,35 @@ namespace Microsoft.ML.Probabilistic.Utilities
                 rank = 1;
                 return typeof(object);
             }
-            else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IList<>))
+            else if (type.IsGenericType)
             {
-                rank = 1;
-                return type.GetGenericArguments()[0];
+                Type genericTypeDefinition = type.GetGenericTypeDefinition();
+                if (genericTypeDefinition == typeof(IList<>) ||
+                    genericTypeDefinition == typeof(IReadOnlyList<>))
+                {
+                    rank = 1;
+                    return type.GetGenericArguments()[0];
+                }
+                // Fall through
+            }
+            // may throw AmbiguousMatchException
+            Type face = type.GetInterface(typeof(IArray2D<>).Name, false);
+            if (face != null)
+            {
+                rank = 2;
+                return face.GetGenericArguments()[0];
             }
             else
             {
-                // may throw AmbiguousMatchException
-                Type face = type.GetInterface(typeof(IArray2D<>).Name, false);
+                face = type.GetInterface(typeof(IList<>).Name, false);
                 if (face != null)
                 {
-                    rank = 2;
+                    rank = 1;
                     return face.GetGenericArguments()[0];
                 }
                 else
                 {
-                    face = type.GetInterface(typeof(IList<>).Name, false);
+                    face = type.GetInterface(typeof(IReadOnlyList<>).Name, false);
                     if (face != null)
                     {
                         rank = 1;

--- a/src/Runtime/Factors/Exp.cs
+++ b/src/Runtime/Factors/Exp.cs
@@ -81,9 +81,8 @@ namespace Microsoft.ML.Probabilistic.Factors
                 return 0.0;
             double[] nodes = new double[QuadratureNodeCount];
             double[] weights = new double[QuadratureNodeCount];
-            double mD, vD;
             Gaussian dMarginal = d * to_d;
-            dMarginal.GetMeanAndVariance(out mD, out vD);
+            dMarginal.GetMeanAndVariance(out double mD, out double vD);
             Quadrature.GaussianNodesAndWeights(mD, vD, nodes, weights);
             if (!to_d.IsUniform())
             {
@@ -254,9 +253,8 @@ namespace Microsoft.ML.Probabilistic.Factors
                 to_d = new Gaussian(MMath.Digamma(exp.Shape - 1) - Math.Log(exp.Rate), MMath.Trigamma(exp.Shape - 1));
             }
 
-            double mD, vD;
             Gaussian dMarginal = d * to_d;
-            dMarginal.GetMeanAndVariance(out mD, out vD);
+            dMarginal.GetMeanAndVariance(out double mD, out double vD);
 
             // Quadrature cannot get more than 6 digits of precision.
             // So in cases where extra precision is required, use another approach.
@@ -322,7 +320,7 @@ namespace Microsoft.ML.Probabilistic.Factors
             }
             else
             {
-                Converter<double, double> p = delegate (double y) { return d.GetLogProb(y) + (exp.Shape - 1) * y - exp.Rate * Math.Exp(y); };
+                double p(double y) { return d.GetLogProb(y) + (exp.Shape - 1) * y - exp.Rate * Math.Exp(y); }
                 double sc = Math.Sqrt(vD);
                 double offset = p(mD);
                 double relTol = 1e-16;
@@ -384,13 +382,11 @@ namespace Microsoft.ML.Probabilistic.Factors
             // f(x,y) = Ga(exp(y); shape, rate) = exp(y*(shape-1) -rate*exp(y))
             double[] nodes = new double[QuadratureNodeCount];
             double[] weights = new double[QuadratureNodeCount];
-            double moD, voD;
-            d.GetMeanAndVariance(out moD, out voD);
-            double mD, vD;
+            d.GetMeanAndVariance(out double moD, out double voD);
             if (result.IsUniform() && exp.Shape > 1)
                 result = new Gaussian(MMath.Digamma(exp.Shape - 1) - Math.Log(exp.Rate), MMath.Trigamma(exp.Shape - 1));
             Gaussian dMarginal = d * result;
-            dMarginal.GetMeanAndVariance(out mD, out vD);
+            dMarginal.GetMeanAndVariance(out double mD, out double vD);
             if (vD == 0)
                 return ExpOp_Slow.DAverageConditional(exp, d);
             // Do not add mD to the quadrature nodes because it will lose precision in the nodes when mD has large magnitude.
@@ -476,8 +472,7 @@ namespace Microsoft.ML.Probabilistic.Factors
         public static Gamma ExpAverageLogarithm([Proper] Gaussian d)
         {
             if (d.IsPointMass) return Gamma.PointMass(Math.Exp(d.Point));
-            double mD, vD;
-            d.GetMeanAndVariance(out mD, out vD);
+            d.GetMeanAndVariance(out double mD, out double vD);
             return ExpDistribution(mD, vD);
         }
 
@@ -495,8 +490,7 @@ namespace Microsoft.ML.Probabilistic.Factors
         [Quality(QualityBand.Experimental)]
         public static Gamma ExpAverageLogarithm([Proper] NonconjugateGaussian d)
         {
-            double mD, vD;
-            d.GetMeanAndVariance(out mD, out vD);
+            d.GetMeanAndVariance(out double mD, out double vD);
             return ExpDistribution(mD, vD);
         }
 
@@ -504,8 +498,7 @@ namespace Microsoft.ML.Probabilistic.Factors
         public static GammaPower ExpAverageLogarithm([Proper] Gaussian d, GammaPower result)
         {
             if (d.IsPointMass) return GammaPower.PointMass(Math.Exp(d.Point), result.Power);
-            double mD, vD;
-            d.GetMeanAndVariance(out mD, out vD);
+            d.GetMeanAndVariance(out double mD, out double vD);
             // E[exp(d)] = exp(mD + vD/2)
             double logMeanMinusMeanLog = vD / 2;
             double logMean = mD + logMeanMinusMeanLog;
@@ -574,8 +567,7 @@ namespace Microsoft.ML.Probabilistic.Factors
             var a = exp.Shape;
             var v_opt = 1.0 / (a - 1.0);
             var b = exp.Rate;
-            double m = 0.0, v = 0.0;
-            d.GetMeanAndVariance(out m, out v);
+            d.GetMeanAndVariance(out double m, out double v);
             if (a > 1)
             {
                 var mf = Math.Log((a - 1) / b) - .5 * v_opt;
@@ -623,8 +615,7 @@ namespace Microsoft.ML.Probabilistic.Factors
             if (exp.IsPointMass)
                 return DAverageLogarithm(exp.Point);
 
-            double m, v;
-            d.GetMeanAndVariance(out m, out v);
+            d.GetMeanAndVariance(out double m, out double v);
             /* --------- This update comes from T. Minka's equations for non-conjugate VMP. -------- */
             Gaussian result = new Gaussian();
             result.Precision = exp.Rate * Math.Exp(m + v / 2);
@@ -707,8 +698,7 @@ namespace Microsoft.ML.Probabilistic.Factors
             {
                 return DAverageConditional(exp, d.Point);
             }
-            double dmode, dminMinusMode, dmaxMinusMode;
-            GetIntegrationBounds(exp, d, out dmode, out dminMinusMode, out dmaxMinusMode);
+            GetIntegrationBounds(exp, d, out double dmode, out double dminMinusMode, out double dmaxMinusMode);
             if (dminMinusMode == dmaxMinusMode) return DAverageConditional(exp, d.Point);
             double expmode = Math.Exp(dmode);
             int n = QuadratureNodeCount;
@@ -737,14 +727,10 @@ namespace Microsoft.ML.Probabilistic.Factors
             // with deriv = -v*b*exp(x)
             // or x = log((a-1 - (x-m)/v)/b)
             // with deriv = -1/((a-1)v - (x-m))
-            double mx, vx;
-            d.GetMeanAndVariance(out mx, out vx);
+            d.GetMeanAndVariance(out double mx, out double vx);
             double aMinus1 = exp.Shape - 1;
             double b = exp.Rate;
             double x = mx;
-            double lowerBound;
-            if (aMinus1 == 0) lowerBound = Math.Log(1e-16 * Math.Abs(mx / vx / b));
-            else lowerBound = Math.Log(1e-16 * Math.Abs(aMinus1 / b));
             for (int iter = 0; iter < 1000; iter++)
             {
                 double oldx = x;
@@ -782,14 +768,14 @@ namespace Microsoft.ML.Probabilistic.Factors
             double expMode = Math.Exp(mode);
             // We want to find where LogFactorMinusMode == logUlp1, so we find zeroes of the difference.
             double logUlp1 = Math.Log(MMath.Ulp1);
-            Func<double, double> func = delegate (double xMinusMode)
+            double func(double xMinusMode)
             {
                 return LogFactorMinusMode(xMinusMode, exp, d, mode, expMode) - logUlp1;
-            };
-            Func<double, double> deriv = delegate (double xMinusMode)
+            }
+            double deriv(double xMinusMode)
             {
                 return -exp.Rate * expMode * Math.Exp(xMinusMode) - xMinusMode * d.Precision + (d.MeanTimesPrecision - mode * d.Precision) + (exp.Shape - 1);
-            };
+            }
             List<double> zeroes = GaussianOp_Slow.FindZeroes(func, deriv, new double[] { 0 }, new double[0]);
             dminMinusMode = MMath.Min(zeroes);
             dmaxMinusMode = MMath.Max(zeroes);
@@ -995,11 +981,9 @@ namespace Microsoft.ML.Probabilistic.Factors
             if (exp.IsPointMass)
                 return ExpOp.DAverageLogarithm(exp.Point);
 
-            double m, v;
-            d.GetMeanAndVariance(out m, out v);
-            double mu, s2;
+            d.GetMeanAndVariance(out double m, out double v);
             var prior = d / to_d;
-            prior.GetMeanAndVariance(out mu, out s2);
+            prior.GetMeanAndVariance(out double mu, out double s2);
             var z = Vector.Zero(2);
             z[0] = m;
             z[1] = Math.Log(v);

--- a/src/Runtime/Factors/Factor.cs
+++ b/src/Runtime/Factors/Factor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.Probabilistic.Factors
     using Utilities;
 
     /// <summary>
-    /// A repository of commonly used factor methods.
+    /// Contains commonly used factor methods.
     /// </summary>
     [Quality(QualityBand.Stable)]
     public static class Factor

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Collections.Concurrent;
 using System.Reflection;
 using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Algorithms;
 using Microsoft.ML.Probabilistic.Utilities;
 using Microsoft.ML.Probabilistic.Math;
 using Microsoft.ML.Probabilistic.Models;

--- a/test/Tests/Core/UtilsTests.cs
+++ b/test/Tests/Core/UtilsTests.cs
@@ -11,6 +11,14 @@ namespace Microsoft.ML.Probabilistic.Tests.Core
     public class UtilsTests
     {
         [Fact]
+        public void GetElementType()
+        {
+            int rank;
+            Assert.Equal(typeof(bool), Utilities.Util.GetElementType(typeof(IReadOnlyList<bool>), out rank));
+            Assert.Equal(1, rank);
+        }
+
+        [Fact]
         public void TestCartesianProduct()
         {
             var lists = new List<IEnumerable<string>>

--- a/test/Tests/SharedVariableTests.cs
+++ b/test/Tests/SharedVariableTests.cs
@@ -722,15 +722,17 @@ namespace Microsoft.ML.Probabilistic.Tests
                     }
                 }
             }
-            z.InitialiseTo(Distribution<int>.Array(Util.ArrayInit(outer.SizeAsInt, i =>
-                                                                                   Util.ArrayInit(inner.SizeAsInt, j =>
-                                                                                                                   Discrete.PointMass(Rand.Int(cRange.SizeAsInt),
-                                                                                                                                      cRange.SizeAsInt)))));
+            Rand.Restart(0);
+            var zInit = Util.ArrayInit(outer.SizeAsInt, i =>
+                Util.ArrayInit(inner.SizeAsInt, j =>
+                Discrete.PointMass(Rand.Int(cRange.SizeAsInt), cRange.SizeAsInt)));
+            z.InitialiseTo(Distribution<int>.Array(zInit));
             bool geForceProper = GateEnterOp<double>.ForceProper;
             try
             {
                 GateEnterOp<double>.ForceProper = true;
-                InferenceEngine engine = new InferenceEngine(); //new VariationalMessagePassing());
+                InferenceEngine engine = new InferenceEngine();
+                engine.ShowProgress = false;
                 for (int pass = 0; pass < 50; pass++)
                 {
                     for (int c = 0; c < numChunks; c++)


### PR DESCRIPTION
InferNet.Infer is generic.
ModelBuilder uses the correct overload of InferNet.Infer.
CodeBuilder.Method checks for the correct number of arguments.
FileArray implements IReadOnlyList.