### PR TITLE
BayesPointMachineClassifier can be serialized as text

### DIFF
--- a/src/Compiler/Infer/Transforms/GateTransform.cs
+++ b/src/Compiler/Infer/Transforms/GateTransform.cs
@@ -154,8 +154,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             }
 
             bool isStochastic = CodeRecognizer.IsStochastic(context, binding.lhs);
-            IExpression caseNumber = null;
-            bool isBinaryCondition = false;
+            IExpression caseNumber;
+            bool isBinaryCondition;
             if (caseValue.GetExpressionType().Equals(typeof(bool)))
             {
                 isBinaryCondition = true;
@@ -169,6 +169,7 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             }
             else
             {
+                isBinaryCondition = false;
                 caseNumber = caseValue;
             }
 

--- a/src/Learners/Classifier/BayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifier.cs
@@ -14,11 +14,11 @@ namespace Microsoft.ML.Probabilistic.Learners
     using Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInternal;
     using Microsoft.ML.Probabilistic.Learners.Mappings;
     using Microsoft.ML.Probabilistic.Math;
-using Microsoft.ML.Probabilistic.Serialization;
+    using Microsoft.ML.Probabilistic.Serialization;
 
-/// <summary>
-/// The Bayes point machine classifier factory.
-/// </summary>
+    /// <summary>
+    /// The Bayes point machine classifier factory.
+    /// </summary>
     public static class BayesPointMachineClassifier
     {
         #region Public factory methods
@@ -292,15 +292,15 @@ using Microsoft.ML.Probabilistic.Serialization;
 
         #endregion
 
-        #region Custom binary deserialization
+        #region Custom deserialization
 
         /// <summary>
-        /// Deserializes a binary Bayes point machine classifier from a reader to a binary stream and a native data format mapping.
+        /// Deserializes a binary Bayes point machine classifier from a reader to a stream and a native data format mapping.
         /// </summary>
         /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
         /// <typeparam name="TInstance">The type of an instance.</typeparam>
         /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
-        /// <param name="reader">The reader to a binary stream of a serialized binary Bayes point machine classifier.</param>
+        /// <param name="reader">The reader to a stream of a serialized binary Bayes point machine classifier.</param>
         /// <param name="mapping">The mapping used for accessing data in the native format.</param>
         /// <returns>The binary Bayes point machine classifier instance.</returns>
         public static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, bool, Bernoulli, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<bool>>
@@ -321,30 +321,6 @@ using Microsoft.ML.Probabilistic.Serialization;
         }
 
         /// <summary>
-        /// Deserializes a binary Bayes point machine classifier from a binary stream and a native data format mapping.
-        /// </summary>
-        /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
-        /// <typeparam name="TInstance">The type of an instance.</typeparam>
-        /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
-        /// <param name="stream">The binary stream of a serialized binary Bayes point machine classifier.</param>
-        /// <param name="mapping">The mapping used for accessing data in the native format.</param>
-        /// <returns>The binary Bayes point machine classifier instance.</returns>
-        public static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, bool, Bernoulli, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<bool>>
-            LoadBackwardCompatibleBinaryClassifier<TInstanceSource, TInstance, TLabelSource>(
-                Stream stream, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, bool> mapping)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
-            {
-                return LoadBackwardCompatibleBinaryClassifier(reader, mapping);
-            }
-        }
-
-        /// <summary>
         /// Deserializes a binary Bayes point machine classifier from a file with the specified name and a native data format mapping.
         /// </summary>
         /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
@@ -362,19 +338,19 @@ using Microsoft.ML.Probabilistic.Serialization;
                 throw new ArgumentNullException(nameof(fileName));
             }
 
-            using (Stream stream = File.Open(fileName, FileMode.Open))
-            { 
-                return LoadBackwardCompatibleBinaryClassifier(stream, mapping);
-            }
+            return WithReader(fileName, reader =>
+            {
+                return LoadBackwardCompatibleBinaryClassifier(reader, mapping);
+            });
         }
 
         /// <summary>
-        /// Deserializes a multi-class Bayes point machine classifier from a reader to a binary stream and a native data format mapping.
+        /// Deserializes a multi-class Bayes point machine classifier from a reader to a stream and a native data format mapping.
         /// </summary>
         /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
         /// <typeparam name="TInstance">The type of an instance.</typeparam>
         /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
-        /// <param name="reader">The reader to a binary stream of a serialized multi-class Bayes point machine classifier.</param>
+        /// <param name="reader">The reader to a stream of a serialized multi-class Bayes point machine classifier.</param>
         /// <param name="mapping">The mapping used for accessing data in the native format.</param>
         /// <returns>The multi-class Bayes point machine classifier instance.</returns>
         public static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, int, Discrete, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<int>>
@@ -395,30 +371,6 @@ using Microsoft.ML.Probabilistic.Serialization;
         }
 
         /// <summary>
-        /// Deserializes a multi-class Bayes point machine classifier from a binary stream and a native data format mapping.
-        /// </summary>
-        /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
-        /// <typeparam name="TInstance">The type of an instance.</typeparam>
-        /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
-        /// <param name="stream">The binary stream of a serialized multi-class Bayes point machine classifier.</param>
-        /// <param name="mapping">The mapping used for accessing data in the native format.</param>
-        /// <returns>The multi-class Bayes point machine classifier instance.</returns>
-        public static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, int, Discrete, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<int>>
-            LoadBackwardCompatibleMulticlassClassifier<TInstanceSource, TInstance, TLabelSource>(
-                Stream stream, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, int> mapping)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
-            {
-                return LoadBackwardCompatibleMulticlassClassifier(reader, mapping);
-            }
-        }
-
-        /// <summary>
         /// Deserializes a multi-class Bayes point machine classifier from a file with the specified name and a native data format mapping.
         /// </summary>
         /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
@@ -436,20 +388,20 @@ using Microsoft.ML.Probabilistic.Serialization;
                 throw new ArgumentNullException(nameof(fileName));
             }
 
-            using (Stream stream = File.Open(fileName, FileMode.Open))
-            { 
-                return LoadBackwardCompatibleMulticlassClassifier(stream, mapping);
-            }
+            return WithReader(fileName, reader =>
+            {
+                return LoadBackwardCompatibleMulticlassClassifier(reader, mapping);
+            });
         }
 
         /// <summary>
-        /// Deserializes a binary Bayes point machine classifier from a reader to a binary stream and a standard data format mapping.
+        /// Deserializes a binary Bayes point machine classifier from a reader to a stream and a standard data format mapping.
         /// </summary>
         /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
         /// <typeparam name="TInstance">The type of an instance.</typeparam>
         /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
         /// <typeparam name="TLabel">The type of a label.</typeparam>
-        /// <param name="reader">The reader to a binary stream of a serialized binary Bayes point machine classifier.</param>
+        /// <param name="reader">The reader to a stream of a serialized binary Bayes point machine classifier.</param>
         /// <param name="mapping">The mapping used for accessing data in the standard format.</param>
         /// <returns>The binary Bayes point machine classifier instance.</returns>
         public static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel, IDictionary<TLabel, double>, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<TLabel>>
@@ -467,31 +419,6 @@ using Microsoft.ML.Probabilistic.Serialization;
             }
 
             return new CompoundBinaryStandardDataFormatBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel>(reader, mapping);
-        }
-
-        /// <summary>
-        /// Deserializes a binary Bayes point machine classifier from a binary stream and a standard data format mapping.
-        /// </summary>
-        /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
-        /// <typeparam name="TInstance">The type of an instance.</typeparam>
-        /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
-        /// <typeparam name="TLabel">The type of a label.</typeparam>
-        /// <param name="stream">The binary stream of a serialized binary Bayes point machine classifier.</param>
-        /// <param name="mapping">The mapping used for accessing data in the standard format.</param>
-        /// <returns>The binary Bayes point machine classifier instance.</returns>
-        public static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel, IDictionary<TLabel, double>, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<TLabel>>
-            LoadBackwardCompatibleBinaryClassifier<TInstanceSource, TInstance, TLabelSource, TLabel>(
-                Stream stream, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> mapping)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
-            {
-                return LoadBackwardCompatibleBinaryClassifier(reader, mapping);
-            }
         }
 
         /// <summary>
@@ -513,20 +440,20 @@ using Microsoft.ML.Probabilistic.Serialization;
                 throw new ArgumentNullException(nameof(fileName));
             }
 
-            using (Stream stream = File.Open(fileName, FileMode.Open))
-            { 
-                return LoadBackwardCompatibleBinaryClassifier(stream, mapping);
-            }
+            return WithReader(fileName, reader =>
+            {
+                return LoadBackwardCompatibleBinaryClassifier(reader, mapping);
+            });
         }
 
         /// <summary>
-        /// Deserializes a multi-class Bayes point machine classifier from a reader to a binary stream and a standard data format mapping.
+        /// Deserializes a multi-class Bayes point machine classifier from a reader to a stream and a standard data format mapping.
         /// </summary>
         /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
         /// <typeparam name="TInstance">The type of an instance.</typeparam>
         /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
         /// <typeparam name="TLabel">The type of a label.</typeparam>
-        /// <param name="reader">The reader to a binary stream of a serialized multi-class Bayes point machine classifier.</param>
+        /// <param name="reader">The reader to a stream of a serialized multi-class Bayes point machine classifier.</param>
         /// <param name="mapping">The mapping used for accessing data in the standard format.</param>
         /// <returns>The multi-class Bayes point machine classifier instance.</returns>
         public static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel, IDictionary<TLabel, double>, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<TLabel>>
@@ -544,31 +471,6 @@ using Microsoft.ML.Probabilistic.Serialization;
             }
 
             return new CompoundMulticlassStandardDataFormatBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel>(reader, mapping);
-        }
-
-        /// <summary>
-        /// Deserializes a multi-class Bayes point machine classifier from a binary stream and a standard data format mapping.
-        /// </summary>
-        /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
-        /// <typeparam name="TInstance">The type of an instance.</typeparam>
-        /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
-        /// <typeparam name="TLabel">The type of a label.</typeparam>
-        /// <param name="stream">The binary stream of a serialized multi-class Bayes point machine classifier.</param>
-        /// <param name="mapping">The mapping used for accessing data in the standard format.</param>
-        /// <returns>The multi-class Bayes point machine classifier instance.</returns>
-        public static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel, IDictionary<TLabel, double>, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<TLabel>>
-            LoadBackwardCompatibleMulticlassClassifier<TInstanceSource, TInstance, TLabelSource, TLabel>(
-                Stream stream, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> mapping)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
-            {
-                return LoadBackwardCompatibleMulticlassClassifier(reader, mapping);
-            }
         }
 
         /// <summary>
@@ -590,10 +492,10 @@ using Microsoft.ML.Probabilistic.Serialization;
                 throw new ArgumentNullException(nameof(fileName));
             }
 
-            using (Stream stream = File.Open(fileName, FileMode.Open))
-            { 
-                return LoadBackwardCompatibleMulticlassClassifier(stream, mapping);
-            }
+            return WithReader(fileName, reader =>
+            {
+                return LoadBackwardCompatibleMulticlassClassifier(reader, mapping);
+            });
         }
 
         #endregion
@@ -762,16 +664,16 @@ using Microsoft.ML.Probabilistic.Serialization;
 
         #endregion
 
-        #region Internal custom binary deserialization
+        #region Internal custom deserialization
 
         /// <summary>
         /// Deserializes a binary Bayes point machine classifier with <see cref="Gaussian"/> prior distributions
-        /// over factorized weights from a reader to a binary stream and a native data format mapping.
+        /// over factorized weights from a reader to a stream and a native data format mapping.
         /// </summary>
         /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
         /// <typeparam name="TInstance">The type of an instance.</typeparam>
         /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
-        /// <param name="reader">The reader to a binary stream of a serialized binary Bayes point machine classifier.</param>
+        /// <param name="reader">The reader to a stream of a serialized binary Bayes point machine classifier.</param>
         /// <param name="mapping">The mapping used for accessing data in the native format.</param>
         /// <returns>The binary Bayes point machine classifier instance.</returns>
         internal static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, bool, Bernoulli, GaussianBayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<bool>>
@@ -793,31 +695,6 @@ using Microsoft.ML.Probabilistic.Serialization;
 
         /// <summary>
         /// Deserializes a binary Bayes point machine classifier with <see cref="Gaussian"/> prior distributions
-        /// over factorized weights from a binary stream and a native data format mapping.
-        /// </summary>
-        /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
-        /// <typeparam name="TInstance">The type of an instance.</typeparam>
-        /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
-        /// <param name="stream">The binary stream of a serialized binary Bayes point machine classifier.</param>
-        /// <param name="mapping">The mapping used for accessing data in the native format.</param>
-        /// <returns>The binary Bayes point machine classifier instance.</returns>
-        internal static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, bool, Bernoulli, GaussianBayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<bool>>
-            LoadBackwardCompatibleGaussianPriorBinaryClassifier<TInstanceSource, TInstance, TLabelSource>(
-                Stream stream, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, bool> mapping)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
-            {
-                return LoadBackwardCompatibleGaussianPriorBinaryClassifier(reader, mapping);
-            }
-        }
-
-        /// <summary>
-        /// Deserializes a binary Bayes point machine classifier with <see cref="Gaussian"/> prior distributions
         /// over factorized weights from a file with the specified name and a native data format mapping.
         /// </summary>
         /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
@@ -835,20 +712,20 @@ using Microsoft.ML.Probabilistic.Serialization;
                 throw new ArgumentNullException(nameof(fileName));
             }
 
-            using (Stream stream = File.Open(fileName, FileMode.Open))
+            return WithReader(fileName, reader =>
             {
-                return LoadBackwardCompatibleGaussianPriorBinaryClassifier(stream, mapping);
-            }
+                return LoadBackwardCompatibleGaussianPriorBinaryClassifier(reader, mapping);
+            });
         }
 
         /// <summary>
         /// Deserializes a multi-class Bayes point machine classifier with <see cref="Gaussian"/> prior distributions
-        /// over factorized weights from a reader to a binary stream and a native data format mapping.
+        /// over factorized weights from a reader to a stream and a native data format mapping.
         /// </summary>
         /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
         /// <typeparam name="TInstance">The type of an instance.</typeparam>
         /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
-        /// <param name="reader">The reader to a binary stream of a serialized multi-class Bayes point machine classifier.</param>
+        /// <param name="reader">The reader to a stream of a serialized multi-class Bayes point machine classifier.</param>
         /// <param name="mapping">The mapping used for accessing data in the native format.</param>
         /// <returns>The multi-class Bayes point machine classifier instance.</returns>
         internal static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, int, Discrete, GaussianBayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<int>>
@@ -870,31 +747,6 @@ using Microsoft.ML.Probabilistic.Serialization;
 
         /// <summary>
         /// Deserializes a multi-class Bayes point machine classifier with <see cref="Gaussian"/> prior distributions
-        /// over factorized weights from a binary stream and a native data format mapping.
-        /// </summary>
-        /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
-        /// <typeparam name="TInstance">The type of an instance.</typeparam>
-        /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
-        /// <param name="stream">The binary stream of a serialized multi-class Bayes point machine classifier.</param>
-        /// <param name="mapping">The mapping used for accessing data in the native format.</param>
-        /// <returns>The multi-class Bayes point machine classifier instance.</returns>
-        internal static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, int, Discrete, GaussianBayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<int>>
-            LoadBackwardCompatibleGaussianPriorMulticlassClassifier<TInstanceSource, TInstance, TLabelSource>(
-                Stream stream, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, int> mapping)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
-            {
-                return LoadBackwardCompatibleGaussianPriorMulticlassClassifier(reader, mapping);
-            }
-        }
-
-        /// <summary>
-        /// Deserializes a multi-class Bayes point machine classifier with <see cref="Gaussian"/> prior distributions
         /// over factorized weights from a file with the specified name and a native data format mapping.
         /// </summary>
         /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
@@ -912,21 +764,21 @@ using Microsoft.ML.Probabilistic.Serialization;
                 throw new ArgumentNullException(nameof(fileName));
             }
 
-            using (Stream stream = File.Open(fileName, FileMode.Open))
+            return WithReader(fileName, reader =>
             {
-                return LoadBackwardCompatibleGaussianPriorMulticlassClassifier(stream, mapping);
-            }
+                return LoadBackwardCompatibleGaussianPriorMulticlassClassifier(reader, mapping);
+            });
         }
 
         /// <summary>
         /// Deserializes a binary Bayes point machine classifier with <see cref="Gaussian"/> prior distributions
-        /// over factorized weights from a reader to a binary stream and a standard data format mapping.
+        /// over factorized weights from a reader to a stream and a standard data format mapping.
         /// </summary>
         /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
         /// <typeparam name="TInstance">The type of an instance.</typeparam>
         /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
         /// <typeparam name="TLabel">The type of a label.</typeparam>
-        /// <param name="reader">The reader to a binary stream of a serialized binary Bayes point machine classifier.</param>
+        /// <param name="reader">The reader to a stream of a serialized binary Bayes point machine classifier.</param>
         /// <param name="mapping">The mapping used for accessing data in the standard format.</param>
         /// <returns>The binary Bayes point machine classifier instance.</returns>
         internal static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel, IDictionary<TLabel, double>, GaussianBayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<TLabel>>
@@ -944,32 +796,6 @@ using Microsoft.ML.Probabilistic.Serialization;
             }
 
             return new GaussianBinaryStandardDataFormatBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel>(reader, mapping);
-        }
-
-        /// <summary>
-        /// Deserializes a binary Bayes point machine classifier with <see cref="Gaussian"/> prior distributions
-        /// over factorized weights from a binary stream and a standard data format mapping.
-        /// </summary>
-        /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
-        /// <typeparam name="TInstance">The type of an instance.</typeparam>
-        /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
-        /// <typeparam name="TLabel">The type of a label.</typeparam>
-        /// <param name="stream">The binary stream of a serialized binary Bayes point machine classifier.</param>
-        /// <param name="mapping">The mapping used for accessing data in the standard format.</param>
-        /// <returns>The binary Bayes point machine classifier instance.</returns>
-        internal static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel, IDictionary<TLabel, double>, GaussianBayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<TLabel>>
-            LoadBackwardCompatibleGaussianPriorBinaryClassifier<TInstanceSource, TInstance, TLabelSource, TLabel>(
-                Stream stream, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> mapping)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
-            {
-                return LoadBackwardCompatibleGaussianPriorBinaryClassifier(reader, mapping);
-            }
         }
 
         /// <summary>
@@ -992,21 +818,21 @@ using Microsoft.ML.Probabilistic.Serialization;
                 throw new ArgumentNullException(nameof(fileName));
             }
 
-            using (Stream stream = File.Open(fileName, FileMode.Open))
+            return WithReader(fileName, reader =>
             {
-                return LoadBackwardCompatibleGaussianPriorBinaryClassifier(stream, mapping);
-            }
+                return LoadBackwardCompatibleGaussianPriorBinaryClassifier(reader, mapping);
+            });
         }
 
         /// <summary>
         /// Deserializes a multi-class Bayes point machine classifier with <see cref="Gaussian"/> prior distributions
-        /// over factorized weights from a reader to a binary stream and a standard data format mapping.
+        /// over factorized weights from a reader to a stream and a standard data format mapping.
         /// </summary>
         /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
         /// <typeparam name="TInstance">The type of an instance.</typeparam>
         /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
         /// <typeparam name="TLabel">The type of a label.</typeparam>
-        /// <param name="reader">The reader to a binary stream of a serialized multi-class Bayes point machine classifier.</param>
+        /// <param name="reader">The reader to a stream of a serialized multi-class Bayes point machine classifier.</param>
         /// <param name="mapping">The mapping used for accessing data in the standard format.</param>
         /// <returns>The multi-class Bayes point machine classifier instance.</returns>
         internal static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel, IDictionary<TLabel, double>, GaussianBayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<TLabel>>
@@ -1024,32 +850,6 @@ using Microsoft.ML.Probabilistic.Serialization;
             }
 
             return new GaussianMulticlassStandardDataFormatBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel>(reader, mapping);
-        }
-
-        /// <summary>
-        /// Deserializes a multi-class Bayes point machine classifier with <see cref="Gaussian"/> prior distributions
-        /// over factorized weights from a binary stream and a standard data format mapping.
-        /// </summary>
-        /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
-        /// <typeparam name="TInstance">The type of an instance.</typeparam>
-        /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
-        /// <typeparam name="TLabel">The type of a label.</typeparam>
-        /// <param name="stream">The binary stream of a serialized multi-class Bayes point machine classifier.</param>
-        /// <param name="mapping">The mapping used for accessing data in the standard format.</param>
-        /// <returns>The multi-class Bayes point machine classifier instance.</returns>
-        internal static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel, IDictionary<TLabel, double>, GaussianBayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<TLabel>>
-            LoadBackwardCompatibleGaussianPriorMulticlassClassifier<TInstanceSource, TInstance, TLabelSource, TLabel>(
-                Stream stream, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> mapping)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
-            {
-                return LoadBackwardCompatibleGaussianPriorMulticlassClassifier(reader, mapping);
-            }
         }
 
         /// <summary>
@@ -1072,12 +872,33 @@ using Microsoft.ML.Probabilistic.Serialization;
                 throw new ArgumentNullException(nameof(fileName));
             }
 
-            using (Stream stream = File.Open(fileName, FileMode.Open))
+            return WithReader(fileName, reader =>
             {
-                return LoadBackwardCompatibleGaussianPriorMulticlassClassifier(stream, mapping);
-            }
+                return LoadBackwardCompatibleGaussianPriorMulticlassClassifier(reader, mapping);
+            });
         }
 
         #endregion
+
+        internal static T WithReader<T>(string fileName, Func<IReader, T> action)
+        {
+            using (var stream = File.Open(fileName, FileMode.Open))
+            {
+                if (fileName.EndsWith(".bin"))
+                {
+                    using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
+                    {
+                        return action(reader);
+                    }
+                }
+                else
+                {
+                    using (var reader = new WrappedTextReader(new StreamReader(stream)))
+                    {
+                        return action(reader);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/Learners/Classifier/BayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifier.cs
@@ -14,10 +14,11 @@ namespace Microsoft.ML.Probabilistic.Learners
     using Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInternal;
     using Microsoft.ML.Probabilistic.Learners.Mappings;
     using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Serialization;
 
-    /// <summary>
-    /// The Bayes point machine classifier factory.
-    /// </summary>
+/// <summary>
+/// The Bayes point machine classifier factory.
+/// </summary>
     public static class BayesPointMachineClassifier
     {
         #region Public factory methods
@@ -304,7 +305,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// <returns>The binary Bayes point machine classifier instance.</returns>
         public static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, bool, Bernoulli, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<bool>>
             LoadBackwardCompatibleBinaryClassifier<TInstanceSource, TInstance, TLabelSource>(
-                BinaryReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, bool> mapping)
+                IReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, bool> mapping)
         {
             if (reader == null)
             {
@@ -337,7 +338,7 @@ namespace Microsoft.ML.Probabilistic.Learners
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
             {
                 return LoadBackwardCompatibleBinaryClassifier(reader, mapping);
             }
@@ -378,7 +379,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// <returns>The multi-class Bayes point machine classifier instance.</returns>
         public static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, int, Discrete, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<int>>
             LoadBackwardCompatibleMulticlassClassifier<TInstanceSource, TInstance, TLabelSource>(
-                BinaryReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, int> mapping)
+                IReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, int> mapping)
         {
             if (reader == null)
             {
@@ -411,7 +412,7 @@ namespace Microsoft.ML.Probabilistic.Learners
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
             {
                 return LoadBackwardCompatibleMulticlassClassifier(reader, mapping);
             }
@@ -453,7 +454,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// <returns>The binary Bayes point machine classifier instance.</returns>
         public static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel, IDictionary<TLabel, double>, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<TLabel>>
             LoadBackwardCompatibleBinaryClassifier<TInstanceSource, TInstance, TLabelSource, TLabel>(
-                BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> mapping)
+                IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> mapping)
         {
             if (reader == null)
             {
@@ -487,7 +488,7 @@ namespace Microsoft.ML.Probabilistic.Learners
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
             {
                 return LoadBackwardCompatibleBinaryClassifier(reader, mapping);
             }
@@ -530,7 +531,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// <returns>The multi-class Bayes point machine classifier instance.</returns>
         public static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel, IDictionary<TLabel, double>, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<TLabel>>
             LoadBackwardCompatibleMulticlassClassifier<TInstanceSource, TInstance, TLabelSource, TLabel>(
-                BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> mapping)
+                IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> mapping)
         {
             if (reader == null)
             {
@@ -564,7 +565,7 @@ namespace Microsoft.ML.Probabilistic.Learners
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
             {
                 return LoadBackwardCompatibleMulticlassClassifier(reader, mapping);
             }
@@ -775,7 +776,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// <returns>The binary Bayes point machine classifier instance.</returns>
         internal static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, bool, Bernoulli, GaussianBayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<bool>>
             LoadBackwardCompatibleGaussianPriorBinaryClassifier<TInstanceSource, TInstance, TLabelSource>(
-                BinaryReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, bool> mapping)
+                IReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, bool> mapping)
         {
             if (reader == null)
             {
@@ -809,7 +810,7 @@ namespace Microsoft.ML.Probabilistic.Learners
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
             {
                 return LoadBackwardCompatibleGaussianPriorBinaryClassifier(reader, mapping);
             }
@@ -852,7 +853,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// <returns>The multi-class Bayes point machine classifier instance.</returns>
         internal static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, int, Discrete, GaussianBayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<int>>
             LoadBackwardCompatibleGaussianPriorMulticlassClassifier<TInstanceSource, TInstance, TLabelSource>(
-                BinaryReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, int> mapping)
+                IReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, int> mapping)
         {
             if (reader == null)
             {
@@ -886,7 +887,7 @@ namespace Microsoft.ML.Probabilistic.Learners
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
             {
                 return LoadBackwardCompatibleGaussianPriorMulticlassClassifier(reader, mapping);
             }
@@ -930,7 +931,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// <returns>The binary Bayes point machine classifier instance.</returns>
         internal static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel, IDictionary<TLabel, double>, GaussianBayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<TLabel>>
             LoadBackwardCompatibleGaussianPriorBinaryClassifier<TInstanceSource, TInstance, TLabelSource, TLabel>(
-                BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> mapping)
+                IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> mapping)
         {
             if (reader == null)
             {
@@ -965,7 +966,7 @@ namespace Microsoft.ML.Probabilistic.Learners
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
             {
                 return LoadBackwardCompatibleGaussianPriorBinaryClassifier(reader, mapping);
             }
@@ -1010,7 +1011,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// <returns>The multi-class Bayes point machine classifier instance.</returns>
         internal static IBayesPointMachineClassifier<TInstanceSource, TInstance, TLabelSource, TLabel, IDictionary<TLabel, double>, GaussianBayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<TLabel>>
             LoadBackwardCompatibleGaussianPriorMulticlassClassifier<TInstanceSource, TInstance, TLabelSource, TLabel>(
-                BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> mapping)
+                IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> mapping)
         {
             if (reader == null)
             {
@@ -1045,7 +1046,7 @@ namespace Microsoft.ML.Probabilistic.Learners
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
             {
                 return LoadBackwardCompatibleGaussianPriorMulticlassClassifier(reader, mapping);
             }

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/BinaryFactorizedInferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/BinaryFactorizedInferenceAlgorithms.cs
@@ -105,7 +105,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the inference algorithms using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the inference algorithms to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/BinaryFactorizedInferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/BinaryFactorizedInferenceAlgorithms.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the inference algorithm from.</param>
-        protected BinaryFactorizedInferenceAlgorithms(BinaryReader reader)
+        protected BinaryFactorizedInferenceAlgorithms(IReader reader)
             : base(reader)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/CompoundBinaryFactorizedInferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/CompoundBinaryFactorizedInferenceAlgorithms.cs
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the inference algorithm from.</param>
-        public CompoundBinaryFactorizedInferenceAlgorithms(BinaryReader reader)
+        public CompoundBinaryFactorizedInferenceAlgorithms(IReader reader)
             : base(reader)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/CompoundBinaryFactorizedInferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/CompoundBinaryFactorizedInferenceAlgorithms.cs
@@ -88,7 +88,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the inference algorithms using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the inference algorithms to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/CompoundMulticlassFactorizedInferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/CompoundMulticlassFactorizedInferenceAlgorithms.cs
@@ -89,7 +89,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the inference algorithms using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the inference algorithms to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/CompoundMulticlassFactorizedInferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/CompoundMulticlassFactorizedInferenceAlgorithms.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the inference algorithm from.</param>
-        public CompoundMulticlassFactorizedInferenceAlgorithms(BinaryReader reader)
+        public CompoundMulticlassFactorizedInferenceAlgorithms(IReader reader)
             : base(reader)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/GaussianBinaryFactorizedInferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/GaussianBinaryFactorizedInferenceAlgorithms.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the inference algorithm from.</param>
-        public GaussianBinaryFactorizedInferenceAlgorithms(BinaryReader reader)
+        public GaussianBinaryFactorizedInferenceAlgorithms(IReader reader)
             : base(reader)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/GaussianBinaryFactorizedInferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/GaussianBinaryFactorizedInferenceAlgorithms.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the inference algorithms using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the inference algorithms to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/GaussianMulticlassFactorizedInferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/GaussianMulticlassFactorizedInferenceAlgorithms.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the inference algorithms using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the inference algorithms to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/GaussianMulticlassFactorizedInferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/GaussianMulticlassFactorizedInferenceAlgorithms.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the inference algorithm from.</param>
-        public GaussianMulticlassFactorizedInferenceAlgorithms(BinaryReader reader)
+        public GaussianMulticlassFactorizedInferenceAlgorithms(IReader reader)
             : base(reader)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/InferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/InferenceAlgorithms.cs
@@ -88,7 +88,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the inference algorithm from.</param>
-        protected InferenceAlgorithms(BinaryReader reader)
+        protected InferenceAlgorithms(IReader reader)
         {
             Debug.Assert(reader != null, "The reader must not be null.");
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/InferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/InferenceAlgorithms.cs
@@ -293,7 +293,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the inference algorithms using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the inference algorithms to.</param>
-        public virtual void SaveForwardCompatible(BinaryWriter writer)
+        public virtual void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(CustomSerializationVersion);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/MulticlassFactorizedInferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/MulticlassFactorizedInferenceAlgorithms.cs
@@ -122,7 +122,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the inference algorithms using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the inference algorithms to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/MulticlassFactorizedInferenceAlgorithms.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Algorithms/MulticlassFactorizedInferenceAlgorithms.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the inference algorithm from.</param>
-        protected MulticlassFactorizedInferenceAlgorithms(BinaryReader reader)
+        protected MulticlassFactorizedInferenceAlgorithms(IReader reader)
             : base(reader)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/BinaryNativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/BinaryNativeDataFormatBayesPointMachineClassifier.cs
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the binary Bayes point machine classifier from.</param>
         /// <param name="mapping">The mapping used for accessing data in the native format.</param>
-        protected BinaryNativeDataFormatBayesPointMachineClassifier(BinaryReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, bool> mapping)
+        protected BinaryNativeDataFormatBayesPointMachineClassifier(IReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, bool> mapping)
             : base(reader, mapping)
         {
             reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/BinaryNativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/BinaryNativeDataFormatBayesPointMachineClassifier.cs
@@ -81,7 +81,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the Bayes point machine classifier to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/BinaryStandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/BinaryStandardDataFormatBayesPointMachineClassifier.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the binary Bayes point machine classifier from.</param>
         /// <param name="standardMapping">The mapping used for accessing data in the standard format.</param>
-        protected BinaryStandardDataFormatBayesPointMachineClassifier(BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
+        protected BinaryStandardDataFormatBayesPointMachineClassifier(IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
             : base(reader)
         {
             Debug.Assert(standardMapping != null, "The mapping must not be null.");

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/BinaryStandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/BinaryStandardDataFormatBayesPointMachineClassifier.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the Bayes point machine classifier to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundBinaryNativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundBinaryNativeDataFormatBayesPointMachineClassifier.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the binary Bayes point machine classifier from.</param>
         /// <param name="mapping">The mapping used for accessing data in the native format.</param>
-        public CompoundBinaryNativeDataFormatBayesPointMachineClassifier(BinaryReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, bool> mapping)
+        public CompoundBinaryNativeDataFormatBayesPointMachineClassifier(IReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, bool> mapping)
             : base(reader, mapping)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundBinaryNativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundBinaryNativeDataFormatBayesPointMachineClassifier.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the Bayes point machine classifier to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundBinaryStandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundBinaryStandardDataFormatBayesPointMachineClassifier.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the Bayes point machine classifier to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundBinaryStandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundBinaryStandardDataFormatBayesPointMachineClassifier.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the binary Bayes point machine classifier from.</param>
         /// <param name="standardMapping">The mapping used for accessing data in the standard format.</param>
-        public CompoundBinaryStandardDataFormatBayesPointMachineClassifier(BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
+        public CompoundBinaryStandardDataFormatBayesPointMachineClassifier(IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
             : base(reader, standardMapping)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundMulticlassNativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundMulticlassNativeDataFormatBayesPointMachineClassifier.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the Bayes point machine classifier to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundMulticlassNativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundMulticlassNativeDataFormatBayesPointMachineClassifier.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the multi-class Bayes point machine classifier from.</param>
         /// <param name="mapping">The mapping used for accessing data in the native format.</param>
-        public CompoundMulticlassNativeDataFormatBayesPointMachineClassifier(BinaryReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, int> mapping)
+        public CompoundMulticlassNativeDataFormatBayesPointMachineClassifier(IReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, int> mapping)
             : base(reader, mapping)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundMulticlassStandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundMulticlassStandardDataFormatBayesPointMachineClassifier.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the Bayes point machine classifier to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundMulticlassStandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/CompoundMulticlassStandardDataFormatBayesPointMachineClassifier.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the multi-class Bayes point machine classifier from.</param>
         /// <param name="standardMapping">The mapping used for accessing data in the standard format.</param>
-        public CompoundMulticlassStandardDataFormatBayesPointMachineClassifier(BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
+        public CompoundMulticlassStandardDataFormatBayesPointMachineClassifier(IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
             : base(reader, standardMapping)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianBinaryNativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianBinaryNativeDataFormatBayesPointMachineClassifier.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the binary Bayes point machine classifier from.</param>
         /// <param name="mapping">The mapping used for accessing data in the native format.</param>
-        public GaussianBinaryNativeDataFormatBayesPointMachineClassifier(BinaryReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, bool> mapping)
+        public GaussianBinaryNativeDataFormatBayesPointMachineClassifier(IReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, bool> mapping)
             : base(reader, mapping)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianBinaryNativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianBinaryNativeDataFormatBayesPointMachineClassifier.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the Bayes point machine classifier to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianBinaryStandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianBinaryStandardDataFormatBayesPointMachineClassifier.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the binary Bayes point machine classifier from.</param>
         /// <param name="standardMapping">The mapping used for accessing data in the standard format.</param>
-        public GaussianBinaryStandardDataFormatBayesPointMachineClassifier(BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
+        public GaussianBinaryStandardDataFormatBayesPointMachineClassifier(IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
             : base(reader, standardMapping)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianBinaryStandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianBinaryStandardDataFormatBayesPointMachineClassifier.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the Bayes point machine classifier to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianMulticlassNativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianMulticlassNativeDataFormatBayesPointMachineClassifier.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the Bayes point machine classifier to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianMulticlassNativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianMulticlassNativeDataFormatBayesPointMachineClassifier.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the multi-class Bayes point machine classifier from.</param>
         /// <param name="mapping">The mapping used for accessing data in the native format.</param>
-        public GaussianMulticlassNativeDataFormatBayesPointMachineClassifier(BinaryReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, int> mapping)
+        public GaussianMulticlassNativeDataFormatBayesPointMachineClassifier(IReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, int> mapping)
             : base(reader, mapping)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianMulticlassStandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianMulticlassStandardDataFormatBayesPointMachineClassifier.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the Bayes point machine classifier to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianMulticlassStandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/GaussianMulticlassStandardDataFormatBayesPointMachineClassifier.cs
@@ -49,7 +49,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the multi-class Bayes point machine classifier from.</param>
         /// <param name="standardMapping">The mapping used for accessing data in the standard format.</param>
-        public GaussianMulticlassStandardDataFormatBayesPointMachineClassifier(BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
+        public GaussianMulticlassStandardDataFormatBayesPointMachineClassifier(IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
             : base(reader, standardMapping)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/MulticlassNativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/MulticlassNativeDataFormatBayesPointMachineClassifier.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the multi-class Bayes point machine classifier from.</param>
         /// <param name="mapping">The mapping used for accessing data in the native format.</param>
-        protected MulticlassNativeDataFormatBayesPointMachineClassifier(BinaryReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, int> mapping)
+        protected MulticlassNativeDataFormatBayesPointMachineClassifier(IReader reader, IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, int> mapping)
             : base(reader, mapping)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/MulticlassNativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/MulticlassNativeDataFormatBayesPointMachineClassifier.cs
@@ -130,7 +130,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the Bayes point machine classifier to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/MulticlassStandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/MulticlassStandardDataFormatBayesPointMachineClassifier.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the multi-class Bayes point machine classifier from.</param>
         /// <param name="standardMapping">The mapping used for accessing data in the standard format.</param>
-        protected MulticlassStandardDataFormatBayesPointMachineClassifier(BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
+        protected MulticlassStandardDataFormatBayesPointMachineClassifier(IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
             : base(reader)
         {
             Debug.Assert(standardMapping != null, "The mapping must not be null.");

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/MulticlassStandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/MulticlassStandardDataFormatBayesPointMachineClassifier.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the Bayes point machine classifier to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/NativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/NativeDataFormatBayesPointMachineClassifier.cs
@@ -100,7 +100,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
             this.capabilities = new BayesPointMachineClassifierCapabilities();
 
             reader.VerifySerializationGuid(
-                this.customSerializationGuid, "The binary stream does not contain an Infer.NET Bayes point machine classifier.");
+                this.customSerializationGuid, "The stream does not contain an Infer.NET Bayes point machine classifier.");
 
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);
             if (deserializedVersion == CustomSerializationVersion)

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/NativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/NativeDataFormatBayesPointMachineClassifier.cs
@@ -354,7 +354,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the Bayes point machine classifier to.</param>
-        public virtual void SaveForwardCompatible(BinaryWriter writer)
+        public virtual void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/NativeDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/NativeDataFormatBayesPointMachineClassifier.cs
@@ -90,7 +90,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// <param name="reader">The binary reader to read the state of the Bayes point machine classifier from.</param>
         /// <param name="mapping">The mapping used for accessing data in the native format.</param>
         protected NativeDataFormatBayesPointMachineClassifier(
-            BinaryReader reader, 
+            IReader reader, 
             IBayesPointMachineClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel> mapping)
         {
             Debug.Assert(reader != null, "The reader must not be null.");

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/StandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/StandardDataFormatBayesPointMachineClassifier.cs
@@ -271,7 +271,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the Bayes point machine classifier to.</param>
-        public virtual void SaveForwardCompatible(BinaryWriter writer)
+        public virtual void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/StandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/StandardDataFormatBayesPointMachineClassifier.cs
@@ -60,7 +60,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// class from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the state of the Bayes point machine classifier from.</param>
-        protected StandardDataFormatBayesPointMachineClassifier(BinaryReader reader)
+        protected StandardDataFormatBayesPointMachineClassifier(IReader reader)
         {
             Debug.Assert(reader != null, "The reader must not be null.");
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/StandardDataFormatBayesPointMachineClassifier.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Classifiers/StandardDataFormatBayesPointMachineClassifier.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
             Debug.Assert(reader != null, "The reader must not be null.");
 
             reader.VerifySerializationGuid(
-                this.customSerializationGuid, "The binary stream does not contain an Infer.NET Bayes point machine classifier.");
+                this.customSerializationGuid, "The stream does not contain an Infer.NET Bayes point machine classifier.");
             reader.ReadSerializationVersion(CustomSerializationVersion);
 
             // Nothing to deserialize

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Mappings/BinaryNativeClassifierMapping.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Mappings/BinaryNativeClassifierMapping.cs
@@ -142,7 +142,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the data mapping using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the data mapping to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Mappings/BinaryNativeClassifierMapping.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Mappings/BinaryNativeClassifierMapping.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the mapping from.</param>
         /// <param name="standardMapping">The mapping for accessing data in standard format.</param>
-        public BinaryNativeClassifierMapping(BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
+        public BinaryNativeClassifierMapping(IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
             : base(reader, standardMapping)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Mappings/MulticlassNativeClassifierMapping.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Mappings/MulticlassNativeClassifierMapping.cs
@@ -131,7 +131,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the data mapping using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the data mapping to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Mappings/MulticlassNativeClassifierMapping.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Mappings/MulticlassNativeClassifierMapping.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the mapping from.</param>
         /// <param name="standardMapping">The mapping for accessing data in standard format.</param>
-        public MulticlassNativeClassifierMapping(BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
+        public MulticlassNativeClassifierMapping(IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, Vector> standardMapping)
             : base(reader, standardMapping)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Mappings/NativeClassifierMapping.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Mappings/NativeClassifierMapping.cs
@@ -128,7 +128,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the mapping from.</param>
         /// <param name="standardMapping">The mapping for accessing data in standard format.</param>
-        protected NativeClassifierMapping(BinaryReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TStandardLabel, Vector> standardMapping)
+        protected NativeClassifierMapping(IReader reader, IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TStandardLabel, Vector> standardMapping)
         {
             this.StandardMapping = standardMapping;
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Mappings/NativeClassifierMapping.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Mappings/NativeClassifierMapping.cs
@@ -266,7 +266,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the state of the data mapping using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the data mapping to.</param>
-        public virtual void SaveForwardCompatible(BinaryWriter writer)
+        public virtual void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(CustomSerializationVersion);
             writer.Write(this.isSparseFeatureRepresentation);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianBayesPointMachineClassifierAdvancedTrainingSettings.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianBayesPointMachineClassifierAdvancedTrainingSettings.cs
@@ -56,7 +56,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the advanced training settings from.</param>
         /// <param name="isTrained">Indicates whether the Bayes point machine classifier is trained.</param>
-        internal GaussianBayesPointMachineClassifierAdvancedTrainingSettings(BinaryReader reader, Func<bool> isTrained)
+        internal GaussianBayesPointMachineClassifierAdvancedTrainingSettings(IReader reader, Func<bool> isTrained)
         {
             if (reader == null)
             {

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianBayesPointMachineClassifierAdvancedTrainingSettings.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianBayesPointMachineClassifierAdvancedTrainingSettings.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// prior distributions over weights using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the advanced training settings to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianBayesPointMachineClassifierTrainingSettings.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianBayesPointMachineClassifierTrainingSettings.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// prior distributions over weights using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the training settings to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianBayesPointMachineClassifierTrainingSettings.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianBayesPointMachineClassifierTrainingSettings.cs
@@ -37,7 +37,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the training settings from.</param>
         /// <param name="isTrained">Indicates whether the Bayes point machine classifier is trained.</param>
-        internal GaussianBayesPointMachineClassifierTrainingSettings(BinaryReader reader, Func<bool> isTrained)
+        internal GaussianBayesPointMachineClassifierTrainingSettings(IReader reader, Func<bool> isTrained)
             : base(reader, isTrained)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianBinaryBayesPointMachineClassifierSettings.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianBinaryBayesPointMachineClassifierSettings.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the settings of the binary Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the settings to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianBinaryBayesPointMachineClassifierSettings.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianBinaryBayesPointMachineClassifierSettings.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the settings of the binary Bayes point machine classifier from.</param>
         /// <param name="isTrained">Indicates whether the binary Bayes point machine classifier is trained.</param>
-        internal GaussianBinaryBayesPointMachineClassifierSettings(BinaryReader reader, Func<bool> isTrained) : base(reader)
+        internal GaussianBinaryBayesPointMachineClassifierSettings(IReader reader, Func<bool> isTrained) : base(reader)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianMulticlassBayesPointMachineClassifierSettings.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianMulticlassBayesPointMachineClassifierSettings.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// </summary>
         /// <param name="reader">The binary reader to read the settings of the multi-class Bayes point machine classifier from.</param>
         /// <param name="isTrained">Indicates whether the multi-class Bayes point machine classifier is trained.</param>
-        internal GaussianMulticlassBayesPointMachineClassifierSettings(BinaryReader reader, Func<bool> isTrained) : base(reader)
+        internal GaussianMulticlassBayesPointMachineClassifierSettings(IReader reader, Func<bool> isTrained) : base(reader)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);
 

--- a/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianMulticlassBayesPointMachineClassifierSettings.cs
+++ b/src/Learners/Classifier/BayesPointMachineClassifierInternal/Settings/GaussianMulticlassBayesPointMachineClassifierSettings.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
         /// Saves the settings of the multi-class Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the settings to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/Settings/BayesPointMachineClassifierPredictionSettings.cs
+++ b/src/Learners/Classifier/Settings/BayesPointMachineClassifierPredictionSettings.cs
@@ -60,7 +60,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the prediction settings from.</param>
-        protected BayesPointMachineClassifierPredictionSettings(BinaryReader reader)
+        protected BayesPointMachineClassifierPredictionSettings(IReader reader)
         {
             if (reader == null)
             {

--- a/src/Learners/Classifier/Settings/BayesPointMachineClassifierPredictionSettings.cs
+++ b/src/Learners/Classifier/Settings/BayesPointMachineClassifierPredictionSettings.cs
@@ -133,7 +133,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// Saves the prediction settings of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the prediction settings to.</param>
-        public virtual void SaveForwardCompatible(BinaryWriter writer)
+        public virtual void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);

--- a/src/Learners/Classifier/Settings/BayesPointMachineClassifierSettings.cs
+++ b/src/Learners/Classifier/Settings/BayesPointMachineClassifierSettings.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the settings of the Bayes point machine classifier from.</param>
-        protected BayesPointMachineClassifierSettings(BinaryReader reader)
+        protected BayesPointMachineClassifierSettings(IReader reader)
         {
             reader.VerifySerializationGuid(
                 this.customSerializationGuid, "The binary stream does not contain the settings of an Infer.NET Bayes point machine classifier.");

--- a/src/Learners/Classifier/Settings/BayesPointMachineClassifierSettings.cs
+++ b/src/Learners/Classifier/Settings/BayesPointMachineClassifierSettings.cs
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// Saves the settings of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the settings to.</param>
-        public virtual void SaveForwardCompatible(BinaryWriter writer)
+        public virtual void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);

--- a/src/Learners/Classifier/Settings/BayesPointMachineClassifierTrainingSettings.cs
+++ b/src/Learners/Classifier/Settings/BayesPointMachineClassifierTrainingSettings.cs
@@ -166,7 +166,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// Saves the training settings of the Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the training settings to.</param>
-        public virtual void SaveForwardCompatible(BinaryWriter writer)
+        public virtual void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);

--- a/src/Learners/Classifier/Settings/BayesPointMachineClassifierTrainingSettings.cs
+++ b/src/Learners/Classifier/Settings/BayesPointMachineClassifierTrainingSettings.cs
@@ -79,7 +79,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// </summary>
         /// <param name="reader">The binary reader to read the training settings from.</param>
         /// <param name="isTrained">Indicates whether the Bayes point machine classifier is trained.</param>
-        internal BayesPointMachineClassifierTrainingSettings(BinaryReader reader, Func<bool> isTrained)
+        internal BayesPointMachineClassifierTrainingSettings(IReader reader, Func<bool> isTrained)
         {
             if (reader == null)
             {

--- a/src/Learners/Classifier/Settings/BinaryBayesPointMachineClassifierPredictionSettings.cs
+++ b/src/Learners/Classifier/Settings/BinaryBayesPointMachineClassifierPredictionSettings.cs
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the prediction settings from.</param>
-        public BinaryBayesPointMachineClassifierPredictionSettings(BinaryReader reader) : base(reader)
+        public BinaryBayesPointMachineClassifierPredictionSettings(IReader reader) : base(reader)
         {
             reader.ReadSerializationVersion(CustomSerializationVersion);
             

--- a/src/Learners/Classifier/Settings/BinaryBayesPointMachineClassifierPredictionSettings.cs
+++ b/src/Learners/Classifier/Settings/BinaryBayesPointMachineClassifierPredictionSettings.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// Saves the prediction settings of the binary Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the prediction settings to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/Settings/BinaryBayesPointMachineClassifierSettings.cs
+++ b/src/Learners/Classifier/Settings/BinaryBayesPointMachineClassifierSettings.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// Saves the settings of the binary Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the settings to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/Settings/BinaryBayesPointMachineClassifierSettings.cs
+++ b/src/Learners/Classifier/Settings/BinaryBayesPointMachineClassifierSettings.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// </summary>
         /// <param name="reader">The binary reader to read the settings of the binary Bayes point machine classifier from.</param>
         /// <param name="isTrained">Indicates whether the binary Bayes point machine classifier is trained.</param>
-        internal BinaryBayesPointMachineClassifierSettings(BinaryReader reader, Func<bool> isTrained) : base(reader)
+        internal BinaryBayesPointMachineClassifierSettings(IReader reader, Func<bool> isTrained) : base(reader)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);
 

--- a/src/Learners/Classifier/Settings/MulticlassBayesPointMachineClassifierPredictionSettings.cs
+++ b/src/Learners/Classifier/Settings/MulticlassBayesPointMachineClassifierPredictionSettings.cs
@@ -83,7 +83,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// Saves the prediction settings of the multi-class Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the prediction settings to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Classifier/Settings/MulticlassBayesPointMachineClassifierPredictionSettings.cs
+++ b/src/Learners/Classifier/Settings/MulticlassBayesPointMachineClassifierPredictionSettings.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the prediction settings from.</param>
-        internal MulticlassBayesPointMachineClassifierPredictionSettings(BinaryReader reader) 
+        internal MulticlassBayesPointMachineClassifierPredictionSettings(IReader reader) 
             : base(reader)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);

--- a/src/Learners/Classifier/Settings/MulticlassBayesPointMachineClassifierSettings.cs
+++ b/src/Learners/Classifier/Settings/MulticlassBayesPointMachineClassifierSettings.cs
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// </summary>
         /// <param name="reader">The binary reader to read the settings of the multi-class Bayes point machine classifier from.</param>
         /// <param name="isTrained">Indicates whether the multi-class Bayes point machine classifier is trained.</param>
-        internal MulticlassBayesPointMachineClassifierSettings(BinaryReader reader, Func<bool> isTrained) : base(reader)
+        internal MulticlassBayesPointMachineClassifierSettings(IReader reader, Func<bool> isTrained) : base(reader)
         {
             int deserializedVersion = reader.ReadSerializationVersion(CustomSerializationVersion);
 

--- a/src/Learners/Classifier/Settings/MulticlassBayesPointMachineClassifierSettings.cs
+++ b/src/Learners/Classifier/Settings/MulticlassBayesPointMachineClassifierSettings.cs
@@ -53,7 +53,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// Saves the settings of the multi-class Bayes point machine classifier using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the settings to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Core/ICustomSerializable.cs
+++ b/src/Learners/Core/ICustomSerializable.cs
@@ -4,17 +4,17 @@
 
 namespace Microsoft.ML.Probabilistic.Learners
 {
-    using System.IO;
+    using Serialization;
 
     /// <summary>
-    /// Interface to any object that needs to control its own binary serialization.
+    /// Interface to any object that needs to control its own serialization.
     /// </summary>
     public interface ICustomSerializable
     {
         /// <summary>
-        /// Saves the state of the object to a binary writer.
+        /// Saves the state of the object to a writer.
         /// </summary>
         /// <param name="writer">The writer to save the state of the object to.</param>
-        void SaveForwardCompatible(BinaryWriter writer);
+        void SaveForwardCompatible(IWriter writer);
     }
 }

--- a/src/Learners/Core/IndexedSet.cs
+++ b/src/Learners/Core/IndexedSet.cs
@@ -66,7 +66,7 @@ namespace Microsoft.ML.Probabilistic.Collections
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The reader to load the indexed set from.</param>
-        public IndexedSet(BinaryReader reader) : this()
+        public IndexedSet(IReader reader) : this()
         {
             if (reader == null)
             {

--- a/src/Learners/Core/IndexedSet.cs
+++ b/src/Learners/Core/IndexedSet.cs
@@ -219,7 +219,7 @@ namespace Microsoft.ML.Probabilistic.Collections
         /// Saves the elements of the indexed set to a binary writer.
         /// </summary>
         /// <param name="writer">The writer to save the elements of the indexed set to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             if (writer == null)
             {

--- a/src/Learners/Core/SettingsGuard.cs
+++ b/src/Learners/Core/SettingsGuard.cs
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// Saves the state of the <see cref="SettingsGuard"/> using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the <see cref="SettingsGuard"/> to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(CustomSerializationVersion);
             writer.Write(this.message);

--- a/src/Learners/Core/SettingsGuard.cs
+++ b/src/Learners/Core/SettingsGuard.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// </summary>
         /// <param name="reader">The reader to load the <see cref="SettingsGuard"/> from.</param>
         /// <param name="isImmutable">If true, the setting cannot be changed.</param>
-        public SettingsGuard(BinaryReader reader, Func<bool> isImmutable)
+        public SettingsGuard(IReader reader, Func<bool> isImmutable)
         {
             if (reader == null)
             {

--- a/src/Learners/Core/Utilities.cs
+++ b/src/Learners/Core/Utilities.cs
@@ -95,7 +95,14 @@ namespace Microsoft.ML.Probabilistic.Learners
 
             using (Stream stream = File.Open(fileName, fileMode))
             {
-                obj.SaveForwardCompatibleBinary(stream);
+                if (fileName.EndsWith(".bin"))
+                {
+                    obj.SaveForwardCompatibleAsBinary(stream);
+                }
+                else
+                {
+                    obj.SaveForwardCompatibleAsText(stream);
+                }
             }
         }
 
@@ -105,7 +112,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// <param name="obj">The object to be serialized.</param>
         /// <param name="stream">The serialization stream.</param>
         /// <remarks>To load a saved learner, you can use the factory methods whose names start with LoadBackwardCompatible.</remarks>
-        public static void SaveForwardCompatibleBinary(this ICustomSerializable obj, Stream stream)
+        public static void SaveForwardCompatibleAsBinary(this ICustomSerializable obj, Stream stream)
         {
             if (obj == null)
             {
@@ -118,6 +125,30 @@ namespace Microsoft.ML.Probabilistic.Learners
             }
 
             using (var writer = new WrappedBinaryWriter(new BinaryWriter(stream, Encoding.UTF8, true)))
+            {
+                obj.SaveForwardCompatible(writer);
+            }
+        }
+
+        /// <summary>
+        /// Persists an object that controls its binary serialization to the specified stream.
+        /// </summary>
+        /// <param name="obj">The object to be serialized.</param>
+        /// <param name="stream">The serialization stream.</param>
+        /// <remarks>To load a saved learner, you can use the factory methods whose names start with LoadBackwardCompatible.</remarks>
+        public static void SaveForwardCompatibleAsText(this ICustomSerializable obj, Stream stream)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            using (var writer = new WrappedTextWriter(new StreamWriter(stream)))
             {
                 obj.SaveForwardCompatible(writer);
             }

--- a/src/Learners/Core/Utilities.cs
+++ b/src/Learners/Core/Utilities.cs
@@ -12,6 +12,8 @@ namespace Microsoft.ML.Probabilistic.Learners
     using System.Runtime.Serialization.Formatters.Binary;
     using System.Text;
 
+    using Serialization;
+
     /// <summary>
     /// Implements various utilities for all learners.
     /// </summary>
@@ -93,7 +95,7 @@ namespace Microsoft.ML.Probabilistic.Learners
 
             using (Stream stream = File.Open(fileName, fileMode))
             {
-                obj.SaveForwardCompatible(stream);
+                obj.SaveForwardCompatibleBinary(stream);
             }
         }
 
@@ -103,7 +105,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// <param name="obj">The object to be serialized.</param>
         /// <param name="stream">The serialization stream.</param>
         /// <remarks>To load a saved learner, you can use the factory methods whose names start with LoadBackwardCompatible.</remarks>
-        public static void SaveForwardCompatible(this ICustomSerializable obj, Stream stream)
+        public static void SaveForwardCompatibleBinary(this ICustomSerializable obj, Stream stream)
         {
             if (obj == null)
             {
@@ -115,7 +117,7 @@ namespace Microsoft.ML.Probabilistic.Learners
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using (var writer = new BinaryWriter(stream, Encoding.UTF8, true))
+            using (var writer = new WrappedBinaryWriter(new BinaryWriter(stream, Encoding.UTF8, true)))
             {
                 obj.SaveForwardCompatible(writer);
             }

--- a/src/Learners/Recommender/Mappings/NegativeDataGeneratorMapping.cs
+++ b/src/Learners/Recommender/Mappings/NegativeDataGeneratorMapping.cs
@@ -238,7 +238,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Mappings
         /// Saves the negative data generation mapping using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the negative data generation mapping to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);

--- a/src/Learners/Recommender/Mappings/NegativeDataGeneratorMapping.cs
+++ b/src/Learners/Recommender/Mappings/NegativeDataGeneratorMapping.cs
@@ -117,7 +117,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Mappings
         /// <param name="reader">The binary reader to read the state of the negative data generation mapping from.</param>
         /// <param name="mapping">The top level mapping.</param>
         public NegativeDataGeneratorMapping(
-            BinaryReader reader,
+            IReader reader,
             IRecommenderMapping<TInstanceSource, TInstance, TUser, TItem, TFeatureSource, TFeatureValues> mapping)
         {
             if (reader == null)

--- a/src/Learners/Recommender/MatchboxRecommender.cs
+++ b/src/Learners/Recommender/MatchboxRecommender.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ML.Probabilistic.Learners
     using Microsoft.ML.Probabilistic.Learners.Mappings;
     using Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal;
     using Microsoft.ML.Probabilistic.Math;
+    using Microsoft.ML.Probabilistic.Serialization;
 
     using RatingDistribution = System.Collections.Generic.IDictionary<int, double>;
     
@@ -116,7 +117,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// <returns>The deserialized recommender object.</returns>
         public static IMatchboxRecommender<TInstanceSource, int, int, Discrete, TFeatureSource>
             LoadBackwardCompatible<TInstanceSource, TFeatureSource>(
-                BinaryReader reader, IMatchboxRecommenderMapping<TInstanceSource, TFeatureSource> mapping)
+                IReader reader, IMatchboxRecommenderMapping<TInstanceSource, TFeatureSource> mapping)
         {
             if (reader == null)
             {
@@ -148,7 +149,7 @@ namespace Microsoft.ML.Probabilistic.Learners
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
             {
                 return LoadBackwardCompatible(reader, mapping);
             }
@@ -191,7 +192,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// <returns>The deserialized recommender object.</returns>
         public static IMatchboxRecommender<TInstanceSource, TUser, TItem, RatingDistribution, TFeatureSource>
             LoadBackwardCompatible<TInstanceSource, TInstance, TUser, TItem, TRating, TFeatureSource>(
-                BinaryReader reader, IStarRatingRecommenderMapping<TInstanceSource, TInstance, TUser, TItem, TRating, TFeatureSource, Vector> mapping)
+                IReader reader, IStarRatingRecommenderMapping<TInstanceSource, TInstance, TUser, TItem, TRating, TFeatureSource, Vector> mapping)
         {
             if (reader == null)
             {
@@ -227,7 +228,7 @@ namespace Microsoft.ML.Probabilistic.Learners
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+            using (var reader = new WrappedBinaryReader(new BinaryReader(stream, Encoding.UTF8, true)))
             {
                 return LoadBackwardCompatible(reader, mapping);
             }

--- a/src/Learners/Recommender/MatchboxRecommenderAdvancedTrainingSettings.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderAdvancedTrainingSettings.cs
@@ -330,7 +330,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// Saves the advanced training settings of a Matchbox recommender using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the advanced training settings to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);

--- a/src/Learners/Recommender/MatchboxRecommenderAdvancedTrainingSettings.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderAdvancedTrainingSettings.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// </summary>
         /// <param name="reader">The binary reader to read the advanced training settings from.</param>
         /// <param name="isTrained">Indicates whether the Matchbox recommender is trained.</param>
-        internal MatchboxRecommenderAdvancedTrainingSettings(BinaryReader reader, Func<bool> isTrained)
+        internal MatchboxRecommenderAdvancedTrainingSettings(IReader reader, Func<bool> isTrained)
         {
             if (reader == null)
             {

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/EntityParameterDistribution.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/EntityParameterDistribution.cs
@@ -69,7 +69,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// Saves the distribution over traits and bias of a user or an item using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the distribution over traits and bias of a user or an item to.</param>
-        public virtual void SaveForwardCompatible(BinaryWriter writer)
+        public virtual void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(CustomSerializationVersion);
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/EntityParameterDistribution.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/EntityParameterDistribution.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the distribution over traits and bias of a user or an item from.</param>
-        protected EntityParameterDistribution(BinaryReader reader)
+        protected EntityParameterDistribution(IReader reader)
         {
             Debug.Assert(reader != null, "The reader must not be null.");
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/FeatureHyperparameters.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/FeatureHyperparameters.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// Saves the feature-related hyper-parameters of the Matchbox recommender using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the feature-related hyper-parameters to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(CustomSerializationVersion);
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/FeatureHyperparameters.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/FeatureHyperparameters.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the feature-related hyper-parameters from.</param>
-        public FeatureHyperparameters(BinaryReader reader)
+        public FeatureHyperparameters(IReader reader)
         {
             if (reader == null)
             {

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/FeatureParameterDistribution.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/FeatureParameterDistribution.cs
@@ -126,7 +126,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// Saves the distributions over feature weights using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the distributions over feature weights to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(CustomSerializationVersion);
             writer.Write(this.TraitWeights);

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/FeatureParameterDistribution.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/FeatureParameterDistribution.cs
@@ -37,10 +37,10 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FeatureParameterDistribution"/> class
-        /// from a reader of a binary stream.
+        /// from a reader of a stream.
         /// </summary>
-        /// <param name="reader">The binary reader to read the distribution over feature weights from.</param>
-        public FeatureParameterDistribution(BinaryReader reader)
+        /// <param name="reader">The reader to read the distribution over feature weights from.</param>
+        public FeatureParameterDistribution(IReader reader)
         {
             if (reader == null) throw new ArgumentNullException(nameof(reader));
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/ItemHyperparameters.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/ItemHyperparameters.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// Saves the item-related hyper-parameters of the Matchbox recommender using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the item-related hyper-parameters to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(CustomSerializationVersion);
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/ItemHyperparameters.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/ItemHyperparameters.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the item-related hyper-parameters from.</param>
-        public ItemHyperparameters(BinaryReader reader)
+        public ItemHyperparameters(IReader reader)
         {
             if (reader == null)
             {

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/ItemParameterDistribution.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/ItemParameterDistribution.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the distribution over item parameters from.</param>
-        public ItemParameterDistribution(BinaryReader reader) : base(reader)
+        public ItemParameterDistribution(IReader reader) : base(reader)
         {
             Debug.Assert(reader != null, "The reader must not be null.");
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/ItemParameterDistribution.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/ItemParameterDistribution.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// Saves the distribution over item parameters using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the distribution over item parameters to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/NativeDataFormatMatchboxRecommender.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/NativeDataFormatMatchboxRecommender.cs
@@ -111,7 +111,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// </summary>
         /// <param name="reader">The binary reader to read the Matchbox recommender from.</param>
         /// <param name="mapping">The mapping used for accessing data.</param>
-        internal NativeDataFormatMatchboxRecommender(BinaryReader reader, IMatchboxRecommenderMapping<TInstanceSource, TFeatureSource> mapping)
+        internal NativeDataFormatMatchboxRecommender(IReader reader, IMatchboxRecommenderMapping<TInstanceSource, TFeatureSource> mapping)
         {
             Debug.Assert(reader != null, "The reader must not be null.");
             Debug.Assert(mapping != null, "The mapping must not be null.");

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/NativeDataFormatMatchboxRecommender.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/NativeDataFormatMatchboxRecommender.cs
@@ -774,7 +774,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// Saves the state of the Matchbox recommender using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the Matchbox recommender to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/NoiseHyperparameters.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/NoiseHyperparameters.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// Saves the noise variance of the Matchbox recommender using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the model noise variance to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(CustomSerializationVersion);
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/NoiseHyperparameters.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/NoiseHyperparameters.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the model noise variance from.</param>
-        public NoiseHyperparameters(BinaryReader reader)
+        public NoiseHyperparameters(IReader reader)
         {
             if (reader == null)
             {

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/ParameterDistributions.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/ParameterDistributions.cs
@@ -348,7 +348,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// Saves the distributions over parameters using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the distributions over parameters to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(CustomSerializationVersion);
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/ParameterDistributions.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/ParameterDistributions.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the distributions over parameters from.</param>
-        public ParameterDistributions(BinaryReader reader)
+        public ParameterDistributions(IReader reader)
         {
             Debug.Assert(reader != null, "The reader must not be null.");
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/StandardDataFormatMatchboxRecommender.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/StandardDataFormatMatchboxRecommender.cs
@@ -104,7 +104,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// <param name="reader">The binary reader to read the Matchbox recommender from.</param>
         /// <param name="topLevelMapping">The mapping used for accessing data.</param>
         internal StandardDataFormatMatchboxRecommender(
-            BinaryReader reader, IStarRatingRecommenderMapping<TInstanceSource, TInstance, TUser, TItem, TDataRating, TFeatureSource, Vector> topLevelMapping)
+            IReader reader, IStarRatingRecommenderMapping<TInstanceSource, TInstance, TUser, TItem, TDataRating, TFeatureSource, Vector> topLevelMapping)
         {
             Debug.Assert(reader != null, "The reader must not be null.");
             Debug.Assert(topLevelMapping != null, "The mapping must not be null.");
@@ -648,7 +648,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
             /// <param name="reader">The binary reader to read the state of the mapping from.</param>
             /// <param name="topLevelMapping">The wrapped mapping for accessing data in standard format.</param>
             public NativeRecommenderMapping(
-                BinaryReader reader,
+                IReader reader,
                 IStarRatingRecommenderMapping<TInstanceSource, TInstance, TUser, TItem, TDataRating, TFeatureSource, Vector> topLevelMapping)
             {
                 Debug.Assert(reader != null, "The reader must not be null.");
@@ -1132,7 +1132,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
             /// from a reader of a binary stream.
             /// </summary>
             /// <param name="reader">The binary reader to read the mapping from entity identifiers to entity objects from.</param>
-            public IndexedEntitySet(BinaryReader reader)
+            public IndexedEntitySet(IReader reader)
             {
                 Debug.Assert(reader != null, "The reader must not be null.");
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/StandardDataFormatMatchboxRecommender.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/StandardDataFormatMatchboxRecommender.cs
@@ -470,7 +470,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// Saves the state of the Matchbox recommender using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the state of the Matchbox recommender to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);
@@ -918,7 +918,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
             /// Saves the state of the mapping using the specified writer to a binary stream.
             /// </summary>
             /// <param name="writer">The writer to save the state of the mapping to.</param>
-            public void SaveForwardCompatible(BinaryWriter writer)
+            public void SaveForwardCompatible(IWriter writer)
             {
                 writer.Write(CustomSerializationVersion);
 
@@ -1203,7 +1203,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
             /// Saves the state of the indexed set using the specified writer to a binary stream.
             /// </summary>
             /// <param name="writer">The writer to save the state of the indexed set to.</param>
-            public void SaveForwardCompatible(BinaryWriter writer)
+            public void SaveForwardCompatible(IWriter writer)
             {
                 writer.Write(CustomSerializationVersion);
                 this.indexedEntitySet.SaveForwardCompatible(writer);

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/UserHyperparameters.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/UserHyperparameters.cs
@@ -71,7 +71,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// Saves the user-related hyper-parameters of the Matchbox recommender using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the user-related hyper-parameters to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(CustomSerializationVersion);
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/UserHyperparameters.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/UserHyperparameters.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the user-related hyper-parameters from.</param>
-        public UserHyperparameters(BinaryReader reader)
+        public UserHyperparameters(IReader reader)
         {
             if (reader == null)
             {

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/UserParameterDistribution.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/UserParameterDistribution.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// Saves the distribution over user parameters using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the distribution over user parameters to.</param>
-        public override void SaveForwardCompatible(BinaryWriter writer)
+        public override void SaveForwardCompatible(IWriter writer)
         {
             base.SaveForwardCompatible(writer);
 

--- a/src/Learners/Recommender/MatchboxRecommenderInternal/UserParameterDistribution.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderInternal/UserParameterDistribution.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the distribution over user parameters from.</param>
-        public UserParameterDistribution(BinaryReader reader) : base(reader)
+        public UserParameterDistribution(IReader reader) : base(reader)
         {
             Debug.Assert(reader != null, "The reader must not be null.");
 

--- a/src/Learners/Recommender/MatchboxRecommenderPredictionSettings.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderPredictionSettings.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// from a reader of a binary stream.
         /// </summary>
         /// <param name="reader">The binary reader to read the prediction settings from.</param>
-        public MatchboxRecommenderPredictionSettings(BinaryReader reader)
+        public MatchboxRecommenderPredictionSettings(IReader reader)
         {
             if (reader == null)
             {

--- a/src/Learners/Recommender/MatchboxRecommenderPredictionSettings.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderPredictionSettings.cs
@@ -132,7 +132,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// Saves the prediction settings of the Matchbox recommender using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the prediction settings to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);

--- a/src/Learners/Recommender/MatchboxRecommenderSettings.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderSettings.cs
@@ -68,7 +68,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// Saves the settings of the Matchbox recommender using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the settings to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);

--- a/src/Learners/Recommender/MatchboxRecommenderSettings.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderSettings.cs
@@ -41,7 +41,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// </summary>
         /// <param name="reader">The binary reader to read the settings of the Matchbox recommender from.</param>
         /// <param name="isTrained">Indicates whether the Matchbox recommender is trained.</param>
-        public MatchboxRecommenderSettings(BinaryReader reader, Func<bool> isTrained)
+        public MatchboxRecommenderSettings(IReader reader, Func<bool> isTrained)
         {
             reader.VerifySerializationGuid(
                 this.customSerializationGuid, "The binary stream does not contain the settings of an Infer.NET Matchbox recommender.");

--- a/src/Learners/Recommender/MatchboxRecommenderTrainingSettings.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderTrainingSettings.cs
@@ -271,7 +271,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// Saves the training settings of the Matchbox recommender using the specified writer to a binary stream.
         /// </summary>
         /// <param name="writer">The writer to save the training settings to.</param>
-        public void SaveForwardCompatible(BinaryWriter writer)
+        public void SaveForwardCompatible(IWriter writer)
         {
             writer.Write(this.customSerializationGuid);
             writer.Write(CustomSerializationVersion);

--- a/src/Learners/Recommender/MatchboxRecommenderTrainingSettings.cs
+++ b/src/Learners/Recommender/MatchboxRecommenderTrainingSettings.cs
@@ -125,7 +125,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// </summary>
         /// <param name="reader">The binary reader to read the training settings from.</param>
         /// <param name="isTrained">Indicates whether the Matchbox recommender is trained.</param>
-        internal MatchboxRecommenderTrainingSettings(BinaryReader reader, Func<bool> isTrained)
+        internal MatchboxRecommenderTrainingSettings(IReader reader, Func<bool> isTrained)
         {
             if (reader == null)
             {
@@ -296,7 +296,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// </summary>
         /// <param name="reader">The binary reader to read the training settings from.</param>
         /// <param name="isTrained">Indicates whether the Matchbox recommender is trained.</param>
-        private void ReadVersion1(BinaryReader reader, Func<bool> isTrained)
+        private void ReadVersion1(IReader reader, Func<bool> isTrained)
         {
             this.Advanced = new MatchboxRecommenderAdvancedTrainingSettings(reader, isTrained);
             this.useUserFeatures = reader.ReadBoolean();
@@ -311,7 +311,7 @@ namespace Microsoft.ML.Probabilistic.Learners
         /// </summary>
         /// <param name="reader">The binary reader to read the training settings from.</param>
         /// <param name="isTrained">Indicates whether the Matchbox recommender is trained.</param>
-        private void ReadVersion2(BinaryReader reader, Func<bool> isTrained)
+        private void ReadVersion2(IReader reader, Func<bool> isTrained)
         {
             this.ReadVersion1(reader, isTrained);
             this.useSharedUserThresholds = reader.ReadBoolean();

--- a/src/Runtime/Core/Serialization/BinaryReaderExtensions.cs
+++ b/src/Runtime/Core/Serialization/BinaryReaderExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
             {
                 if (exceptionMessage == null)
                 {
-                    exceptionMessage = $"The deserialized guid {deserializedGuid} is invalid. Custom binary serialization of this object expects the guid to be {expectedSerializationGuid}.";
+                    exceptionMessage = $"The deserialized guid {deserializedGuid} is invalid. Custom serialization of this object expects the guid to be {expectedSerializationGuid}.";
                 }
 
                 throw new SerializationException(exceptionMessage);

--- a/src/Runtime/Core/Serialization/BinaryReaderExtensions.cs
+++ b/src/Runtime/Core/Serialization/BinaryReaderExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
     using GaussianMatrix = Distributions.DistributionRefArray<Distributions.DistributionStructArray<Microsoft.ML.Probabilistic.Distributions.Gaussian, double>, double[]>;
 
     /// <summary>
-    /// Provides extension methods for <see cref="BinaryReader"/>.
+    /// Provides extension methods for <see cref="IReader"/>.
     /// </summary>
     public static class BinaryReaderExtensions
     {
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// <param name="exceptionMessage">An optional message for the <see cref="SerializationException"/>.</param>
         /// <exception cref="SerializationException">If the deserialized <see cref="Guid"/> is invalid.</exception>
         public static void VerifySerializationGuid(
-            this BinaryReader reader,
+            this IReader reader,
             Guid expectedSerializationGuid,
             string exceptionMessage = null)
         {
@@ -66,7 +66,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// <exception cref="SerializationException">
         /// If the deserialized version is less than 1 or greater than <paramref name="maxPermittedSerializationVersion"/>.
         /// </exception>
-        public static int ReadSerializationVersion(this BinaryReader reader, int maxPermittedSerializationVersion, string exceptionMessage = null)
+        public static int ReadSerializationVersion(this IReader reader, int maxPermittedSerializationVersion, string exceptionMessage = null)
         {
             if (reader == null)
             {
@@ -146,7 +146,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="reader">The reader of the binary stream.</param>
         /// <returns>The integer array constructed from the binary stream.</returns>
-        public static int[] ReadInt32Array(this BinaryReader reader)
+        public static int[] ReadInt32Array(this IReader reader)
         {
             if (reader == null)
             {
@@ -173,7 +173,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="reader">The reader of the binary stream.</param>
         /// <returns>The <see cref="Gaussian"/> distribution constructed from the binary stream.</returns>
-        public static Gaussian ReadGaussian(this BinaryReader reader)
+        public static Gaussian ReadGaussian(this IReader reader)
         {
             if (reader == null)
             {
@@ -188,7 +188,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="reader">The reader of the binary stream.</param>
         /// <returns>The array of <see cref="Gaussian"/> distributions constructed from the binary stream.</returns>
-        public static GaussianArray ReadGaussianArray(this BinaryReader reader)
+        public static GaussianArray ReadGaussianArray(this IReader reader)
         {
             if (reader == null)
             {
@@ -209,7 +209,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="reader">The reader of the binary stream.</param>
         /// <returns>The jagged array of <see cref="Gaussian"/> distributions constructed from the binary stream.</returns>
-        public static GaussianMatrix ReadGaussianMatrix(this BinaryReader reader)
+        public static GaussianMatrix ReadGaussianMatrix(this IReader reader)
         {
             if (reader == null)
             {
@@ -230,7 +230,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="reader">The reader of the binary stream.</param>
         /// <returns>The <see cref="Gamma"/> distribution constructed from the binary stream.</returns>
-        public static Gamma ReadGamma(this BinaryReader reader)
+        public static Gamma ReadGamma(this IReader reader)
         {
             if (reader == null)
             {
@@ -245,7 +245,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="reader">The reader of the binary stream.</param>
         /// <returns>The array of <see cref="Gamma"/> distributions constructed from the binary stream.</returns>
-        public static GammaArray ReadGammaArray(this BinaryReader reader)
+        public static GammaArray ReadGammaArray(this IReader reader)
         {
             if (reader == null)
             {

--- a/src/Runtime/Core/Serialization/BinaryWriterExtensions.cs
+++ b/src/Runtime/Core/Serialization/BinaryWriterExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
     using GaussianMatrix = Distributions.DistributionRefArray<Distributions.DistributionStructArray<Microsoft.ML.Probabilistic.Distributions.Gaussian, double>, double[]>;
 
     /// <summary>
-    /// Provides extension methods for <see cref="BinaryWriter"/>.
+    /// Provides extension methods for <see cref="IWriter"/>.
     /// </summary>
     public static class BinaryWriterExtensions
     {
@@ -66,7 +66,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="writer">The binary writer.</param>
         /// <param name="array">The array of integers to write to the stream.</param>
-        public static void Write(this BinaryWriter writer, IList<int> array)
+        public static void Write(this IWriter writer, IList<int> array)
         {
             if (writer == null)
             {
@@ -90,7 +90,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="writer">The binary writer.</param>
         /// <param name="distribution">The <see cref="Gaussian"/> distribution to write to the stream.</param>
-        public static void Write(this BinaryWriter writer, Gaussian distribution)
+        public static void Write(this IWriter writer, Gaussian distribution)
         {
             if (writer == null)
             {
@@ -111,7 +111,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="writer">The binary writer.</param>
         /// <param name="array">The array of <see cref="Gaussian"/> distributions to write to the stream.</param>
-        public static void Write(this BinaryWriter writer, IList<Gaussian> array)
+        public static void Write(this IWriter writer, IList<Gaussian> array)
         {
             if (writer == null)
             {
@@ -135,7 +135,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="writer">The binary writer.</param>
         /// <param name="gaussians">The jagged array of <see cref="Gaussian"/> distributions to write to the stream.</param>
-        public static void Write(this BinaryWriter writer, GaussianMatrix gaussians)
+        public static void Write(this IWriter writer, GaussianMatrix gaussians)
         {
             if (writer == null)
             {
@@ -159,7 +159,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="writer">The binary writer.</param>
         /// <param name="distribution">The <see cref="Gamma"/> distribution to write to the stream.</param>
-        public static void Write(this BinaryWriter writer, Gamma distribution)
+        public static void Write(this IWriter writer, Gamma distribution)
         {
             if (writer == null)
             {
@@ -180,7 +180,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="writer">The binary writer.</param>
         /// <param name="array">The array of <see cref="Gamma"/> distributions to write to the stream.</param>
-        public static void Write(this BinaryWriter writer, IList<Gamma> array)
+        public static void Write(this IWriter writer, IList<Gamma> array)
         {
             if (writer == null)
             {

--- a/src/Runtime/Core/Serialization/IReader.cs
+++ b/src/Runtime/Core/Serialization/IReader.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    public interface IReader
+    {
+        bool ReadBoolean();
+        int ReadInt32();
+        double ReadDouble();
+        string ReadString();
+        Guid ReadGuid();
+        object ReadObject();
+    }
+}

--- a/src/Runtime/Core/Serialization/IWriter.cs
+++ b/src/Runtime/Core/Serialization/IWriter.cs
@@ -6,13 +6,13 @@ namespace Microsoft.ML.Probabilistic.Serialization
 {
     using System;
 
-    public interface IReader
+    public interface IWriter
     {
-        bool ReadBoolean();
-        int ReadInt32();
-        double ReadDouble();
-        string ReadString();
-        Guid ReadGuid();
-        object ReadObject();
+        void Write(bool value);
+        void Write(int value);
+        void Write(string value);
+        void Write(double value);
+        void Write(Guid value);
+        void WriteObject(object value);
     }
 }

--- a/src/Runtime/Core/Serialization/WrappedBinaryReader.cs
+++ b/src/Runtime/Core/Serialization/WrappedBinaryReader.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.ML.Probabilistic.Serialization
+{
+    public class WrappedBinaryReader : IReader, IDisposable
+    {
+        BinaryReader binaryReader;
+
+        public WrappedBinaryReader(BinaryReader binaryReader)
+        {
+            this.binaryReader = binaryReader;
+        }
+
+        public void Dispose()
+        {
+            binaryReader.Dispose();
+        }
+
+        public bool ReadBoolean()
+        {
+            return binaryReader.ReadBoolean();
+        }
+
+        public double ReadDouble()
+        {
+            return binaryReader.ReadDouble();
+        }
+
+        public Guid ReadGuid()
+        {
+            return binaryReader.ReadGuid();
+        }
+
+        public int ReadInt32()
+        {
+            return binaryReader.ReadInt32();
+        }
+
+        public object ReadObject()
+        {
+            return binaryReader.ReadObject();
+        }
+
+        public string ReadString()
+        {
+            return binaryReader.ReadString();
+        }
+    }
+}

--- a/src/Runtime/Core/Serialization/WrappedBinaryWriter.cs
+++ b/src/Runtime/Core/Serialization/WrappedBinaryWriter.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.ML.Probabilistic.Serialization
+{
+    using System;
+    using System.IO;
+
+    public class WrappedBinaryWriter : IWriter, IDisposable
+    {
+        BinaryWriter binaryWriter;
+
+        public WrappedBinaryWriter(BinaryWriter binaryWriter)
+        {
+            this.binaryWriter = binaryWriter;
+        }
+
+        public void Dispose()
+        {
+            binaryWriter.Dispose();
+        }
+
+        public void Write(bool value)
+        {
+            binaryWriter.Write(value);
+        }
+
+        public void Write(int value)
+        {
+            binaryWriter.Write(value);
+        }
+
+        public void Write(string value)
+        {
+            binaryWriter.Write(value);
+        }
+
+        public void Write(double value)
+        {
+            binaryWriter.Write(value);
+        }
+
+        public void Write(Guid value)
+        {
+            binaryWriter.Write(value);
+        }
+
+        public void WriteObject(object value)
+        {
+            binaryWriter.WriteObject(value);
+        }
+    }
+}

--- a/src/Runtime/Core/Serialization/WrappedTextReader.cs
+++ b/src/Runtime/Core/Serialization/WrappedTextReader.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.ML.Probabilistic.Serialization
+{
+    public class WrappedTextReader : IReader, IDisposable
+    {
+        StreamReader reader;
+
+        public WrappedTextReader(StreamReader streamReader)
+        {
+            this.reader = streamReader;
+        }
+
+        public void Dispose()
+        {
+            reader.Dispose();
+        }
+
+        public bool ReadBoolean()
+        {
+            string line = reader.ReadLine();
+            return bool.Parse(line);
+        }
+
+        public double ReadDouble()
+        {
+            string line = reader.ReadLine();
+            return double.Parse(line);
+        }
+
+        public Guid ReadGuid()
+        {
+            string line = reader.ReadLine();
+            return Guid.Parse(line);
+        }
+
+        public int ReadInt32()
+        {
+            string line = reader.ReadLine();
+            return int.Parse(line);
+        }
+
+        public object ReadObject()
+        {
+            string line = reader.ReadLine();
+            return line;
+        }
+
+        public string ReadString()
+        {
+            return reader.ReadLine();
+        }
+    }
+}

--- a/src/Runtime/Core/Serialization/WrappedTextWriter.cs
+++ b/src/Runtime/Core/Serialization/WrappedTextWriter.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.ML.Probabilistic.Serialization
+{
+    public class WrappedTextWriter : IWriter, IDisposable
+    {
+        StreamWriter writer;
+
+        public WrappedTextWriter(StreamWriter writer)
+        {
+            this.writer = writer;
+        }
+
+        public void Dispose()
+        {
+            writer.Dispose();
+        }
+
+        public void Write(bool value)
+        {
+            writer.WriteLine(value);
+        }
+
+        public void Write(int value)
+        {
+            writer.WriteLine(value);
+        }
+
+        public void Write(string value)
+        {
+            writer.WriteLine(value);
+        }
+
+        public void Write(double value)
+        {
+            writer.WriteLine(value);
+        }
+
+        public void Write(Guid value)
+        {
+            writer.WriteLine(value);
+        }
+
+        public void WriteObject(object value)
+        {
+            if (value is string s)
+            {
+                writer.WriteLine(s);
+            }
+            else
+            {
+                throw new ArgumentException("value is not a string", nameof(value));
+            }
+        }
+    }
+}

--- a/test/Learners/LearnersTests/BayesPointMachineClassifierTests.cs
+++ b/test/Learners/LearnersTests/BayesPointMachineClassifierTests.cs
@@ -4888,8 +4888,8 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var mapping = new BinaryNativeBayesPointMachineClassifierTestMapping();
             var classifier = BayesPointMachineClassifier.CreateBinaryClassifier(mapping);
 
-            const string TrainedFileName = "trainedBinaryNativeClassifier.bin";
-            const string UntrainedFileName = "untrainedBinaryNativeClassifier.bin";
+            const string TrainedFileName = "trainedBinaryNativeClassifier" + extension;
+            const string UntrainedFileName = "untrainedBinaryNativeClassifier" + extension;
 
             // Train and serialize
             classifier.Settings.Training.IterationCount = IterationCount;
@@ -4910,16 +4910,12 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var trainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleBinaryClassifier(TrainedFileName, mapping);
 
             // Deserialize both classifier and mapping
-            BinaryNativeBayesPointMachineClassifierTestMapping deserializedMapping;
-            IBayesPointMachineClassifier<NativeDataset, int, NativeDataset, bool, Bernoulli, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<bool>> untrainedClassifier;
-            using (var stream = File.Open(UntrainedFileName, FileMode.Open))
+            var (untrainedClassifier, deserializedMapping) = BayesPointMachineClassifier.WithReader(UntrainedFileName, reader =>
             {
-                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
-                {
-                    deserializedMapping = new BinaryNativeBayesPointMachineClassifierTestMapping(reader);
-                    untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleBinaryClassifier(reader, deserializedMapping);
-                }
-            }
+                var deserializedMapping1 = new BinaryNativeBayesPointMachineClassifierTestMapping(reader);
+                var untrainedClassifier1 = BayesPointMachineClassifier.LoadBackwardCompatibleBinaryClassifier(reader, deserializedMapping1);
+                return (untrainedClassifier1, deserializedMapping1);
+            });
 
             // Check predictions of deserialized classifiers
             CheckDeserializedNativePrediction(trainedClassifier, untrainedClassifier, deserializedMapping, trainingData, testData, expectedLabelDistributions, expectedIncrementalLabelDistributions, checkPrediction);
@@ -4952,6 +4948,8 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             }
         }
 
+        const string extension = ".txt";
+
         /// <summary>
         /// Tests custom binary serialization and deserialization of the multi-class Bayes point machine classifier and data in native format.
         /// </summary>
@@ -4970,8 +4968,8 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var mapping = new MulticlassNativeBayesPointMachineClassifierTestMapping();
             var classifier = BayesPointMachineClassifier.CreateMulticlassClassifier(mapping);
 
-            const string TrainedFileName = "trainedMulticlassNativeClassifier.bin";
-            const string UntrainedFileName = "untrainedMulticlassNativeClassifier.bin";
+            const string TrainedFileName = "trainedMulticlassNativeClassifier" + extension;
+            const string UntrainedFileName = "untrainedMulticlassNativeClassifier" + extension;
 
             // Train and serialize
             classifier.Settings.Training.IterationCount = IterationCount;
@@ -4992,16 +4990,12 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var trainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleMulticlassClassifier(TrainedFileName, mapping);
 
             // Deserialize both classifier and mapping
-            MulticlassNativeBayesPointMachineClassifierTestMapping deserializedMapping;
-            IBayesPointMachineClassifier<NativeDataset, int, NativeDataset, int, Discrete, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<int>> untrainedClassifier;
-            using (var stream = File.Open(UntrainedFileName, FileMode.Open))
+            var (untrainedClassifier, deserializedMapping) = BayesPointMachineClassifier.WithReader(UntrainedFileName, reader =>
             {
-                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
-                {
-                    deserializedMapping = new MulticlassNativeBayesPointMachineClassifierTestMapping(reader);
-                    untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleMulticlassClassifier(reader, deserializedMapping);
-                }
-            }
+                var deserializedMapping1 = new MulticlassNativeBayesPointMachineClassifierTestMapping(reader);
+                var untrainedClassifier1 = BayesPointMachineClassifier.LoadBackwardCompatibleMulticlassClassifier(reader, deserializedMapping1);
+                return (untrainedClassifier1, deserializedMapping1);
+            });
 
             // Check predictions of deserialized classifiers
             CheckDeserializedNativePrediction(trainedClassifier, untrainedClassifier, deserializedMapping, trainingData, testData, expectedLabelDistributions, expectedIncrementalLabelDistributions, checkPrediction);
@@ -5052,8 +5046,8 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var mapping = new BinaryStandardBayesPointMachineClassifierTestMapping();
             var classifier = BayesPointMachineClassifier.CreateBinaryClassifier(mapping);
 
-            const string TrainedFileName = "trainedBinaryStandardClassifier.bin";
-            const string UntrainedFileName = "untrainedBinaryStandardClassifier.bin";
+            const string TrainedFileName = "trainedBinaryStandardClassifier" + extension;
+            const string UntrainedFileName = "untrainedBinaryStandardClassifier" + extension;
 
             // Train and serialize
             classifier.Settings.Training.IterationCount = IterationCount;
@@ -5074,15 +5068,11 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var trainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleBinaryClassifier(TrainedFileName, mapping);
 
             // Deserialize both classifier and mapping
-            IBayesPointMachineClassifier<StandardDataset, string, StandardDataset, string, IDictionary<string, double>, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<string>> untrainedClassifier;
-            using (var stream = File.Open(UntrainedFileName, FileMode.Open))
+            var untrainedClassifier = BayesPointMachineClassifier.WithReader(UntrainedFileName, reader =>
             {
-                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
-                {
-                    var deserializedMapping = new BinaryStandardBayesPointMachineClassifierTestMapping(reader);
-                    untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleBinaryClassifier(reader, deserializedMapping);
-                }
-            }
+                var deserializedMapping = new BinaryStandardBayesPointMachineClassifierTestMapping(reader);
+                return BayesPointMachineClassifier.LoadBackwardCompatibleBinaryClassifier(reader, deserializedMapping);
+            });
             
             // Check predictions of deserialized classifiers
             CheckDeserializedStandardPrediction(trainedClassifier, untrainedClassifier, trainingData, testData, expectedLabelDistributions, expectedIncrementalLabelDistributions, checkPrediction);
@@ -5133,8 +5123,8 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var mapping = new MulticlassStandardBayesPointMachineClassifierTestMapping();
             var classifier = BayesPointMachineClassifier.CreateMulticlassClassifier(mapping);
 
-            const string TrainedFileName = "trainedMulticlassStandardClassifier.bin";
-            const string UntrainedFileName = "untrainedMulticlassStandardClassifier.bin";
+            const string TrainedFileName = "trainedMulticlassStandardClassifier" + extension;
+            const string UntrainedFileName = "untrainedMulticlassStandardClassifier" + extension;
 
             // Train and serialize
             classifier.Settings.Training.IterationCount = IterationCount;
@@ -5155,15 +5145,11 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var trainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleMulticlassClassifier(TrainedFileName, mapping);
 
             // Deserialize both classifier and mapping
-            IBayesPointMachineClassifier<StandardDataset, string, StandardDataset, string, IDictionary<string, double>, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<string>> untrainedClassifier;
-            using (var stream = File.Open(UntrainedFileName, FileMode.Open))
+            var untrainedClassifier = BayesPointMachineClassifier.WithReader(UntrainedFileName, reader =>
             {
-                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
-                {
-                    var deserializedMapping = new MulticlassStandardBayesPointMachineClassifierTestMapping(reader);
-                    untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleMulticlassClassifier(reader, deserializedMapping);
-                }
-            }
+                var deserializedMapping = new MulticlassStandardBayesPointMachineClassifierTestMapping(reader);
+                return BayesPointMachineClassifier.LoadBackwardCompatibleMulticlassClassifier(reader, deserializedMapping);
+            });
 
             // Check predictions of deserialized classifiers
             CheckDeserializedStandardPrediction(trainedClassifier, untrainedClassifier, trainingData, testData, expectedLabelDistributions, expectedIncrementalLabelDistributions, checkPrediction);
@@ -5215,8 +5201,8 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var mapping = new BinaryNativeBayesPointMachineClassifierTestMapping();
             var classifier = BayesPointMachineClassifier.CreateGaussianPriorBinaryClassifier(mapping);
 
-            const string TrainedFileName = "trainedGaussianPriorBinaryNativeClassifier.bin";
-            const string UntrainedFileName = "untrainedGaussianPriorBinaryNativeClassifier.bin";
+            const string TrainedFileName = "trainedGaussianPriorBinaryNativeClassifier" + extension;
+            const string UntrainedFileName = "untrainedGaussianPriorBinaryNativeClassifier" + extension;
 
             // Train and serialize
             classifier.Settings.Training.IterationCount = IterationCount;
@@ -5237,16 +5223,12 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var trainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorBinaryClassifier(TrainedFileName, mapping);
 
             // Deserialize both classifier and mapping
-            BinaryNativeBayesPointMachineClassifierTestMapping deserializedMapping;
-            IBayesPointMachineClassifier<NativeDataset, int, NativeDataset, bool, Bernoulli, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<bool>> untrainedClassifier;
-            using (var stream = File.Open(UntrainedFileName, FileMode.Open))
+            var (untrainedClassifier, deserializedMapping) = BayesPointMachineClassifier.WithReader(UntrainedFileName, reader =>
             {
-                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
-                {
-                    deserializedMapping = new BinaryNativeBayesPointMachineClassifierTestMapping(reader);
-                    untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorBinaryClassifier(reader, deserializedMapping);
-                }
-            }
+                var deserializedMapping1 = new BinaryNativeBayesPointMachineClassifierTestMapping(reader);
+                var untrainedClassifier1 = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorBinaryClassifier(reader, deserializedMapping1);
+                return (untrainedClassifier1, deserializedMapping1);
+            });
 
             // Check predictions of deserialized classifiers
             CheckDeserializedNativePrediction(trainedClassifier, untrainedClassifier, deserializedMapping, trainingData, testData, expectedLabelDistributions, expectedIncrementalLabelDistributions, checkPrediction);
@@ -5298,8 +5280,8 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var mapping = new MulticlassNativeBayesPointMachineClassifierTestMapping();
             var classifier = BayesPointMachineClassifier.CreateGaussianPriorMulticlassClassifier(mapping);
 
-            const string TrainedFileName = "trainedGaussianPriorMulticlassNativeClassifier.bin";
-            const string UntrainedFileName = "untrainedGaussianPriorMulticlassNativeClassifier.bin";
+            const string TrainedFileName = "trainedGaussianPriorMulticlassNativeClassifier" + extension;
+            const string UntrainedFileName = "untrainedGaussianPriorMulticlassNativeClassifier" + extension;
 
             // Train and serialize
             classifier.Settings.Training.IterationCount = IterationCount;
@@ -5320,16 +5302,12 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var trainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorMulticlassClassifier(TrainedFileName, mapping);
 
             // Deserialize both classifier and mapping
-            MulticlassNativeBayesPointMachineClassifierTestMapping deserializedMapping;
-            IBayesPointMachineClassifier<NativeDataset, int, NativeDataset, int, Discrete, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<int>> untrainedClassifier;
-            using (var stream = File.Open(UntrainedFileName, FileMode.Open))
+            var (untrainedClassifier, deserializedMapping) = BayesPointMachineClassifier.WithReader(UntrainedFileName, reader =>
             {
-                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
-                {
-                    deserializedMapping = new MulticlassNativeBayesPointMachineClassifierTestMapping(reader);
-                    untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorMulticlassClassifier(reader, deserializedMapping);
-                }
-            }
+                var deserializedMapping1 = new MulticlassNativeBayesPointMachineClassifierTestMapping(reader);
+                var untrainedClassifier1 = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorMulticlassClassifier(reader, deserializedMapping1);
+                return (untrainedClassifier1, deserializedMapping1);
+            });
 
             // Check predictions of deserialized classifiers
             CheckDeserializedNativePrediction(trainedClassifier, untrainedClassifier, deserializedMapping, trainingData, testData, expectedLabelDistributions, expectedIncrementalLabelDistributions, checkPrediction);
@@ -5381,8 +5359,8 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var mapping = new BinaryStandardBayesPointMachineClassifierTestMapping();
             var classifier = BayesPointMachineClassifier.CreateGaussianPriorBinaryClassifier(mapping);
 
-            const string TrainedFileName = "trainedGaussianPriorBinaryStandardClassifier.bin";
-            const string UntrainedFileName = "untrainedGaussianPriorBinaryStandardClassifier.bin";
+            const string TrainedFileName = "trainedGaussianPriorBinaryStandardClassifier" + extension;
+            const string UntrainedFileName = "untrainedGaussianPriorBinaryStandardClassifier" + extension;
 
             // Train and serialize
             classifier.Settings.Training.IterationCount = IterationCount;
@@ -5403,15 +5381,11 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var trainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorBinaryClassifier(TrainedFileName, mapping);
 
             // Deserialize both classifier and mapping
-            IBayesPointMachineClassifier<StandardDataset, string, StandardDataset, string, IDictionary<string, double>, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<string>> untrainedClassifier;
-            using (var stream = File.Open(UntrainedFileName, FileMode.Open))
+            var untrainedClassifier = BayesPointMachineClassifier.WithReader(UntrainedFileName, reader =>
             {
-                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
-                {
-                    var deserializedMapping = new BinaryStandardBayesPointMachineClassifierTestMapping(reader);
-                    untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorBinaryClassifier(reader, deserializedMapping);
-                }
-            }
+                var deserializedMapping = new BinaryStandardBayesPointMachineClassifierTestMapping(reader);
+                return BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorBinaryClassifier(reader, deserializedMapping);
+            });
 
             // Check predictions of deserialized classifiers
             CheckDeserializedStandardPrediction(trainedClassifier, untrainedClassifier, trainingData, testData, expectedLabelDistributions, expectedIncrementalLabelDistributions, checkPrediction);
@@ -5463,8 +5437,8 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var mapping = new MulticlassStandardBayesPointMachineClassifierTestMapping();
             var classifier = BayesPointMachineClassifier.CreateGaussianPriorMulticlassClassifier(mapping);
 
-            const string TrainedFileName = "trainedGaussianPriorMulticlassStandardClassifier.bin";
-            const string UntrainedFileName = "untrainedGaussianPriorMulticlassStandardClassifier.bin";
+            const string TrainedFileName = "trainedGaussianPriorMulticlassStandardClassifier" + extension;
+            const string UntrainedFileName = "untrainedGaussianPriorMulticlassStandardClassifier" + extension;
 
             // Train and serialize
             classifier.Settings.Training.IterationCount = IterationCount;
@@ -5485,15 +5459,11 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var trainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorMulticlassClassifier(TrainedFileName, mapping);
 
             // Deserialize both classifier and mapping
-            IBayesPointMachineClassifier<StandardDataset, string, StandardDataset, string, IDictionary<string, double>, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<string>> untrainedClassifier;
-            using (var stream = File.Open(UntrainedFileName, FileMode.Open))
+            var untrainedClassifier = BayesPointMachineClassifier.WithReader(UntrainedFileName, reader =>
             {
-                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
-                {
-                    var deserializedMapping = new MulticlassStandardBayesPointMachineClassifierTestMapping(reader);
-                    untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorMulticlassClassifier(reader, deserializedMapping);
-                }
-            }
+                var deserializedMapping = new MulticlassStandardBayesPointMachineClassifierTestMapping(reader);
+                return BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorMulticlassClassifier(reader, deserializedMapping);
+            });
 
             // Check predictions of deserialized classifiers
             CheckDeserializedStandardPrediction(trainedClassifier, untrainedClassifier, trainingData, testData, expectedLabelDistributions, expectedIncrementalLabelDistributions, checkPrediction);

--- a/test/Learners/LearnersTests/BayesPointMachineClassifierTests.cs
+++ b/test/Learners/LearnersTests/BayesPointMachineClassifierTests.cs
@@ -5705,7 +5705,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
         {
             using (var stream = new MemoryStream())
             {
-                var writer = new BinaryWriter(stream);
+                var writer = new WrappedBinaryWriter(new BinaryWriter(stream));
                 writer.Write(new Guid("57CB3182-7C83-49F3-B56D-C3C7661439F5")); // Invalid serialization guid
                 
                 stream.Seek(0, SeekOrigin.Begin);
@@ -9586,7 +9586,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// Saves the state of the native data mapping using a writer to a binary stream.
             /// </summary>
             /// <param name="writer">The writer to save the state of the native data mapping to.</param>
-            public void SaveForwardCompatible(BinaryWriter writer)
+            public void SaveForwardCompatible(IWriter writer)
             {
                 writer.Write(this.BatchCount);
             }
@@ -9759,7 +9759,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// Saves the state of the standard data mapping using a writer to a binary stream.
             /// </summary>
             /// <param name="writer">The writer to save the state of the standard data mapping to.</param>
-            public void SaveForwardCompatible(BinaryWriter writer)
+            public void SaveForwardCompatible(IWriter writer)
             {
                 // Nothing to serialize.
             }

--- a/test/Learners/LearnersTests/BayesPointMachineClassifierTests.cs
+++ b/test/Learners/LearnersTests/BayesPointMachineClassifierTests.cs
@@ -4914,7 +4914,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             IBayesPointMachineClassifier<NativeDataset, int, NativeDataset, bool, Bernoulli, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<bool>> untrainedClassifier;
             using (var stream = File.Open(UntrainedFileName, FileMode.Open))
             {
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     deserializedMapping = new BinaryNativeBayesPointMachineClassifierTestMapping(reader);
                     untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleBinaryClassifier(reader, deserializedMapping);
@@ -4996,7 +4996,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             IBayesPointMachineClassifier<NativeDataset, int, NativeDataset, int, Discrete, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<int>> untrainedClassifier;
             using (var stream = File.Open(UntrainedFileName, FileMode.Open))
             {
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     deserializedMapping = new MulticlassNativeBayesPointMachineClassifierTestMapping(reader);
                     untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleMulticlassClassifier(reader, deserializedMapping);
@@ -5077,7 +5077,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             IBayesPointMachineClassifier<StandardDataset, string, StandardDataset, string, IDictionary<string, double>, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<string>> untrainedClassifier;
             using (var stream = File.Open(UntrainedFileName, FileMode.Open))
             {
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     var deserializedMapping = new BinaryStandardBayesPointMachineClassifierTestMapping(reader);
                     untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleBinaryClassifier(reader, deserializedMapping);
@@ -5158,7 +5158,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             IBayesPointMachineClassifier<StandardDataset, string, StandardDataset, string, IDictionary<string, double>, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<string>> untrainedClassifier;
             using (var stream = File.Open(UntrainedFileName, FileMode.Open))
             {
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     var deserializedMapping = new MulticlassStandardBayesPointMachineClassifierTestMapping(reader);
                     untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleMulticlassClassifier(reader, deserializedMapping);
@@ -5241,7 +5241,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             IBayesPointMachineClassifier<NativeDataset, int, NativeDataset, bool, Bernoulli, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<bool>> untrainedClassifier;
             using (var stream = File.Open(UntrainedFileName, FileMode.Open))
             {
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     deserializedMapping = new BinaryNativeBayesPointMachineClassifierTestMapping(reader);
                     untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorBinaryClassifier(reader, deserializedMapping);
@@ -5324,7 +5324,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             IBayesPointMachineClassifier<NativeDataset, int, NativeDataset, int, Discrete, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<int>> untrainedClassifier;
             using (var stream = File.Open(UntrainedFileName, FileMode.Open))
             {
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     deserializedMapping = new MulticlassNativeBayesPointMachineClassifierTestMapping(reader);
                     untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorMulticlassClassifier(reader, deserializedMapping);
@@ -5406,7 +5406,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             IBayesPointMachineClassifier<StandardDataset, string, StandardDataset, string, IDictionary<string, double>, BayesPointMachineClassifierTrainingSettings, BinaryBayesPointMachineClassifierPredictionSettings<string>> untrainedClassifier;
             using (var stream = File.Open(UntrainedFileName, FileMode.Open))
             {
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     var deserializedMapping = new BinaryStandardBayesPointMachineClassifierTestMapping(reader);
                     untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorBinaryClassifier(reader, deserializedMapping);
@@ -5488,7 +5488,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             IBayesPointMachineClassifier<StandardDataset, string, StandardDataset, string, IDictionary<string, double>, BayesPointMachineClassifierTrainingSettings, MulticlassBayesPointMachineClassifierPredictionSettings<string>> untrainedClassifier;
             using (var stream = File.Open(UntrainedFileName, FileMode.Open))
             {
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     var deserializedMapping = new MulticlassStandardBayesPointMachineClassifierTestMapping(reader);
                     untrainedClassifier = BayesPointMachineClassifier.LoadBackwardCompatibleGaussianPriorMulticlassClassifier(reader, deserializedMapping);
@@ -5701,7 +5701,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
         /// Checks that the specified deserialization action throws a serialization exception for invalid versions.
         /// </summary>
         /// <param name="deserialize">The action which deserializes from a binary reader.</param>
-        private static void CheckCustomSerializationVersionException(Action<BinaryReader> deserialize)
+        private static void CheckCustomSerializationVersionException(Action<IReader> deserialize)
         {
             using (var stream = new MemoryStream())
             {
@@ -5709,8 +5709,8 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
                 writer.Write(new Guid("57CB3182-7C83-49F3-B56D-C3C7661439F5")); // Invalid serialization guid
                 
                 stream.Seek(0, SeekOrigin.Begin);
-                
-                using (var reader = new BinaryReader(stream))
+
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     Assert.Throws<SerializationException>(() => deserialize(reader));
                 }
@@ -9476,7 +9476,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// Initializes a new instance of the <see cref="NativeBayesPointMachineClassifierTestMapping{TLabel}"/> class.
             /// </summary>
             /// <param name="reader">The reader to load the mapping from.</param>
-            protected NativeBayesPointMachineClassifierTestMapping(BinaryReader reader)
+            protected NativeBayesPointMachineClassifierTestMapping(IReader reader)
             {
                 this.BatchCount = reader.ReadInt32();
             }
@@ -9611,7 +9611,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// Initializes a new instance of the <see cref="BinaryNativeBayesPointMachineClassifierTestMapping"/> class.
             /// </summary>
             /// <param name="reader">The reader to load the mapping from.</param>
-            public BinaryNativeBayesPointMachineClassifierTestMapping(BinaryReader reader) : base(reader)
+            public BinaryNativeBayesPointMachineClassifierTestMapping(IReader reader) : base(reader)
             {
             }
 
@@ -9647,7 +9647,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// Initializes a new instance of the <see cref="MulticlassNativeBayesPointMachineClassifierTestMapping"/> class.
             /// </summary>
             /// <param name="reader">The reader to load the mapping from.</param>
-            public MulticlassNativeBayesPointMachineClassifierTestMapping(BinaryReader reader) : base(reader)
+            public MulticlassNativeBayesPointMachineClassifierTestMapping(IReader reader) : base(reader)
             {
             }
 
@@ -9683,7 +9683,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// Initializes a new instance of the <see cref="StandardBayesPointMachineClassifierTestMapping"/> class.
             /// </summary>
             /// <param name="reader">The reader to load the mapping from.</param>
-            protected StandardBayesPointMachineClassifierTestMapping(BinaryReader reader)
+            protected StandardBayesPointMachineClassifierTestMapping(IReader reader)
             {
             }
 
@@ -9783,7 +9783,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// Initializes a new instance of the <see cref="BinaryStandardBayesPointMachineClassifierTestMapping"/> class.
             /// </summary>
             /// <param name="reader">The reader to load the mapping from.</param>
-            public BinaryStandardBayesPointMachineClassifierTestMapping(BinaryReader reader) : base(reader)
+            public BinaryStandardBayesPointMachineClassifierTestMapping(IReader reader) : base(reader)
             {
             }
 
@@ -9846,7 +9846,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// Initializes a new instance of the <see cref="MulticlassStandardBayesPointMachineClassifierTestMapping"/> class.
             /// </summary>
             /// <param name="reader">The reader to load the mapping from.</param>
-            public MulticlassStandardBayesPointMachineClassifierTestMapping(BinaryReader reader) : base(reader)
+            public MulticlassStandardBayesPointMachineClassifierTestMapping(IReader reader) : base(reader)
             {
             }
 

--- a/test/Learners/LearnersTests/LearnersTests.csproj
+++ b/test/Learners/LearnersTests/LearnersTests.csproj
@@ -39,7 +39,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-	  <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
 	  <PackageReference Include="xunit" Version="2.4.1" />
 	  <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
 		  <PrivateAssets>all</PrivateAssets>
@@ -63,7 +62,6 @@
     <ProjectReference Include="..\..\..\src\Learners\Recommender\Recommender.csproj" />
     <ProjectReference Include="..\..\..\src\Learners\Runners\CommandLine\CommandLine.csproj" />
     <ProjectReference Include="..\..\..\src\Learners\Runners\Common\Common.csproj" />
-    <ProjectReference Include="..\..\Tests\Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="CustomSerializedLearners\2015-03-20\SparseBinaryNativeClassifier-2015-03-20.bin">

--- a/test/Learners/LearnersTests/LearnersTests.csproj
+++ b/test/Learners/LearnersTests/LearnersTests.csproj
@@ -63,6 +63,7 @@
     <ProjectReference Include="..\..\..\src\Learners\Recommender\Recommender.csproj" />
     <ProjectReference Include="..\..\..\src\Learners\Runners\CommandLine\CommandLine.csproj" />
     <ProjectReference Include="..\..\..\src\Learners\Runners\Common\Common.csproj" />
+    <ProjectReference Include="..\..\Tests\Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="CustomSerializedLearners\2015-03-20\SparseBinaryNativeClassifier-2015-03-20.bin">

--- a/test/Learners/LearnersTests/LearnersTests.csproj
+++ b/test/Learners/LearnersTests/LearnersTests.csproj
@@ -38,9 +38,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+	  <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+	  <PackageReference Include="xunit" Version="2.4.1" />
+	  <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+	  <PackageReference Include="xunit.analyzers" Version="0.10.0" />
+	  <PackageReference Include="xunit.assert" Version="2.4.1" />
+	  <PackageReference Include="xunit.core" Version="2.4.1" />
+	  <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+	  <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+	  <PackageReference Include="xunit.runner.console" Version="2.4.1" />
+	  <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -114,6 +126,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Data\W5ANormalized.csv.gz">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="sequential.xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/test/Learners/LearnersTests/MatchboxRecommenderTests.cs
+++ b/test/Learners/LearnersTests/MatchboxRecommenderTests.cs
@@ -1151,7 +1151,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
         {
             using (var stream = new MemoryStream())
             {
-                var writer = new BinaryWriter(stream);
+                var writer = new WrappedBinaryWriter(new BinaryWriter(stream));
                 writer.Write(new Guid("2317C228-3BB2-423C-B299-33A64A1BC1F3")); // Invalid serialization version
 
                 stream.Seek(0, SeekOrigin.Begin);
@@ -1770,7 +1770,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// Saves the state of the native data mapping using a writer to a binary stream.
             /// </summary>
             /// <param name="writer">The writer to save the state of the native data mapping to.</param>
-            public void SaveForwardCompatible(BinaryWriter writer)
+            public void SaveForwardCompatible(IWriter writer)
             {
                 // Nothing to serialize
             }
@@ -1887,7 +1887,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// Saves the state of the standard data mapping using a writer to a binary stream.
             /// </summary>
             /// <param name="writer">The writer to save the state of the standard data mapping to.</param>
-            public void SaveForwardCompatible(BinaryWriter writer)
+            public void SaveForwardCompatible(IWriter writer)
             {
                 writer.Write(3); // Fake serialization version
             }

--- a/test/Learners/LearnersTests/MatchboxRecommenderTests.cs
+++ b/test/Learners/LearnersTests/MatchboxRecommenderTests.cs
@@ -741,7 +741,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
                 IMatchboxRecommender<NativeDataset, int, int, Discrete, NativeDataset> notTrainedRecommender;
                 using (var stream = File.Open(NotTrainedFileName, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(stream))
+                    using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                     {
                         var deserializedMapping = new NativeRecommenderTestMapping(reader);
                         notTrainedRecommender = MatchboxRecommender.LoadBackwardCompatible(reader, deserializedMapping);
@@ -791,7 +791,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
         /// Tests binary custom serialization/deserialization of the recommender operating on the standard data format.
         /// </summary>
         [Fact]
-        [Trait("Category", "OpenBug")]
+        [Trait("Category", "OpenBug")] // Fails with SerializationException : Unable to find assembly 'Infer.Learners.Tests'
         public void StandardDataFormatCustomSerializationTest()
         {
             const int BatchCount = 2;
@@ -826,7 +826,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
                 IMatchboxRecommender<StandardDataset, User, Item, RatingDistribution, FeatureProvider> notTrainedRecommender;
                 using (var stream = File.Open(NotTrainedFileName, FileMode.Open))
                 {
-                    using (var reader = new BinaryReader(stream))
+                    using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                     {
                         var deserializedMapping = new StandardRecommenderTestMapping(reader);
                         notTrainedRecommender = MatchboxRecommender.LoadBackwardCompatible(reader, deserializedMapping);
@@ -1147,7 +1147,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
         /// Checks that the specified deserialization action throws a serialization exception for invalid versions.
         /// </summary>
         /// <param name="deserialize">The action which deserializes from a binary reader.</param>
-        private static void CheckCustomSerializationVersionException(Action<BinaryReader> deserialize)
+        private static void CheckCustomSerializationVersionException(Action<IReader> deserialize)
         {
             using (var stream = new MemoryStream())
             {
@@ -1156,7 +1156,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
 
                 stream.Seek(0, SeekOrigin.Begin);
 
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     Assert.Throws<SerializationException>(() => deserialize(reader));
                 }
@@ -1563,7 +1563,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// Initializes a new instance of the <see cref="NativeRecommenderTestMapping"/> class.
             /// </summary>
             /// <param name="reader">The reader to load the mapping from.</param>
-            public NativeRecommenderTestMapping(BinaryReader reader)
+            public NativeRecommenderTestMapping(IReader reader)
             {
                 if (reader == null)
                 {
@@ -1796,7 +1796,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// Initializes a new instance of the <see cref="StandardRecommenderTestMapping"/> class.
             /// </summary>
             /// <param name="reader">The reader to load the mapping from.</param>
-            public StandardRecommenderTestMapping(BinaryReader reader)
+            public StandardRecommenderTestMapping(IReader reader)
             {
                 reader.ReadSerializationVersion(4);
 

--- a/test/Learners/LearnersTests/NegativeDataGenerationTests.cs
+++ b/test/Learners/LearnersTests/NegativeDataGenerationTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
     using Microsoft.ML.Probabilistic.Learners.Mappings;
     using Microsoft.ML.Probabilistic.Learners.MatchboxRecommenderInternal;
     using Microsoft.ML.Probabilistic.Math;
+    using Microsoft.ML.Probabilistic.Serialization;
 
     /// <summary>
     /// Tests for the negative data generator.
@@ -117,7 +118,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
 
                 stream.Seek(0, SeekOrigin.Begin);
 
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     var deserializedMapping =
                         new NegativeDataGeneratorMapping<PositiveOnlyDataset, Tuple<string, string>, string, string, FeatureProvider, Vector>(reader, positiveOnlyMapping);

--- a/test/Learners/LearnersTests/NegativeDataGenerationTests.cs
+++ b/test/Learners/LearnersTests/NegativeDataGenerationTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var negativeDataGeneratorMapping = positiveOnlyMapping.WithGeneratedNegativeData(1.0);
             using (Stream stream = new MemoryStream())
             {
-                negativeDataGeneratorMapping.SaveForwardCompatibleBinary(stream);
+                negativeDataGeneratorMapping.SaveForwardCompatibleAsBinary(stream);
 
                 stream.Seek(0, SeekOrigin.Begin);
 

--- a/test/Learners/LearnersTests/NegativeDataGenerationTests.cs
+++ b/test/Learners/LearnersTests/NegativeDataGenerationTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             var negativeDataGeneratorMapping = positiveOnlyMapping.WithGeneratedNegativeData(1.0);
             using (Stream stream = new MemoryStream())
             {
-                negativeDataGeneratorMapping.SaveForwardCompatible(stream);
+                negativeDataGeneratorMapping.SaveForwardCompatibleBinary(stream);
 
                 stream.Seek(0, SeekOrigin.Begin);
 

--- a/test/Learners/TestApp/Program.cs
+++ b/test/Learners/TestApp/Program.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Probabilistic.Learners.TestApp
             // Tests for the Bayes Point machine classifier
             var classifierTests = new BayesPointMachineClassifierTests();
 
-            classifierTests.GaussianSparseBinaryStandardCustomSerializationRegressionTest();
+            classifierTests.DenseBinaryStandardSerializationRegressionTest();
             ////classifierTests.DenseBinaryNativeConstantZeroFeatureTest();
             ////classifierTests.SparseBinaryNativeConstantZeroFeatureTest();
             ////classifierTests.DenseMulticlassNativeConstantZeroFeatureTest();

--- a/test/Learners/TestApp/Program.cs
+++ b/test/Learners/TestApp/Program.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Probabilistic.Learners.TestApp
             // Tests for the Bayes Point machine classifier
             var classifierTests = new BayesPointMachineClassifierTests();
 
-            classifierTests.GaussianDenseBinaryStandardCustomSerializationRegressionTest();
+            classifierTests.GaussianSparseBinaryStandardCustomSerializationRegressionTest();
             ////classifierTests.DenseBinaryNativeConstantZeroFeatureTest();
             ////classifierTests.SparseBinaryNativeConstantZeroFeatureTest();
             ////classifierTests.DenseMulticlassNativeConstantZeroFeatureTest();

--- a/test/Learners/TestApp/Program.cs
+++ b/test/Learners/TestApp/Program.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ML.Probabilistic.Learners.TestApp
             // Tests for the Bayes Point machine classifier
             var classifierTests = new BayesPointMachineClassifierTests();
 
-            classifierTests.DenseBinaryStandardSerializationRegressionTest();
+            classifierTests.GaussianDenseBinaryStandardCustomSerializationRegressionTest();
             ////classifierTests.DenseBinaryNativeConstantZeroFeatureTest();
             ////classifierTests.SparseBinaryNativeConstantZeroFeatureTest();
             ////classifierTests.DenseMulticlassNativeConstantZeroFeatureTest();

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -83,8 +83,6 @@ namespace TestApp
             Stopwatch watch = new Stopwatch();
             watch.Start();
 
-            BlogTests.TrueSkill2Test();
-
             if (false)
             {
                 // Run all tests (need to run in 64-bit else OutOfMemory due to loading many DLLs)

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -83,6 +83,8 @@ namespace TestApp
             Stopwatch watch = new Stopwatch();
             watch.Start();
 
+            BlogTests.TrueSkill2Test();
+
             if (false)
             {
                 // Run all tests (need to run in 64-bit else OutOfMemory due to loading many DLLs)

--- a/test/Tests/BlogTests.cs
+++ b/test/Tests/BlogTests.cs
@@ -76,11 +76,11 @@ namespace Microsoft.ML.Probabilistic.Tests
             public TrueSkillV2Batch(double dynamicsVariance, double performanceVariance, double drawMargin, double initialSigma)
             {
                 InitialSigma = initialSigma;
-                NGames = Variable.New<int>();
-                Range game = new Range(NGames);
-                PlayersInGames = Variable.Array<int>(game);
+                NGames = Variable.New<int>().Named("NGames");
+                Range game = new Range(NGames).Named("game");
+                PlayersInGames = Variable.Array<int>(game).Named("PlayersInGames");
 
-                Range gamePlayer = new Range(PlayersInGames[game]);
+                Range gamePlayer = new Range(PlayersInGames[game]).Named("gamePlayer");
 
                 PrevGameIndices = Variable.Array(Variable.Array<int>(gamePlayer), game).Named("Previous Game Indices").Attrib(new DoNotInfer());
                 PrevGamePlayerIndices = Variable.Array(Variable.Array<int>(gamePlayer), game).Named("Previous Game Player Indices").Attrib(new DoNotInfer());
@@ -106,8 +106,8 @@ namespace Microsoft.ML.Probabilistic.Tests
 
                         using (Variable.IfNot(playersFirstGame))
                         {
-                            var prevGame = Variable.Min(PrevGameIndices[game][gamePlayer], 0);
-                            var prevGamePlayerIndex = Variable.Min(PrevGamePlayerIndices[game][gamePlayer], 0);
+                            var prevGame = PrevGameIndices[game][gamePlayer];//, 0).Named("prevGame");
+                            var prevGamePlayerIndex = PrevGamePlayerIndices[game][gamePlayer];//, 0).Named("prevGamePlayerIndex");
                             Skills[game][gamePlayer] = Variable.GaussianFromMeanAndVariance(
                                 Skills[prevGame][prevGamePlayerIndex],
                                 dynamicsVariance

--- a/test/Tests/BlogTests.cs
+++ b/test/Tests/BlogTests.cs
@@ -47,6 +47,9 @@ namespace Microsoft.ML.Probabilistic.Tests
     /// </summary>
     public class BlogTests
     {
+        /// <summary>
+        /// This test should give a warning for excessive memory use.
+        /// </summary>
         internal static void TrueSkill2Test()
         {
             TrueSkillV2Batch model = new TrueSkillV2Batch(1, 1, 1, 1);

--- a/test/Tests/Core/CustomSerializationTests.cs
+++ b/test/Tests/Core/CustomSerializationTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
                 stream.Seek(0, SeekOrigin.Begin);
 
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     Gaussian natural = reader.ReadGaussian();
                     Assert.Equal(-13.89, natural.MeanTimesPrecision);
@@ -63,7 +63,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
                 stream.Seek(0, SeekOrigin.Begin);
 
-                using (var reader = new BinaryReader(stream))
+                using (var reader = new WrappedBinaryReader(new BinaryReader(stream)))
                 {
                     Gamma shapeAndRate = reader.ReadGamma();
                     Assert.Equal(1.0, shapeAndRate.Shape);

--- a/test/Tests/Core/CustomSerializationTests.cs
+++ b/test/Tests/Core/CustomSerializationTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             using (var stream = new MemoryStream())
             {
-                var writer = new BinaryWriter(stream);
+                var writer = new WrappedBinaryWriter(new BinaryWriter(stream));
                 writer.Write(Gaussian.FromNatural(-13.89, 436.12)); 
                 writer.Write(Gaussian.PointMass(Math.PI)); 
                 writer.Write(Gaussian.Uniform()); 
@@ -56,7 +56,7 @@ namespace Microsoft.ML.Probabilistic.Tests
         {
             using (var stream = new MemoryStream())
             {
-                var writer = new BinaryWriter(stream);
+                var writer = new WrappedBinaryWriter(new BinaryWriter(stream));
                 writer.Write(Gamma.FromShapeAndRate(1.0, 10.0)); 
                 writer.Write(Gamma.PointMass(Math.PI));
                 writer.Write(Gamma.Uniform()); 

--- a/test/Tests/Distributions/SerializableTest.cs
+++ b/test/Tests/Distributions/SerializableTest.cs
@@ -343,13 +343,14 @@ namespace Microsoft.ML.Probabilistic.Tests
                 return serializer.Deserialize<T>(jsonReader);
             }
         }
+    }
 
-        /// <summary>
-        /// Treats as objects distribution member types which implement <see cref="IList{T}"/>.
-        /// </summary>
-        private class CollectionAsObjectResolver : DefaultContractResolver
-        {
-            private static readonly HashSet<Type> SerializeAsObjectTypes = new HashSet<Type>
+    /// <summary>
+    /// Treats as objects distribution member types which implement <see cref="IList{T}"/>.
+    /// </summary>
+    public class CollectionAsObjectResolver : DefaultContractResolver
+    {
+        private static readonly HashSet<Type> SerializeAsObjectTypes = new HashSet<Type>
             {
                 typeof(Vector),
                 typeof(Matrix),
@@ -357,21 +358,20 @@ namespace Microsoft.ML.Probabilistic.Tests
                 typeof(ISparseList<>)
             };
 
-            private static readonly ConcurrentDictionary<Type, JsonContract> ResolvedContracts = new ConcurrentDictionary<Type, JsonContract>();
+        private static readonly ConcurrentDictionary<Type, JsonContract> ResolvedContracts = new ConcurrentDictionary<Type, JsonContract>();
 
-            public override JsonContract ResolveContract(Type type) => ResolvedContracts.GetOrAdd(type, this.ResolveContractInternal);
+        public override JsonContract ResolveContract(Type type) => ResolvedContracts.GetOrAdd(type, this.ResolveContractInternal);
 
-            private JsonContract ResolveContractInternal(Type type) => IsExcludedType(type)
-                ? this.CreateObjectContract(type)
-                : this.CreateContract(type);
+        private JsonContract ResolveContractInternal(Type type) => IsExcludedType(type)
+            ? this.CreateObjectContract(type)
+            : this.CreateContract(type);
 
-            private static bool IsExcludedType(Type type)
-            {
-                if (type == null) return false;
-                if (SerializeAsObjectTypes.Contains(type)) return true;
-                if (type.IsGenericType && SerializeAsObjectTypes.Contains(type.GetGenericTypeDefinition())) return true;
-                return IsExcludedType(type.BaseType) || type.GetInterfaces().Any(IsExcludedType);
-            }
+        private static bool IsExcludedType(Type type)
+        {
+            if (type == null) return false;
+            if (SerializeAsObjectTypes.Contains(type)) return true;
+            if (type.IsGenericType && SerializeAsObjectTypes.Contains(type.GetGenericTypeDefinition())) return true;
+            return IsExcludedType(type.BaseType) || type.GetInterfaces().Any(IsExcludedType);
         }
     }
 }


### PR DESCRIPTION
* BayesPointMachineClassifier.LoadBackwardCompatibleBinaryClassifier and SaveForwardCompatible use text or binary depending on the file extension
* Added IWriter and IReader, WrappedBinaryWriter, WrappedBinaryReader, WrappedTextWriter, WrappedTextReader
* Changed uses of BinaryWriter to IWriter
* Changed uses of BinaryReader to IReader
* LearnersTests uses same xunit version as other tests