### PR TITLE
Extend SequenceDistribution API and bugfix

### DIFF
--- a/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
@@ -16,6 +16,15 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     /// </content>
     public abstract partial class Automaton<TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis>
     {
+        /// <inheritdoc cref="TryDeterminize(out TThis)" path="/summary"/>
+        /// <returns>Result automaton. Determinized automaton, if the operation was successful, current automaton or
+        /// an equvalent automaton without epsilon transitions otherwise.</returns>
+        public TThis TryDeterminize()
+        {
+            TryDeterminize(out TThis result);
+            return result;
+        }
+
         /// <summary>
         /// Attempts to determinize the automaton,
         /// i.e. modify it such that for every state and every element there is at most one transition that allows for that element,

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -2504,7 +2504,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         public static TThis Read(Func<double> readDouble, Func<int> readInt32, Func<TElementDistribution> readElementDistribution)
         {
             var propertyMask = new BitVector32(readInt32());
-            var res = new TThis();
             var idx = 0;
             // Serialized "isEpsilonFree" is not used. Will be taken from builder anyway
             var hasEpsilonFreeIgnored = propertyMask[1 << idx++];
@@ -2514,15 +2513,16 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             var hasStartState = propertyMask[1 << idx++];
             var hasIsDeterminizedValue = propertyMask[1 << idx++];
             var isDeterminized = propertyMask[1 << idx++];
+            double? logValueOverride = null, pruneStatesWithLogEndWeightLessThan = null;
 
             if (hasLogValueOverride)
             {
-                res.LogValueOverride = readDouble();
+                logValueOverride = readDouble();
             }
 
             if (hasPruneWeights)
             {
-                res.PruneStatesWithLogEndWeightLessThan = readDouble();
+                pruneStatesWithLogEndWeightLessThan = readDouble();
             }
 
             var builder = new Builder(0);
@@ -2543,7 +2543,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 State.ReadTo(ref builder, readInt32, readDouble, readElementDistribution);
             }
 
-            return new TThis() { Data = builder.GetData(hasIsDeterminizedValue ? (bool?)isDeterminized : null) };
+            return new TThis()
+            { 
+                Data = builder.GetData(hasIsDeterminizedValue ? (bool?)isDeterminized : null),
+                LogValueOverride = logValueOverride,
+                PruneStatesWithLogEndWeightLessThan = pruneStatesWithLogEndWeightLessThan
+            };
         }
         #endregion
     }

--- a/src/Runtime/Distributions/Automata/Automaton.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.cs
@@ -1481,7 +1481,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             var result = new TThis() { Data = builder.GetData(determinizationState) };
             if (determinizationState != true && result is StringAutomaton && tryDeterminize)
             {
-                result.TryDeterminize(out result);
+                result = result.TryDeterminize();
             }
             return result;
         }

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -1026,14 +1026,14 @@ namespace Microsoft.ML.Probabilistic.Distributions
 
         #endregion
 
-            #region ToString
+        #region ToString
 
-            /// <summary>
-            /// Returns a string that represents the distribution.
-            /// </summary>
-            /// <returns>
-            /// A string that represents the distribution.
-            /// </returns>
+        /// <summary>
+        /// Returns a string that represents the distribution.
+        /// </summary>
+        /// <returns>
+        /// A string that represents the distribution.
+        /// </returns>
         public override string ToString()
         {
             return this.ToString((Action<TElementDistribution, StringBuilder>)null);

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -1021,7 +1021,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// </summary>
         /// <param name="transducer">The transducer to project on.</param>
         /// <returns>The projection.</returns>
-        public TThis ProjectOnTransducer<TTransducer>(TTransducer transducer) where TTransducer : Transducer<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton, TTransducer>, new()
+        public TThis ApplyTransducer<TTransducer>(TTransducer transducer) where TTransducer : Transducer<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton, TTransducer>, new()
             => FromWeightFunction(IsPointMass ? transducer.ProjectSource(Point) : transducer.ProjectSource(ToAutomaton()));
 
         #endregion

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -1016,16 +1016,24 @@ namespace Microsoft.ML.Probabilistic.Distributions
             }
         }
 
+        /// <summary>
+        /// Computes a distribution <c>g(b) = sum_a f(a) T(a, b)</c>, where <c>f(a)</c> is the current distribution and <c>T(a, b)</c> is a given transducer.
+        /// </summary>
+        /// <param name="transducer">The transducer to project on.</param>
+        /// <returns>The projection.</returns>
+        public TThis ProjectOnTransducer<TTransducer>(TTransducer transducer) where TTransducer : Transducer<TSequence, TElement, TElementDistribution, TSequenceManipulator, TAutomaton, TTransducer>, new()
+            => FromWeightFunction(IsPointMass ? transducer.ProjectSource(Point) : transducer.ProjectSource(ToAutomaton()));
+
         #endregion
 
-        #region ToString
+            #region ToString
 
-        /// <summary>
-        /// Returns a string that represents the distribution.
-        /// </summary>
-        /// <returns>
-        /// A string that represents the distribution.
-        /// </returns>
+            /// <summary>
+            /// Returns a string that represents the distribution.
+            /// </summary>
+            /// <returns>
+            /// A string that represents the distribution.
+            /// </returns>
         public override string ToString()
         {
             return this.ToString((Action<TElementDistribution, StringBuilder>)null);

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -1748,7 +1748,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
             {
                 // Determinization of automaton may fail if distribution is not normalized.
                 this.EnsureNormalized();
-                sequenceToWeight.AsAutomaton().TryDeterminize(out var determinizedAutomaton);
+                var determinizedAutomaton = sequenceToWeight.AsAutomaton().TryDeterminize();
                 // Sometimes automaton is not determinized, but is still made epsilon-free,
                 // which is a nice optimization to keep.
                 sequenceToWeight = WeightFunctionFactory.FromAutomaton(determinizedAutomaton);

--- a/src/Runtime/Factors/StringFormatOp.cs
+++ b/src/Runtime/Factors/StringFormatOp.cs
@@ -563,7 +563,7 @@ namespace Microsoft.ML.Probabilistic.Factors
             // Accepts placeholders for arguments other then current, then for the current argument, then again other placeholders
             result = checkBracesForOtherArgs.Append(validateArgumentThenOtherArguments);
 
-            result.TryDeterminize(out result);
+            result = result.TryDeterminize();
             ArgsToValidatingAutomaton[argListKey] = result;
 
             return result;

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -2279,7 +2279,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 determinizableAutomaton,
                 x =>
                 {
-                    x.TryDeterminize(out var determinized);
+                    var determinized = x.TryDeterminize();
                     return determinized;
                 });
 
@@ -2293,7 +2293,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 nonDeterminizableAutomaton,
                 x =>
                 {
-                    x.TryDeterminize(out var notDeterminized);
+                    var notDeterminized = x.TryDeterminize();
                     return notDeterminized;
                 });
         }
@@ -2362,7 +2362,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             var calculatedSupport1 = new HashSet<string>(automaton.EnumerateSupport());
             Assert.True(calculatedSupport1.SetEquals(expectedSupport));
 
-            automaton.TryDeterminize(out automaton);
+            automaton = automaton.TryDeterminize();
             var calculatedSupport2 = new HashSet<string>(automaton.EnumerateSupport());
             Assert.True(calculatedSupport2.SetEquals(expectedSupport));
         }
@@ -2566,8 +2566,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 .AddTransition('c', Weight.FromLogValue(-10000))
                 .SetEndWeight(Weight.One);
             var automaton = builder.GetAutomaton();
-            var tmp = automaton.Clone();
-            tmp.TryDeterminize(out tmp);
+            var tmp = automaton.Clone().TryDeterminize();
             automaton = automaton.ConstantOnSupportLog(0.0);
             var support = automaton.EnumerateSupport().OrderBy(s => s).ToArray();
             Assert.Equal(new[] {"a", "ac", "b", "bc", "c"}, support);
@@ -2622,8 +2621,8 @@ namespace Microsoft.ML.Probabilistic.Tests
         /// <returns>The number of states in the determinized automaton.</returns>
         private static int CountStates(params string[] values)
         {
-            var workspace = Automaton<string, char, ImmutableDiscreteChar, StringManipulator, StringAutomaton>.FromLogValues(values.Select(v => new KeyValuePair<string, double>(v, 0.0)));
-            workspace.TryDeterminize(out workspace);
+            var workspace = Automaton<string, char, ImmutableDiscreteChar, StringManipulator, StringAutomaton>.FromLogValues(values.Select(v => new KeyValuePair<string, double>(v, 0.0)))
+                .TryDeterminize();
             return workspace.States.Count;
         }
         

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -2277,11 +2277,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
             StringInferenceTestUtilities.TestAutomatonPropertyPreservation(
                 determinizableAutomaton,
-                x =>
-                {
-                    var determinized = x.TryDeterminize();
-                    return determinized;
-                });
+                x => x.TryDeterminize());
 
             builder = new StringAutomaton.Builder();
             builder.Start.AddTransition('a', Weight.FromValue(2)).AddSelfTransition('b', Weight.FromValue(0.5)).AddTransition('c', Weight.FromValue(3.0)).SetEndWeight(Weight.FromValue(4));
@@ -2291,11 +2287,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
             StringInferenceTestUtilities.TestAutomatonPropertyPreservation(
                 nonDeterminizableAutomaton,
-                x =>
-                {
-                    var notDeterminized = x.TryDeterminize();
-                    return notDeterminized;
-                });
+                x => x.TryDeterminize());
         }
 
         /// <summary>

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -1093,6 +1093,21 @@ namespace Microsoft.ML.Probabilistic.Tests
                 x => x.WithGroupsClear());
         }
 
+        /// <summary>
+        /// Tests that the deserialized automaton has the same LogValueOverride
+        /// and PruneStatesWithLogEndWeightLessThan values as it had before serialization.
+        /// </summary>
+        [Fact]
+        [Trait("Category", "StringInference")]
+        public void SerializationPreservesProperties()
+        {
+            StringAutomaton automaton = StringAutomaton.ConstantOn(2.0, "ab");
+
+            StringInferenceTestUtilities.TestAutomatonPropertyPreservation(
+                automaton,
+                x => StringInferenceTestUtilities.Clone(x));
+        }
+
 
         #region ToString tests
 

--- a/test/Tests/Strings/SequenceDistributionTests.cs
+++ b/test/Tests/Strings/SequenceDistributionTests.cs
@@ -676,6 +676,38 @@ namespace Microsoft.ML.Probabilistic.Tests
             }
         }
 
+        [Fact]
+        [Trait("Category", "StringInference")]
+        public void SetLogValueOverride()
+        {
+            StringDistribution point = StringDistribution.PointMass("ab");
+            Assert.Equal(0.0, point.GetLogProb("ab"));
+            point.SetLogValueOverride(-1.0);
+            Assert.Equal(-1.0, point.GetLogProb("ab"));
+            Assert.Equal(double.NegativeInfinity, point.GetLogProb("cc"));
+            point.SetLogValueOverride(null);
+            Assert.Equal(0.0, point.GetLogProb("ab"));
+            Assert.Equal(double.NegativeInfinity, point.GetLogProb("cc"));
+
+            StringDistribution dict = StringDistribution.OneOf("ab", "cd");
+            StringInferenceTestUtilities.TestProbability(dict, 0.5, "ab", "cd");
+            dict.SetLogValueOverride(-1.0);
+            StringInferenceTestUtilities.TestLogProbability(dict, -1.0, "ab", "cd");
+            StringInferenceTestUtilities.TestLogProbability(dict, double.NegativeInfinity, "ef", "gh");
+            dict.SetLogValueOverride(null);
+            StringInferenceTestUtilities.TestProbability(dict, 0.5, "ab", "cd");
+            StringInferenceTestUtilities.TestLogProbability(dict, double.NegativeInfinity, "ef", "gh");
+
+            StringDistribution automaton = StringDistribution.Repeat("a");
+            StringInferenceTestUtilities.TestProbability(automaton, 1.0, "a", "aa");
+            automaton.SetLogValueOverride(-1.0);
+            StringInferenceTestUtilities.TestLogProbability(automaton, -1.0, "a", "aa");
+            StringInferenceTestUtilities.TestLogProbability(automaton, double.NegativeInfinity, "ef", "gh");
+            automaton.SetLogValueOverride(null);
+            StringInferenceTestUtilities.TestProbability(automaton, 1.0, "a", "aa");
+            StringInferenceTestUtilities.TestLogProbability(automaton, double.NegativeInfinity, "ef", "gh");
+        }
+
         #region Sampling tests
 
         /// <summary>

--- a/test/Tests/Strings/SequenceDistributionTests.cs
+++ b/test/Tests/Strings/SequenceDistributionTests.cs
@@ -763,14 +763,14 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             StringTransducer replace = StringTransducer.Replace("hello", "worlds");
 
-            var proj1 = StringDistribution.PointMass("hello").ProjectOnTransducer(replace);
+            var proj1 = StringDistribution.PointMass("hello").ApplyTransducer(replace);
             Assert.True(proj1.IsPointMass);
             Assert.Equal("worlds", proj1.Point);
 
-            var proj2 = StringDistribution.PointMass("worlds").ProjectOnTransducer(replace);
+            var proj2 = StringDistribution.PointMass("worlds").ApplyTransducer(replace);
             Assert.True(proj2.IsZero());
 
-            var proj3 = StringDistribution.OneOf("hello", "worlds").ProjectOnTransducer(replace);
+            var proj3 = StringDistribution.OneOf("hello", "worlds").ApplyTransducer(replace);
             Assert.True(proj3.IsPointMass);
             Assert.Equal("worlds", proj3.Point);
         }

--- a/test/Tests/Strings/SequenceDistributionTests.cs
+++ b/test/Tests/Strings/SequenceDistributionTests.cs
@@ -514,7 +514,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             Assert.Equal("ab\"", point.ToString(SequenceDistributionFormats.Friendly));
             Assert.Equal("ab\"", point.ToString(SequenceDistributionFormats.Regexp));
             Assert.Equal(
-@"digraph finite_state_machine {"                        + Environment.NewLine +   
+@"digraph finite_state_machine {"                        + Environment.NewLine +
 @"  rankdir=LR;"                                         + Environment.NewLine +
 @"  node [shape = doublecircle; label = ""0\nE=0""]; N0" + Environment.NewLine +
 @"  node [shape = circle; label = ""1\nE=0""]; N1"       + Environment.NewLine +
@@ -759,7 +759,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
         [Fact]
         [Trait("Category", "StringInference")]
-        public void ProjectOnTransducer()
+        public void ApplyTransducer()
         {
             StringTransducer replace = StringTransducer.Replace("hello", "worlds");
 

--- a/test/Tests/Strings/SequenceDistributionTests.cs
+++ b/test/Tests/Strings/SequenceDistributionTests.cs
@@ -757,6 +757,24 @@ namespace Microsoft.ML.Probabilistic.Tests
             Assert.False(automatonNonDeterminizable.ToAutomaton().IsDeterministic());
         }
 
+        [Fact]
+        [Trait("Category", "StringInference")]
+        public void ProjectOnTransducer()
+        {
+            StringTransducer replace = StringTransducer.Replace("hello", "worlds");
+
+            var proj1 = StringDistribution.PointMass("hello").ProjectOnTransducer(replace);
+            Assert.True(proj1.IsPointMass);
+            Assert.Equal("worlds", proj1.Point);
+
+            var proj2 = StringDistribution.PointMass("worlds").ProjectOnTransducer(replace);
+            Assert.True(proj2.IsZero());
+
+            var proj3 = StringDistribution.OneOf("hello", "worlds").ProjectOnTransducer(replace);
+            Assert.True(proj3.IsPointMass);
+            Assert.Equal("worlds", proj3.Point);
+        }
+
         #region Sampling tests
 
         /// <summary>

--- a/test/Tests/Strings/StringInferenceTestUtilities.cs
+++ b/test/Tests/Strings/StringInferenceTestUtilities.cs
@@ -319,7 +319,12 @@ namespace Microsoft.ML.Probabilistic.Tests
             }
         }
 
-        private static StringAutomaton Clone(StringAutomaton automaton)
+        /// <summary>
+        /// Clones an automaton by consecutively serializing and deserializing it.
+        /// </summary>
+        /// <param name="automaton">Automaton to clone.</param>
+        /// <returns>Cloned automaton.</returns>
+        public static StringAutomaton Clone(StringAutomaton automaton)
         {
             using (var ms = new MemoryStream())
             using (var writer = new BinaryWriter(ms))
@@ -333,7 +338,13 @@ namespace Microsoft.ML.Probabilistic.Tests
             }
         }
 
-        private static StringDistribution Clone(StringDistribution stringDistribution)
+        /// <summary>
+        /// Clones a string distribution by consecutively serializing and deserializing
+        /// its automaton representation.
+        /// </summary>
+        /// <param name="stringDistribution">Distribution to clone.</param>
+        /// <returns>Cloned distribution.</returns>
+        public static StringDistribution Clone(StringDistribution stringDistribution)
         {
             if (stringDistribution.IsPointMass) return StringDistribution.String(stringDistribution.Point);
             var clonedAutomaton = Clone(stringDistribution.ToAutomaton());


### PR DESCRIPTION
- Fixed automaton deserialization ignoring LogValueOverride
- Fixed SequenceDistribution.EnumerateSupport and TryEnumerateSupport having different side effects
- Added TryDeterminize, SetLogValueOverride, and ProjectOnTransducer methods to SequenceDistribution
- Added a parameterless overload for Atomaton.TryDeterminize that returns the output of TryDeterminize(out TThis) and discards information about deterministicity of said output