### PR TITLE
Added IClassifierMapping.LabelToString and ParseLabel

### DIFF
--- a/src/Learners/Classifier/Mappings/ClassifierMappingExtensions.cs
+++ b/src/Learners/Classifier/Mappings/ClassifierMappingExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Mappings
         /// <param name="labelSource">An optional label source.</param>
         /// <returns>All possible values of a label.</returns>
         /// <exception cref="MappingException">Thrown if the class labels are null, empty, identical or not unique.</exception>
-        public static IEnumerable<TLabel> GetClassLabelsSafe<TInstanceSource, TInstance, TLabelSource, TLabel, TFeatures>(
+        public static IReadOnlyList<TLabel> GetClassLabelsSafe<TInstanceSource, TInstance, TLabelSource, TLabel, TFeatures>(
             this IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, TFeatures> mapping,
             TInstanceSource instanceSource = default(TInstanceSource),
             TLabelSource labelSource = default(TLabelSource))
@@ -36,7 +36,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Mappings
                 throw new MappingException("The class labels must not be null.");
             }
 
-            IList<TLabel> classLabelList = classLabels.ToList();
+            IReadOnlyList<TLabel> classLabelList = classLabels.OrderBy(classLabel => classLabel).ToList();
 
             if (classLabelList.Any(label => label == null))
             {

--- a/src/Learners/Classifier/Mappings/IClassifierMapping.cs
+++ b/src/Learners/Classifier/Mappings/IClassifierMapping.cs
@@ -4,6 +4,8 @@
 
 namespace Microsoft.ML.Probabilistic.Learners.Mappings
 {
+    using Microsoft.ML.Probabilistic.Utilities;
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -16,7 +18,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Mappings
     /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
     /// <typeparam name="TLabel">The type of a label.</typeparam>
     /// <typeparam name="TFeatures">The type of the feature values.</typeparam>
-    public interface IClassifierMapping<in TInstanceSource, TInstance, in TLabelSource, out TLabel, out TFeatures> 
+    public interface IClassifierMapping<in TInstanceSource, TInstance, in TLabelSource, TLabel, out TFeatures> 
         : IPredictorMapping<TInstanceSource, TInstance, TLabelSource, TLabel, TFeatures>
     {
         /// <summary>
@@ -26,5 +28,67 @@ namespace Microsoft.ML.Probabilistic.Learners.Mappings
         /// <param name="labelSource">An optional label source.</param>
         /// <returns>All possible values of a label.</returns>
         IEnumerable<TLabel> GetClassLabels(TInstanceSource instanceSource = default(TInstanceSource), TLabelSource labelSource = default(TLabelSource));
+
+        /// <summary>
+        /// Serializes a label to a string.
+        /// </summary>
+        /// <param name="label"></param>
+        /// <returns></returns>
+        string LabelToString(TLabel label);
+
+        /// <summary>
+        /// Deserializes a label from a string.  Reverses <see cref="LabelToString(TLabel)"/>.
+        /// </summary>
+        /// <param name="labelString">The output of <see cref="LabelToString(TLabel)"/></param>
+        /// <returns>The label</returns>
+        TLabel ParseLabel(string labelString);
+    }
+
+    /// <summary>
+    /// Provides a default implementation of <see cref="IClassifierMapping{TInstanceSource, TInstance, TLabelSource, TLabel, TFeatures}"/>
+    /// </summary>
+    /// <typeparam name="TInstanceSource">The type of a source of instances.</typeparam>
+    /// <typeparam name="TInstance">The type of an instance.</typeparam>
+    /// <typeparam name="TLabelSource">The type of a source of labels.</typeparam>
+    /// <typeparam name="TLabel">The type of a label.</typeparam>
+    /// <typeparam name="TFeatures">The type of the feature values.</typeparam>
+    [Serializable]
+    public abstract class ClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, TFeatures> :
+        IClassifierMapping<TInstanceSource, TInstance, TLabelSource, TLabel, TFeatures>
+    {
+        /// <inheritdoc/>
+        public abstract TFeatures GetFeatures(TInstance instance, TInstanceSource instanceSource = default);
+
+        /// <inheritdoc/>
+        public abstract IEnumerable<TInstance> GetInstances(TInstanceSource instanceSource);
+
+        /// <inheritdoc/>
+        public abstract TLabel GetLabel(TInstance instance, TInstanceSource instanceSource = default, TLabelSource labelSource = default);
+
+        /// <inheritdoc/>
+        public abstract IEnumerable<TLabel> GetClassLabels(TInstanceSource instanceSource = default(TInstanceSource), TLabelSource labelSource = default(TLabelSource));
+
+        /// <inheritdoc/>
+        public virtual string LabelToString(TLabel label)
+        {
+            return label.ToString();
+        }
+
+        /// <inheritdoc/>
+        public virtual TLabel ParseLabel(string labelString)
+        {
+            if (labelString is TLabel value)
+            {
+                return value;
+            }
+            else if (0 is TLabel)
+            {
+                return (TLabel)(object)int.Parse(labelString);
+            }
+            else
+            {
+                throw new NotImplementedException($"Cannot parse object type {StringUtil.TypeToString(typeof(TLabel))}.  To add this functionality, provide a ParseLabel implementation in your mapping class.");
+            }
+        }
     }
 }

--- a/src/Learners/Core/IndexedSet.cs
+++ b/src/Learners/Core/IndexedSet.cs
@@ -80,7 +80,7 @@ namespace Microsoft.ML.Probabilistic.Collections
                 int elementCount = reader.ReadInt32();
                 for (int index = 0; index < elementCount; index++)
                 {
-                    var element = (T)reader.ReadObject();
+                    var element = reader.ReadObject<T>();
                     this.Add(element, false);
                 }
             }

--- a/src/Learners/Runners/Common/DataModel/ClassifierMapping.cs
+++ b/src/Learners/Runners/Common/DataModel/ClassifierMapping.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Runners
     /// The classifier mapping.
     /// </summary>
     [Serializable]
-    public class ClassifierMapping : IClassifierMapping<IList<LabeledFeatureValues>, LabeledFeatureValues, IList<LabelDistribution>, string, Vector>
+    public class ClassifierMapping : ClassifierMapping<IList<LabeledFeatureValues>, LabeledFeatureValues, IList<LabelDistribution>, string, Vector>
     {
         /// <summary>
         /// The bidirectional mapping from feature names to feature indexes.
@@ -38,7 +38,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Runners
         /// <param name="instanceSource">The source of instances.</param>
         /// <returns>The instances provided by the instance source.</returns>
         /// <remarks>Assumes that the same instance source always provides the same instances.</remarks>
-        public IEnumerable<LabeledFeatureValues> GetInstances(IList<LabeledFeatureValues> instanceSource)
+        public override IEnumerable<LabeledFeatureValues> GetInstances(IList<LabeledFeatureValues> instanceSource)
         {
             if (instanceSource == null)
             {
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Runners
         /// <param name="instanceSource">An optional source of instances.</param>
         /// <returns>The features for the given instance.</returns>
         /// <remarks>Assumes that the same instance source always provides the same features for a given instance.</remarks>
-        public Vector GetFeatures(LabeledFeatureValues instance, IList<LabeledFeatureValues> instanceSource = null)
+        public override Vector GetFeatures(LabeledFeatureValues instance, IList<LabeledFeatureValues> instanceSource = null)
         {
             if (instance == null)
             {
@@ -73,7 +73,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Runners
         /// <param name="labelSource">An optional source of labels.</param>
         /// <returns>The label of the given instance.</returns>
         /// <remarks>Assumes that the same sources always provide the same label for a given instance.</remarks>
-        public string GetLabel(LabeledFeatureValues instance, IList<LabeledFeatureValues> instanceSource, IList<LabelDistribution> labelSource = null)
+        public override string GetLabel(LabeledFeatureValues instance, IList<LabeledFeatureValues> instanceSource, IList<LabelDistribution> labelSource = null)
         {
             if (instance == null)
             {
@@ -89,7 +89,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Runners
         /// <param name="instanceSource">An optional instance source.</param>
         /// <param name="labelSource">An optional label source.</param>
         /// <returns>All possible values of a label.</returns>
-        public IEnumerable<string> GetClassLabels(IList<LabeledFeatureValues> instanceSource, IList<LabelDistribution> labelSource = null)
+        public override IEnumerable<string> GetClassLabels(IList<LabeledFeatureValues> instanceSource, IList<LabelDistribution> labelSource = null)
         {
             if (instanceSource == null)
             {

--- a/src/Runtime/Core/Serialization/BinaryReaderExtensions.cs
+++ b/src/Runtime/Core/Serialization/BinaryReaderExtensions.cs
@@ -95,14 +95,14 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="reader">The reader of the binary stream.</param>
         /// <returns>The object constructed from the binary stream.</returns>
-        public static object ReadObject(this BinaryReader reader)
+        public static T ReadObject<T>(this BinaryReader reader)
         {
             if (reader == null)
             {
                 throw new ArgumentNullException(nameof(reader));
             }
 
-            return ByteArrayToObject(reader.ReadByteArray());
+            return ByteArrayToObject<T>(reader.ReadByteArray());
         }
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
         /// </summary>
         /// <param name="array">The byte array to convert.</param>
         /// <returns>The object for the specified byte array.</returns>
-        private static object ByteArrayToObject(byte[] array)
+        private static T ByteArrayToObject<T>(byte[] array)
         {
             Debug.Assert(array != null, "The array must not be null.");
 
@@ -277,7 +277,7 @@ namespace Microsoft.ML.Probabilistic.Serialization
                 var binaryFormatter = new BinaryFormatter();
                 memoryStream.Write(array, 0, array.Length);
                 memoryStream.Seek(0, SeekOrigin.Begin);
-                return binaryFormatter.Deserialize(memoryStream);
+                return (T)binaryFormatter.Deserialize(memoryStream);
             }
         }
 

--- a/src/Runtime/Core/Serialization/IReader.cs
+++ b/src/Runtime/Core/Serialization/IReader.cs
@@ -13,6 +13,6 @@ namespace Microsoft.ML.Probabilistic.Serialization
         double ReadDouble();
         string ReadString();
         Guid ReadGuid();
-        object ReadObject();
+        T ReadObject<T>();
     }
 }

--- a/src/Runtime/Core/Serialization/WrappedBinaryReader.cs
+++ b/src/Runtime/Core/Serialization/WrappedBinaryReader.cs
@@ -39,9 +39,9 @@ namespace Microsoft.ML.Probabilistic.Serialization
             return binaryReader.ReadInt32();
         }
 
-        public object ReadObject()
+        public T ReadObject<T>()
         {
-            return binaryReader.ReadObject();
+            return binaryReader.ReadObject<T>();
         }
 
         public string ReadString()

--- a/src/Runtime/Core/Serialization/WrappedTextReader.cs
+++ b/src/Runtime/Core/Serialization/WrappedTextReader.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Microsoft.ML.Probabilistic.Utilities;
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -43,10 +45,17 @@ namespace Microsoft.ML.Probabilistic.Serialization
             return int.Parse(line);
         }
 
-        public object ReadObject()
+        public T ReadObject<T>()
         {
             string line = reader.ReadLine();
-            return line;
+            if (line is T value)
+            {
+                return value;
+            }
+            else
+            {
+                throw new NotImplementedException($"Cannot read object type {StringUtil.TypeToString(typeof(T))}");
+            }
         }
 
         public string ReadString()

--- a/test/Learners/LearnersTests/ClassifierEvaluatorTests.cs
+++ b/test/Learners/LearnersTests/ClassifierEvaluatorTests.cs
@@ -375,7 +375,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
         /// <summary>
         /// The classifier mapping.
         /// </summary>
-        private class ClassifierMapping : IClassifierMapping<IEnumerable<LabelDistribution>, LabelDistribution, IEnumerable<LabelDistribution>, string, Vector>
+        private class ClassifierMapping : ClassifierMapping<IEnumerable<LabelDistribution>, LabelDistribution, IEnumerable<LabelDistribution>, string, Vector>
         {
             /// <summary>
             /// Provides the instances for a given instance source.
@@ -383,7 +383,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// <param name="instanceSource">The source of instances.</param>
             /// <returns>The instances provided by the instance source.</returns>
             /// <remarks>Assumes that the same instance source always provides the same instances.</remarks>
-            public IEnumerable<LabelDistribution> GetInstances(IEnumerable<LabelDistribution> instanceSource)
+            public override IEnumerable<LabelDistribution> GetInstances(IEnumerable<LabelDistribution> instanceSource)
             {
                 if (instanceSource == null)
                 {
@@ -400,7 +400,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// <param name="instanceSource">An optional source of instances.</param>
             /// <returns>The features for the given instance.</returns>
             /// <remarks>Assumes that the same instance source always provides the same features for a given instance.</remarks>
-            public Vector GetFeatures(LabelDistribution instance, IEnumerable<LabelDistribution> instanceSource = null)
+            public override Vector GetFeatures(LabelDistribution instance, IEnumerable<LabelDistribution> instanceSource = null)
             {
                 throw new NotImplementedException("Features are not required in evaluation.");
             }
@@ -413,7 +413,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// <param name="labelSource">An optional source of labels.</param>
             /// <returns>The label of the given instance.</returns>
             /// <remarks>Assumes that the same sources always provide the same label for a given instance.</remarks>
-            public string GetLabel(LabelDistribution instance, IEnumerable<LabelDistribution> instanceSource = null, IEnumerable<LabelDistribution> labelSource = null)
+            public override string GetLabel(LabelDistribution instance, IEnumerable<LabelDistribution> instanceSource = null, IEnumerable<LabelDistribution> labelSource = null)
             {
                 if (instance == null)
                 {
@@ -441,7 +441,7 @@ namespace Microsoft.ML.Probabilistic.Learners.Tests
             /// <param name="instanceSource">An optional instance source.</param>
             /// <param name="labelSource">An optional label source.</param>
             /// <returns>All possible values of a label.</returns>
-            public IEnumerable<string> GetClassLabels(IEnumerable<LabelDistribution> instanceSource = null, IEnumerable<LabelDistribution> labelSource = null)
+            public override IEnumerable<string> GetClassLabels(IEnumerable<LabelDistribution> instanceSource = null, IEnumerable<LabelDistribution> labelSource = null)
             {
                 if (instanceSource == null)
                 {


### PR DESCRIPTION
This is needed to allow classifiers to be serialized to text.  Other changes:
* BinaryNativeClassifierMapping and MulticlassNativeClassifierMapping serialize labels as strings. Incremented CustomSerializationVersion for each.
* BinaryNativeClassifierMapping does not serialize labels when TLabel is bool.
* IReader.ReadObject is generic.