### PR TITLE
FileArray.GetTempFolder returns a folder in the current directory

### DIFF
--- a/src/Runtime/Core/Collections/FileArray.cs
+++ b/src/Runtime/Core/Collections/FileArray.cs
@@ -110,7 +110,7 @@ namespace Microsoft.ML.Probabilistic.Collections
 
         public static string GetTempFolder(string name)
         {
-            string path = Path.GetTempPath() + name;
+            string path = "FileArray" + Path.DirectorySeparatorChar + name;
             return path;
         }
 


### PR DESCRIPTION
Fixes #382 