### PR TITLE
Changed the BCC confusion matrix prior

### DIFF
--- a/src/Examples/Crowdsourcing/ActiveLearning.cs
+++ b/src/Examples/Crowdsourcing/ActiveLearning.cs
@@ -199,7 +199,7 @@ namespace Crowdsourcing
                             results.RunDawidSkene(subData, calculateAccuracy);
                             break;
                         default: // Run BCC models
-                            results.RunBCC(modelName, subData, data, model, Results.RunMode.ClearResults, calculateAccuracy, communityCount, false);
+                            results.RunBCC(resultsDir + modelName, subData, data, model, Results.RunMode.ClearResults, calculateAccuracy, communityCount, false);
                             break;
                     }
                 }

--- a/src/Examples/Crowdsourcing/Crowdsourcing.cs
+++ b/src/Examples/Crowdsourcing/Crowdsourcing.cs
@@ -193,7 +193,7 @@ namespace Crowdsourcing
                     results.RunDawidSkene(data, true);
                     break;
                 default:
-                    results.RunBCC(ResultsDir + modelName, data, data, model, Results.RunMode.ClearResults, false, communityCount, true, false);
+                    results.RunBCC(ResultsDir + modelName, data, data, model, Results.RunMode.ClearResults, false, communityCount, false, false);
                     break;
             }
 

--- a/src/Examples/Crowdsourcing/Crowdsourcing.cs
+++ b/src/Examples/Crowdsourcing/Crowdsourcing.cs
@@ -193,14 +193,14 @@ namespace Crowdsourcing
                     results.RunDawidSkene(data, true);
                     break;
                 default:
-                    results.RunBCC(modelName, data, data, model, Results.RunMode.ClearResults, false, communityCount, false, false);
+                    results.RunBCC(ResultsDir + modelName, data, data, model, Results.RunMode.ClearResults, false, communityCount, true, false);
                     break;
             }
 
             // Write the inference results on a csv file
             using (StreamWriter writer = new StreamWriter(ResultsDir + "endpoints.csv", true))
             {
-                writer.WriteLine("{0}:,{1:0.000},{2:0.0000}", modelName, results.Accuracy, results.NegativeLogProb);
+                writer.WriteLine("{0},{1:0.000},{2:0.0000}", modelName, results.Accuracy, results.NegativeLogProb);
             }
             return results;
         }

--- a/src/Examples/CrowdsourcingWithWords/BCC.cs
+++ b/src/Examples/CrowdsourcingWithWords/BCC.cs
@@ -65,7 +65,7 @@ namespace CrowdsourcingWithWords
             var confusionMatrixPrior = new Dirichlet[LabelCount];
             for (int d = 0; d < LabelCount; d++)
             {
-                confusionMatrixPrior[d] = new Dirichlet(Util.ArrayInit(LabelCount, i => i == d ? (InitialWorkerBelief / (1 - InitialWorkerBelief)) * (LabelCount - 1) : 1.0));
+                confusionMatrixPrior[d] = new Dirichlet(Util.ArrayInit(LabelCount, i => i == d ? (InitialWorkerBelief / (1 - InitialWorkerBelief)) * LabelCount : 1.0));
             }
 
             return confusionMatrixPrior;

--- a/test/Tests/DocumentationTests.cs
+++ b/test/Tests/DocumentationTests.cs
@@ -1490,17 +1490,16 @@ namespace Microsoft.ML.Probabilistic.Tests
         internal void XmlSerializationExample()
         {
             Dirichlet d = new Dirichlet(3.0, 1.0, 2.0);
+            string fileName = "temp.xml";
             DataContractSerializer serializer = new DataContractSerializer(typeof(Dirichlet), new DataContractSerializerSettings { DataContractResolver = new InferDataContractResolver() });
             // write to disk
-            using (FileStream stream = new FileStream("temp.xml", FileMode.Create))
+            using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateTextWriter(new FileStream(fileName, FileMode.Create)))
             {
-                XmlDictionaryWriter writer = XmlDictionaryWriter.CreateTextWriter(stream);
                 serializer.WriteObject(writer, d);
             }
             // read from disk
-            using (FileStream stream = new FileStream("temp.xml", FileMode.Open))
+            using (XmlDictionaryReader reader = XmlDictionaryReader.CreateTextReader(new FileStream(fileName, FileMode.Open), new XmlDictionaryReaderQuotas()))
             {
-                XmlDictionaryReader reader = XmlDictionaryReader.CreateTextReader(stream, new XmlDictionaryReaderQuotas());
                 Dirichlet d2 = (Dirichlet)serializer.ReadObject(reader);
                 Console.WriteLine(d2);
             }


### PR DESCRIPTION
Changed the BCC confusion matrix prior so that TrueLabels can be inferred when LabelCount==2.
Fixed serialization of BCC posteriors.  BCC posteriors now save to the Results folder.
Fixed serialization example code.