### PR TITLE
Micro-optimize StringAutomaton.Product and StringTransducer.ProjectSource

### DIFF
--- a/src/Runtime/Core/Collections/GenerationalDictionary.cs
+++ b/src/Runtime/Core/Collections/GenerationalDictionary.cs
@@ -47,16 +47,16 @@ namespace Microsoft.ML.Probabilistic.Collections
             var index = hash & this.mask;
             for (var probe = 1;; ++probe)
             {
-                if (this.entries[index].Generation != currentGeneration)
+                ref var entry = ref this.entries[index];
+                if (entry.Generation != currentGeneration)
                 {
                     value = default(TValue);
                     return false;
                 }
 
-                if (this.entries[index].Hash == hash &&
-                    this.entries[index].Key.Equals(key))
+                if (entry.Hash == hash && entry.Key.Equals(key))
                 {
-                    value = this.entries[index].Value;
+                    value = entry.Value;
                     return true;
                 }
 
@@ -65,6 +65,11 @@ namespace Microsoft.ML.Probabilistic.Collections
         }
 
         public void Add(TKey key, TValue value)
+        {
+            this.GetOrAdd(key, value) = value;
+        }
+
+        public ref TValue GetOrAdd(TKey key, TValue value)
         {
             if (this.filledEntriesCount >= this.growThreshold)
             {
@@ -76,11 +81,12 @@ namespace Microsoft.ML.Probabilistic.Collections
             var index = hash & this.mask;
             for (var probe = 1;; ++probe)
             {
-                if (this.entries[index].Generation != currentGeneration)
+                ref var entry = ref this.entries[index];
+                if (entry.Generation != currentGeneration)
                 {
                     ++this.filledEntriesCount;
 
-                    this.entries[index] = new Entry
+                    entry = new Entry
                     {
                         Key = key,
                         Hash = hash,
@@ -88,13 +94,12 @@ namespace Microsoft.ML.Probabilistic.Collections
                         Value = value,
                     };
 
-                    return;
+                    return ref entry.Value;
                 }
 
-                if (this.entries[index].Hash == hash &&
-                    this.entries[index].Key.Equals(key))
+                if (entry.Hash == hash && entry.Key.Equals(key))
                 {
-                    throw new ArgumentException("Element with given key already exists in the dictionary");
+                    return ref entry.Value;
                 }
 
                 index = (index + probe) & this.mask;
@@ -108,15 +113,15 @@ namespace Microsoft.ML.Probabilistic.Collections
             var index = hash & this.mask;
             for (var probe = 1;; ++probe)
             {
-                if (this.entries[index].Generation != currentGeneration)
+                ref var entry = ref this.entries[index];
+                if (entry.Generation != currentGeneration)
                 {
                     throw new ArgumentException("Element with given key already does not exist in the dictionary");
                 }
 
-                if (this.entries[index].Hash == hash &&
-                    this.entries[index].Key.Equals(key))
+                if (entry.Hash == hash && entry.Key.Equals(key))
                 {
-                    this.entries[index].Value = value;
+                    entry.Value = value;
                     return;
                 }
 

--- a/src/Runtime/Core/Collections/ReadOnlyArray.cs
+++ b/src/Runtime/Core/Collections/ReadOnlyArray.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ML.Probabilistic.Collections
     /// </remarks>
     [Serializable]
     [DataContract]
-    public struct ReadOnlyArray<T> : IReadOnlyList<T>
+    public struct ReadOnlyArray<T>
     {
         /// <summary>
         /// Regular array that holds data.
@@ -51,7 +51,7 @@ namespace Microsoft.ML.Probabilistic.Collections
         public static ReadOnlyArray<T> Empty => new ReadOnlyArray<T>(Array.Empty<T>());
 
         /// <inheritdoc/>
-        public T this[int index] => this.array[index];
+        public ref readonly T this[int index] => ref this.array[index];
 
         /// <inheritdoc/>
         public int Count => this.array.Length;
@@ -70,13 +70,13 @@ namespace Microsoft.ML.Probabilistic.Collections
         public ReadOnlyArraySegmentEnumerator<T> GetEnumerator() =>
             new ReadOnlyArraySegmentEnumerator<T>(this, 0, this.array.Length);
 
-        /// <inheritdoc/>
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() =>
-            new ReadOnlyArraySegmentEnumerator<T>(this, 0, this.array.Length);
-
-        /// <inheritdoc/>
-        IEnumerator IEnumerable.GetEnumerator() =>
-            new ReadOnlyArraySegmentEnumerator<T>(this, 0, this.array.Length);
+        public IEnumerable<T> Enumerate()
+        {
+            foreach (var val in this)
+            {
+                yield return val;
+            }
+        }
 
         public override bool Equals(object o) => o is ReadOnlyArray<T> that && this == that;
 
@@ -115,7 +115,7 @@ namespace Microsoft.ML.Probabilistic.Collections
     /// <summary>
     /// A version if <see cref="ArraySegment{T}"/> which can not be mutated.
     /// </summary>
-    public struct ReadOnlyArraySegment<T> : IReadOnlyList<T>
+    public struct ReadOnlyArraySegment<T>
     {
         /// <summary>
         /// Underlying read-only array.
@@ -146,12 +146,12 @@ namespace Microsoft.ML.Probabilistic.Collections
         }
 
         /// <inheritdoc/>
-        public T this[int index]
+        public ref readonly T this[int index]
         {
             get
             {
                 Debug.Assert(index >= 0 && index < this.length);
-                return this.array[this.begin + index];
+                return ref this.array[this.begin + index];
             }
         }
 
@@ -167,29 +167,24 @@ namespace Microsoft.ML.Probabilistic.Collections
         public ReadOnlyArraySegmentEnumerator<T> GetEnumerator() =>
             new ReadOnlyArraySegmentEnumerator<T>(this.array, this.begin, this.begin + this.length);
 
-        /// <inheritdoc/>
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() =>
-            new ReadOnlyArraySegmentEnumerator<T>(this.array, this.begin, this.begin + this.length);
-
-        /// <inheritdoc/>
-        IEnumerator IEnumerable.GetEnumerator() =>
-            new ReadOnlyArraySegmentEnumerator<T>(this.array, this.begin, this.begin + this.length);
+        public IEnumerable<T> Enumerate()
+        {
+            foreach (var val in this)
+            {
+                yield return val;
+            }
+        }
     }
 
     /// <summary>
     /// Enumerator for immutable arrays and immutable array segments.
     /// </summary>
-    public struct ReadOnlyArraySegmentEnumerator<T> : IEnumerator<T>
+    public struct ReadOnlyArraySegmentEnumerator<T>
     {
         /// <summary>
         /// Underlying immutable array.
         /// </summary>
         private readonly ReadOnlyArray<T> array;
-
-        /// <summary>
-        /// Index of the first element which belongs segment begin enumerated.
-        /// </summary>
-        private readonly int begin;
 
         /// <summary>
         /// Index of the first element which does not belong segment begin enumerated.
@@ -207,7 +202,6 @@ namespace Microsoft.ML.Probabilistic.Collections
         internal ReadOnlyArraySegmentEnumerator(ReadOnlyArray<T> array, int begin, int end)
         {
             this.array = array;
-            this.begin = begin;
             this.end = end;
             this.pointer = begin - 1;
         }
@@ -225,16 +219,7 @@ namespace Microsoft.ML.Probabilistic.Collections
         }
 
         /// <inheritdoc/>
-        public T Current => this.array[this.pointer];
-
-        /// <inheritdoc/>
-        object IEnumerator.Current => this.Current;
-
-        /// <inheritdoc/>
-        void IEnumerator.Reset()
-        {
-            this.pointer = this.begin - 1;
-        }
+        public ref readonly T Current => ref this.array[this.pointer];
     }
 
     public static class ReadOnlyArray

--- a/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Determinization.cs
@@ -130,7 +130,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     {
                         var destinationStates = new Determinization.WeightedStateSet(transition.DestinationStateIndex);
                         var outgoingTransitionInfo = new Determinization.OutgoingTransition(
-                            transition.ElementDistribution.Value, transition.Weight, destinationStates);
+                            transition.ElementDistribution, transition.Weight, destinationStates);
                         if (!TryAddTransition(enqueuedWeightedStateSetStack, outgoingTransitionInfo, currentState))
                         {
                             return false;

--- a/src/Runtime/Distributions/Automata/Automaton.EnumerateSupport.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.EnumerateSupport.cs
@@ -489,7 +489,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     }
                     else
                     {
-                        var elementDistribution = transition.ElementDistribution.Value;
+                        var elementDistribution = transition.ElementDistribution;
                         if (elementDistribution.IsPointMass)
                         {
                             nextElement = elementDistribution.Point;
@@ -563,7 +563,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         return currentStateIndex;
                     }
 
-                    var dist = transition.ElementDistribution.Value;
+                    var dist = transition.ElementDistribution;
 
                     if (!dist.IsPointMass)
                     {

--- a/src/Runtime/Distributions/Automata/Automaton.GroupExtractor.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.GroupExtractor.cs
@@ -47,7 +47,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         }
                         hasNoIncomingTransitions.Remove(transition.DestinationStateIndex);
                         newSourceState.AddTransition(
-                            transition.ElementDistribution,
+                            transition.OptionalElementDistribution,
                             transition.Weight,
                             stateMapping[transition.DestinationStateIndex].Index);
                     }

--- a/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Simplification.cs
@@ -197,20 +197,20 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         TElementDistribution newElementDistribution;
                         if (transition1.Weight.IsInfinity && transition2.Weight.IsInfinity)
                         {
-                            newElementDistribution = transition1.ElementDistribution.Value.Sum(1.0,
-                                transition2.ElementDistribution.Value,
+                            newElementDistribution = transition1.ElementDistribution.Sum(1.0,
+                                transition2.ElementDistribution,
                                 1.0);
                         }
                         else if (transition1.Weight > transition2.Weight)
                         {
-                            newElementDistribution = transition1.ElementDistribution.Value.Sum(1.0,
-                                transition2.ElementDistribution.Value,
+                            newElementDistribution = transition1.ElementDistribution.Sum(1.0,
+                                transition2.ElementDistribution,
                                 (transition2.Weight / transition1.Weight).Value);
                         }
                         else
                         {
-                            newElementDistribution = transition1.ElementDistribution.Value.Sum((transition1.Weight / transition2.Weight).Value,
-                                transition2.ElementDistribution.Value,
+                            newElementDistribution = transition1.ElementDistribution.Sum((transition1.Weight / transition2.Weight).Value,
+                                transition2.ElementDistribution,
                                 1.0);
                         }
 
@@ -349,14 +349,14 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                             selfLoop2.HasValue &&
                             selfLoop1.Value.Group == selfLoop2.Value.Group &&
                             selfLoop1.Value.Weight == selfLoop2.Value.Weight &&
-                            EqualDistributions(selfLoop1.Value.ElementDistribution, selfLoop2.Value.ElementDistribution));
+                            EqualDistributions(selfLoop1.Value.OptionalElementDistribution, selfLoop2.Value.OptionalElementDistribution));
                 }
 
                 bool CanMergeDestinations(Transition transition1, Transition transition2)
                 {
                     // Check that group and element distribution match
                     if (transition1.Group != transition2.Group ||
-                        !EqualDistributions(transition1.ElementDistribution, transition2.ElementDistribution))
+                        !EqualDistributions(transition1.OptionalElementDistribution, transition2.OptionalElementDistribution))
                     {
                         return false;
                     }

--- a/src/Runtime/Distributions/Automata/Automaton.State.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.State.cs
@@ -5,9 +5,6 @@
 namespace Microsoft.ML.Probabilistic.Distributions.Automata
 {
     using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Text;
 
     using Microsoft.ML.Probabilistic.Collections;
@@ -63,7 +60,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     this.Data.FirstTransitionIndex,
                     this.Data.TransitionsCount);
 
-            internal StateData Data => this.states[this.Index];
+            internal ref readonly StateData Data => ref this.states[this.Index];
 
             /// <summary>
             /// Compares 2 states for equality.

--- a/src/Runtime/Distributions/Automata/Automaton.Transition.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Transition.cs
@@ -76,7 +76,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
 
             public Transition With(Option<TElementDistribution>? elementDistribution = null, Weight? weight = null, int? destinationStateIndex = null, int? group = null) =>
                 new Transition(
-                    elementDistribution ?? this.ElementDistribution,
+                    elementDistribution ?? this.OptionalElementDistribution,
                     weight ?? this.Weight,
                     destinationStateIndex ?? this.DestinationStateIndex,
                     group ?? this.Group);
@@ -98,12 +98,19 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             }
 
             /// <summary>
-            /// Gets the element distribution for this transition.
+            /// Gets the element distribution for this transition. <see cref="Option.None"/> is
+            /// returned if it is an epsilon transition.
             /// </summary>
-            public Option<TElementDistribution> ElementDistribution
+            public Option<TElementDistribution> OptionalElementDistribution
             {
                 get => this.hasElementDistribution == 0 ? Option.None : Option.Some(this.elementDistribution);
             }
+
+            /// <summary>
+            /// Returns element distribution for this transition. If transitio is epsilon,
+            /// default(TElementDistribution) is returned.
+            /// </summary>
+            public TElementDistribution ElementDistribution => this.elementDistribution;
 
             /// <summary>
             /// Gets a value indicating whether this transition is an epsilon transition.
@@ -132,7 +139,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 }
 
                 sb.Append('[');
-                sb.Append(this.ElementDistribution.HasValue ? this.ElementDistribution.ToString() : "eps");
+                sb.Append(this.IsEpsilon ? "eps" : this.ElementDistribution.ToString());
                 sb.Append(']');
                 sb.Append(" " + this.Weight.Value);
                 sb.Append(" -> " + this.DestinationStateIndex);

--- a/src/Runtime/Distributions/Automata/Automaton.Transition.cs
+++ b/src/Runtime/Distributions/Automata/Automaton.Transition.cs
@@ -57,7 +57,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             /// <param name="weight">The weight associated with the transition.</param>
             /// <param name="destinationStateIndex">The index of the destination state of the transition.</param>
             /// <param name="group">The group this transition belongs to.</param>
-            [Construction("ElementDistribution", "Weight", "DestinationStateIndex", "Group")]
+            [Construction("OptionalElementDistribution", "Weight", "DestinationStateIndex", "Group")]
             public Transition(Option<TElementDistribution> elementDistribution, Weight weight, int destinationStateIndex, int group = 0)
                 : this()
             {

--- a/src/Runtime/Distributions/Automata/GraphVizAutomatonFormat.cs
+++ b/src/Runtime/Distributions/Automata/GraphVizAutomatonFormat.cs
@@ -54,9 +54,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     {
                         transitionLabel = "eps";
                     }
-                    else if (transition.ElementDistribution.Value.IsPointMass)
+                    else if (transition.ElementDistribution.IsPointMass)
                     {
-                        transitionLabel = EscapeLabel(transition.ElementDistribution.Value.Point.ToString());
+                        transitionLabel = EscapeLabel(transition.ElementDistribution.Point.ToString());
                     }
                     else
                     {

--- a/src/Runtime/Distributions/Automata/ImmutablePairDistribution.cs
+++ b/src/Runtime/Distributions/Automata/ImmutablePairDistribution.cs
@@ -77,7 +77,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// Stores the product of distributions over the first and the the second element
         /// when the equality constraint is enabled.
         /// </summary>
-        private Option<TElementDistribution> firstTimesSecond;
+        private TElementDistribution firstTimesSecond;
 
         /// <summary>
         /// Gets a value indicating whether the equality constraint is set on the distribution.
@@ -146,9 +146,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 Debug.Assert(
                     this.First.HasValue && this.Second.HasValue,
                     "Cannot have a constrained pair distribution with a missing element distribution.");
-                Debug.Assert(this.firstTimesSecond.HasValue, "Must have been computed.");
 
-                double logAverageOf = this.firstTimesSecond.Value.GetLogProb(first);
+                double logAverageOf = this.firstTimesSecond.GetLogProb(first);
                 if (double.IsNegativeInfinity(logAverageOf))
                 {
                     result = default(TElementDistribution);
@@ -177,9 +176,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 Debug.Assert(
                     this.First.HasValue && this.Second.HasValue,
                     "Cannot have a constrained pair distribution with a missing element distribution.");
-                Debug.Assert(this.firstTimesSecond.HasValue, "Must have been computed.");
 
-                double logAverageOf = firstTimesSecond.Value.GetLogAverageOf(first);
+                double logAverageOf = firstTimesSecond.GetLogAverageOf(first);
                 
                 if (double.IsNegativeInfinity(logAverageOf))
                 {
@@ -187,7 +185,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     return double.NegativeInfinity;
                 }
                 
-                result = firstTimesSecond.Value.Multiply(first);
+                result = firstTimesSecond.Multiply(first);
                 return logAverageOf;    
             }
 
@@ -237,7 +235,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     "Cannot have a constrained pair distribution with a missing element distribution.");
 
                 double result = 0;
-                var product = firstTimesSecond.Value;
+                var product = firstTimesSecond;
                 result += product.GetLogAverageOf(that.First.Value);
                 product = product.Multiply(that.First.Value);
                 result += product.GetLogAverageOf(that.Second.Value);

--- a/src/Runtime/Distributions/Automata/RegexpTreeBuilder.cs
+++ b/src/Runtime/Distributions/Automata/RegexpTreeBuilder.cs
@@ -107,7 +107,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                             {
                                 var destStateRegexp = transition.IsEpsilon
                                     ? RegexpTreeNode<TElement, TElementDistribution>.Empty()
-                                    : RegexpTreeNode<TElement, TElementDistribution>.FromElementSet(transition.ElementDistribution);
+                                    : RegexpTreeNode<TElement, TElementDistribution>.FromElementSet(transition.OptionalElementDistribution);
                                 stateDownwardRegexp = RegexpTreeNode<TElement, TElementDistribution>.Or(
                                     stateDownwardRegexp,
                                     RegexpTreeNode<TElement, TElementDistribution>.Concat(destStateRegexp, stateRegexps[transition.DestinationStateIndex]));
@@ -250,7 +250,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                                 var regex =
                                     transition.IsEpsilon
                                         ? RegexpTreeNode<TElement, TElementDistribution>.Empty()
-                                        : RegexpTreeNode<TElement, TElementDistribution>.FromElementSet(transition.ElementDistribution);
+                                        : RegexpTreeNode<TElement, TElementDistribution>.FromElementSet(transition.OptionalElementDistribution);
 
                                 var destinationNodeIndex = stateIndexToNodeIndex[transition.DestinationStateIndex];
                                 if (outgoingRegexes.ContainsKey(destinationNodeIndex))
@@ -397,7 +397,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     {
                         var destStateRegexp = transition.IsEpsilon
                                 ? RegexpTreeNode<TElement, TElementDistribution>.Empty()
-                                : RegexpTreeNode<TElement, TElementDistribution>.FromElementSet(transition.ElementDistribution);
+                                : RegexpTreeNode<TElement, TElementDistribution>.FromElementSet(transition.OptionalElementDistribution);
                         regexps[stateIndex, destStateIndex] = RegexpTreeNode<TElement, TElementDistribution>.Or(
                             regexps[stateIndex, destStateIndex], destStateRegexp);
                     }

--- a/src/Runtime/Distributions/Automata/RegexpTreeNode.cs
+++ b/src/Runtime/Distributions/Automata/RegexpTreeNode.cs
@@ -310,12 +310,15 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             if (ranges.Count > 1)
             {
                 resultBuilder.Append('[');
-                ranges.ForEach(range => AppendCharacterRange(resultBuilder, range));
+                foreach (var range in ranges)
+                {
+                    AppendCharacterRange(resultBuilder, range);
+                }
                 resultBuilder.Append(']');
             }
             else if (ranges.Count == 1)
             {
-                AppendCharacterRange(resultBuilder, ranges.Single());
+                AppendCharacterRange(resultBuilder, ranges[0]);
             }
         }
 

--- a/src/Runtime/Distributions/Automata/StringAutomaton.cs
+++ b/src/Runtime/Distributions/Automata/StringAutomaton.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         private static void AddTransitionCharSegmentBounds(
             Transition transition, Weight sourceStateResidualWeight, List<TransitionCharSegmentBound> segmentBounds)
         {
-            var distribution = transition.ElementDistribution.Value;
+            var distribution = transition.ElementDistribution;
             var ranges = distribution.Ranges;
             var weightBase = transition.Weight * sourceStateResidualWeight;
 

--- a/src/Runtime/Distributions/Automata/StringManipulator.cs
+++ b/src/Runtime/Distributions/Automata/StringManipulator.cs
@@ -12,10 +12,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     /// Provides the ability to manipulate strings.
     /// </summary>
     [Serializable]
-    public class StringManipulator : ISequenceManipulator<string, char>
+    public struct StringManipulator : ISequenceManipulator<string, char>
     {
-        public IEqualityComparer<string> SequenceEqualityComparer { get; } =
-            StringComparer.Ordinal;
+        public IEqualityComparer<string> SequenceEqualityComparer => StringComparer.Ordinal;
 
         /// <summary>
         /// Converts a given sequence of characters to a string.

--- a/src/Runtime/Distributions/Automata/Transducer.cs
+++ b/src/Runtime/Distributions/Automata/Transducer.cs
@@ -204,9 +204,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 for (var iterator = builder[stateIndex].TransitionIterator; iterator.Ok; iterator.Next())
                 {
                     var transition = iterator.Value;
-                    if (transition.ElementDistribution.HasValue)
+                    if (!transition.IsEpsilon)
                     {
-                        transition = transition.With(elementDistribution: transition.ElementDistribution.Value.Transpose());
+                        transition = transition.With(elementDistribution: transition.ElementDistribution.Transpose());
                         iterator.Value = transition;
                     }
                 }

--- a/src/Runtime/Distributions/Automata/TransducerBase.cs
+++ b/src/Runtime/Distributions/Automata/TransducerBase.cs
@@ -456,9 +456,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// Unfortunately, it's not clear how to avoid the duplication in the current design.
         /// </remarks>
         /// <remarks>
-        /// This method intentionally does not use higher-level APIs like <see cref="State"/>,
-        /// and <see cref="StateCollection"/> because it is a part of very hot loops and
-        /// overhead from those is tens of percents.
+        /// This method intentionally does not use higher-level APIs like <see cref="Automaton{TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis}.State"/>,
+        /// and <see cref="Automaton{TSequence, TElement, TElementDistribution, TSequenceManipulator, TThis}.StateCollection"/>
+        /// because it is a part of very hot loops and overhead from those is tens of percents.
         /// </remarks>
         public TDestAutomaton ProjectSource(TSrcSequence srcSequence)
         {

--- a/src/Runtime/Distributions/Automata/TransducerBase.cs
+++ b/src/Runtime/Distributions/Automata/TransducerBase.cs
@@ -9,7 +9,6 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
     using System.Diagnostics;
     using System.Linq;
     using Microsoft.ML.Probabilistic.Collections;
-    using Microsoft.ML.Probabilistic.Math;
     using Microsoft.ML.Probabilistic.Utilities;
 
     /// <summary>
@@ -364,12 +363,12 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                 Automaton<TSrcSequence, TSrcElement, TSrcElementDistribution, TSrcSequenceManipulator, TSrcAutomaton>.State srcState)
             {
                 var destPair = new IntPair(mappingState.Index, srcState.Index);
-                if (!destStateCache.TryGetValue(destPair, out var destStateIndex))
+                ref var destStateIndex = ref destStateCache.GetOrAdd(destPair, -1);
+                if (destStateIndex == -1)
                 {
                     var destState = result.AddState();
                     destState.SetEndWeight(mappingState.EndWeight * srcState.EndWeight);
                     stack.Push((mappingState.Index, srcState.Index, destState.Index));
-                    destStateCache.Add(destPair, destState.Index);
                     destStateIndex = destState.Index;
                 }
 
@@ -397,9 +396,9 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                     if (IsSrcEpsilon(mappingTransition))
                     {
                         var destElementDistribution =
-                            mappingTransition.ElementDistribution.HasValue
-                                ? mappingTransition.ElementDistribution.Value.Second
-                                : Option.None;
+                            mappingTransition.IsEpsilon
+                                ? Option.None
+                                : mappingTransition.ElementDistribution.Second;
                         var childDestStateIndex = CreateDestState(childMappingState, srcState);
                         destState.AddTransition(destElementDistribution, mappingTransition.Weight, childDestStateIndex, mappingTransition.Group);
                         continue;
@@ -412,8 +411,8 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                         
                         var srcChildState = srcAutomaton.States[srcTransition.DestinationStateIndex];
 
-                        var projectionLogScale = mappingTransition.ElementDistribution.Value.ProjectFirst(
-                            srcTransition.ElementDistribution.Value, out var destElementDistribution);
+                        var projectionLogScale = mappingTransition.ElementDistribution.ProjectFirst(
+                            srcTransition.ElementDistribution, out var destElementDistribution);
                         if (double.IsNegativeInfinity(projectionLogScale))
                         {
                             continue;
@@ -456,6 +455,11 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// The code of this method has a lot in common with the code of Automaton.SetToProduct.
         /// Unfortunately, it's not clear how to avoid the duplication in the current design.
         /// </remarks>
+        /// <remarks>
+        /// This method intentionally does not use higher-level APIs like <see cref="State"/>,
+        /// and <see cref="StateCollection"/> because it is a part of very hot loops and
+        /// overhead from those is tens of percents.
+        /// </remarks>
         public TDestAutomaton ProjectSource(TSrcSequence srcSequence)
         {
             Argument.CheckIfNotNull(srcSequence, "srcSequence");
@@ -473,20 +477,23 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             var result = new Automaton<TDestSequence, TDestElement, TDestElementDistribution, TDestSequenceManipulator, TDestAutomaton>.Builder();
             var (destStateCache, stack) = PreallocatedAutomataObjects.LeaseProductState();
 
+            var mappingStates = mappingAutomaton.Data.States;
+            var mappingTransitions = mappingAutomaton.Data.Transitions;
+
             // Creates destination state and schedules projection computation for it.
             // If computation is already scheduled or done the state index is simply taken from cache
-            int CreateDestState(PairListAutomaton.State mappingState, int srcSequenceIndex)
+            int CreateDestState(int mappingStateIndex, int srcSequenceIndex)
             {
-                var destPair = new IntPair(mappingState.Index, srcSequenceIndex);
-                if (!destStateCache.TryGetValue(destPair, out var destStateIndex))
+                var destPair = new IntPair(mappingStateIndex, srcSequenceIndex);
+                ref var destStateIndex = ref destStateCache.GetOrAdd(destPair, -1);
+                if (destStateIndex == -1)
                 {
                     var destState = result.AddState();
                     destState.SetEndWeight(
                         srcSequenceIndex == srcSequenceLength
-                            ? mappingState.EndWeight
+                            ? mappingStates[mappingStateIndex].EndWeight
                             : Weight.Zero);
-                    stack.Push((mappingState.Index, srcSequenceIndex, destState.Index));
-                    destStateCache.Add(destPair, destState.Index);
+                    stack.Push((mappingStateIndex, srcSequenceIndex, destState.Index));
                     destStateIndex = destState.Index;
                 }
 
@@ -494,38 +501,39 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
             }
 
             // Populate the stack with start destination state
-            result.StartStateIndex = CreateDestState(mappingAutomaton.Start, 0);
+            result.StartStateIndex = CreateDestState(mappingAutomaton.Data.StartStateIndex, 0);
 
             while (stack.Count > 0)
             {
                 var (mappingStateIndex, srcSequenceIndex, destStateIndex) = stack.Pop();
 
-                var mappingState = mappingAutomaton.States[mappingStateIndex];
                 var destState = result[destStateIndex];
+                var transitionsBegin = mappingStates[mappingStateIndex].FirstTransitionIndex;
+                var transitionsEnd = transitionsBegin + mappingStates[mappingStateIndex].TransitionsCount;
 
                 // Enumerate transitions from the current mapping state
-                foreach (var mappingTransition in mappingState.Transitions)
+                for (var i = transitionsBegin; i < transitionsEnd; ++i)
                 {
-                    var destMappingState = mappingAutomaton.States[mappingTransition.DestinationStateIndex];
+                    var mappingTransition = mappingTransitions[i];
+                    var destMappingState = mappingTransition.DestinationStateIndex;
 
                     // Epsilon transition case
-                    if (IsSrcEpsilon(mappingTransition))
+                    if (mappingTransition.IsEpsilon)
                     {
-                        var destElementWeights =
-                            mappingTransition.ElementDistribution.HasValue
-                                ? mappingTransition.ElementDistribution.Value.Second
-                                : Option.None;
                         var childDestStateIndex = CreateDestState(destMappingState, srcSequenceIndex);
-                        destState.AddTransition(destElementWeights, mappingTransition.Weight, childDestStateIndex, mappingTransition.Group);
-                        continue;
+                        destState.AddEpsilonTransition(mappingTransition.Weight, childDestStateIndex, mappingTransition.Group);
                     }
-
-                    // Normal transition case - Find epsilon-reachable states
-                    if (srcSequenceIndex < srcSequenceLength)
+                    else if (mappingTransition.ElementDistribution.First.HasNoValue)
+                    {
+                        var destElementDist = mappingTransition.ElementDistribution.Second;
+                        var childDestStateIndex = CreateDestState(destMappingState, srcSequenceIndex);
+                        destState.AddTransition(destElementDist, mappingTransition.Weight, childDestStateIndex, mappingTransition.Group);
+                    }
+                    else if (srcSequenceIndex < srcSequenceLength)
                     {
                         var srcSequenceElement = sourceSequenceManipulator.GetElement(srcSequence, srcSequenceIndex);
 
-                        var projectionLogScale = mappingTransition.ElementDistribution.Value.ProjectFirst(
+                        var projectionLogScale = mappingTransition.ElementDistribution.ProjectFirst(
                             srcSequenceElement, out var destElementDistribution);
                         if (double.IsNegativeInfinity(projectionLogScale))
                         {
@@ -578,7 +586,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
         /// <param name="transition">The transition to check.</param>
         /// <returns>A value indicating whether a given transducer transition is either epsilon of has epsilon source element.</returns>
         private static bool IsSrcEpsilon(PairListAutomaton.Transition transition) =>
-            !transition.ElementDistribution.HasValue || !transition.ElementDistribution.Value.First.HasValue;
+            transition.IsEpsilon || !transition.ElementDistribution.First.HasValue;
 
         #endregion
 

--- a/src/Runtime/Distributions/Automata/WeightFunctions.DictionaryWeightFunction.cs
+++ b/src/Runtime/Distributions/Automata/WeightFunctions.DictionaryWeightFunction.cs
@@ -855,7 +855,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                                 transitionsToMerge.Add(currentState.Index, stateDict);
                             }
                             var distr = new List<(char character, Weight weight)>();
-                            distr.Add((currentTransition.ElementDistribution.Value.Point, currentTransition.Weight));
+                            distr.Add((currentTransition.ElementDistribution.Point, currentTransition.Weight));
                             distr.Add((transitionChar, weight));
                             stateDict.Add(destinationStateIndex, distr);
                             iterator.Remove();

--- a/src/Runtime/Distributions/Automata/WeightFunctions.MultiRepresentationWeightFunction.cs
+++ b/src/Runtime/Distributions/Automata/WeightFunctions.MultiRepresentationWeightFunction.cs
@@ -350,7 +350,7 @@ namespace Microsoft.ML.Probabilistic.Distributions.Automata
                                         + 2 * 24 // Headers of the states and transitions arrays
                                         + automaton.Data.States.Count * (2 * sizeof(int) + sizeof(double)) // states
                                         + automaton.Data.Transitions.Count * 24 // 24 is the size of one transition w/o storage for discrete char
-                                        + automaton.Data.Transitions.Count(tr => !tr.IsEpsilon) * 80;
+                                        + automaton.Data.Transitions.Enumerate().Count(tr => !tr.IsEpsilon) * 80;
                                     // 40 is the size of a DiscreteChar filled with nulls;
                                     // another 40 is the size of an array with a single char range.
                                     // Any specific DiscreteChar can be larger or can be cached.

--- a/src/Runtime/Distributions/DiscreteChar.cs
+++ b/src/Runtime/Distributions/DiscreteChar.cs
@@ -161,8 +161,11 @@ namespace Microsoft.ML.Probabilistic.Distributions
         #region Factory methods
 
         /// <inheritdoc cref="ImmutableDiscreteChar.Create(IEnumerable{ImmutableDiscreteChar.CharRange})"/>
-        [Construction("Ranges")]
         public static DiscreteChar Create(IEnumerable<ImmutableDiscreteChar.CharRange> ranges) =>
+            new DiscreteChar(ImmutableDiscreteChar.Create(ranges));
+
+        /// <inheritdoc cref="ImmutableDiscreteChar.Create(ReadOnlyArray{ImmutableDiscreteChar.CharRange})"/>
+        public static DiscreteChar Create(ReadOnlyArray<ImmutableDiscreteChar.CharRange> ranges) =>
             new DiscreteChar(ImmutableDiscreteChar.Create(ranges));
 
         /// <inheritdoc cref="ImmutableDiscreteChar.Uniform"/>
@@ -713,6 +716,25 @@ namespace Microsoft.ML.Probabilistic.Distributions
         /// <remarks>The probabilities do not need to be normalized. The character ranges do not need to be sorted.</remarks>
         /// <returns>The created distribution.</returns>
         [Construction("Ranges")]
+        public static ImmutableDiscreteChar Create(ReadOnlyArray<CharRange> ranges)
+        {
+            Argument.CheckIfNotNull(ranges, "ranges");
+
+            var builder = StorageBuilder.Create();
+            foreach (var range in ranges)
+            {
+                builder.AddRange(range);
+            }
+            builder.SortAndCheckRanges();
+            return new ImmutableDiscreteChar(builder.GetResult());
+        }
+
+        /// <summary>
+        /// Creates a distribution given a list of constant probability character ranges.
+        /// </summary>
+        /// <param name="ranges">The constant-probability character ranges.</param>
+        /// <remarks>The probabilities do not need to be normalized. The character ranges do not need to be sorted.</remarks>
+        /// <returns>The created distribution.</returns>
         public static ImmutableDiscreteChar Create(IEnumerable<CharRange> ranges)
         {
             Argument.CheckIfNotNull(ranges, "ranges");

--- a/src/Runtime/Distributions/DiscreteChar.cs
+++ b/src/Runtime/Distributions/DiscreteChar.cs
@@ -1856,7 +1856,6 @@ namespace Microsoft.ML.Probabilistic.Distributions
                 this.CharClasses = charClasses;
                 this.regexRepresentation = regexRepresentation;
                 this.symbolRepresentation = symbolRepresentation;
-                var supportCount = this.Ranges.Where(range => !range.Probability.IsZero).Sum(range => range.EndExclusive - range.StartInclusive);
             }
 
             public static Storage CreateUncached(
@@ -2015,7 +2014,10 @@ namespace Microsoft.ML.Probabilistic.Distributions
             public void Write(Action<int> writeInt32, Action<double> writeDouble)
             {
                 writeInt32(this.Ranges.Count);
-                this.Ranges.ForEach(range => range.Write(writeInt32, writeDouble));
+                foreach (var range in this.Ranges)
+                {
+                    range.Write(writeInt32, writeDouble);
+                }
                 writeInt32((int)this.CharClasses);
             }
 

--- a/src/Runtime/Distributions/SequenceDistribution.cs
+++ b/src/Runtime/Distributions/SequenceDistribution.cs
@@ -1441,7 +1441,7 @@ namespace Microsoft.ML.Probabilistic.Distributions
                     {
                         if (!transition.IsEpsilon)
                         {
-                            sampledElements.Add(transition.ElementDistribution.Value.Sample());
+                            sampledElements.Add(transition.ElementDistribution.Sample());
                         }
 
                         currentState = automaton.States[transition.DestinationStateIndex];

--- a/src/Runtime/Factors/SingleOp.cs
+++ b/src/Runtime/Factors/SingleOp.cs
@@ -55,7 +55,7 @@ namespace Microsoft.ML.Probabilistic.Factors
                         if (!destStateClosure.EndWeight.IsZero)
                         {
                             Weight weight = Weight.Product(stateLogWeight, transition.Weight, destStateClosure.EndWeight);
-                            var logProbs = transition.ElementDistribution.Value.GetProbs();
+                            var logProbs = transition.ElementDistribution.GetProbs();
                             logProbs.SetToFunction(logProbs, Math.Log);
                             resultLogProb = LogSumExp(resultLogProb, logProbs, weight);
                         }

--- a/test/Tests/Strings/AutomatonTests.cs
+++ b/test/Tests/Strings/AutomatonTests.cs
@@ -734,7 +734,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 .Scale(0.5);
 
             // Make sure it contains epsilon transitions
-            Assert.Contains(automaton.States, s => s.Transitions.Any(t => t.IsEpsilon));
+            Assert.Contains(automaton.States, s => s.Transitions.Enumerate().Any(t => t.IsEpsilon));
 
             // Test the original automaton, its epsilon closure and the closure of the closure
             for (int i = 0; i < 3; ++i)
@@ -745,7 +745,7 @@ namespace Microsoft.ML.Probabilistic.Tests
                 automaton = automaton.GetEpsilonClosure();
 
                 // Make sure it doesn't contain epsilon transitions
-                Assert.True(automaton.States.All(s => s.Transitions.All(t => !t.IsEpsilon)));
+                Assert.True(automaton.States.All(s => s.Transitions.Enumerate().All(t => !t.IsEpsilon)));
             }
         }
 

--- a/test/Tests/Strings/SequenceDistributionTests.cs
+++ b/test/Tests/Strings/SequenceDistributionTests.cs
@@ -597,7 +597,7 @@ namespace Microsoft.ML.Probabilistic.Tests
 
             void AddCharToModel(ImmutableDiscreteChar c, double ratio)
             {
-                var realCharProb = c.Ranges.First().Probability;
+                var realCharProb = c.Ranges[0].Probability;
                 var weight = Weight.FromValue(ratio) * Weight.Inverse(realCharProb);
                 state = state.AddTransition(c, weight);
                 state.SetEndWeight(Weight.One);


### PR DESCRIPTION
In our project these 2 methods are very hot. They are near-optimal algorithmically but implementation
wasn't efficient due to use of convenient abstractions and JIT in netframework4.7.2 being not very sophisticated.
(dotnet7 optimizes original code a lot better, but due to various reasons we can't migrate to it yet).

List of micro-optimizations in no particular order:
- ReadOnlyArray<> now returns values by reference
  - It means it can't implement IReadOnlyList<> interface anymore. But it wasn't used through interface anywhere anyway
- GenerationalDictionary<> now accesses hash-table cells by reference
- GenerationalDictionary.GetOrAdd() method added which replaces 2 calls to TryGetValue()+Add()
- Automaton.Builder now manages its dynamically growing arrays on its own instead of using List<>.
  This reduces indirection and allows to access elements by reference
- Automaton.Transition.ElementDistribution is not Option<TElementDistribution> anymore. Boxing of
  element distribution into Option<> was not optimized out by JIT.
  - New API is a little less safe (because this property can be used only for non-epsilon transitions) but more efficient.
  - Transition.OptionalElementDistribution property was added for non-performance critical parts of the code.
- StringManipulator is now a struct (value type). It allows to monomorphize generic class and inline calls to its methods.
  With classes (reference types) calls had to be dynamically dispatched.
- Automaton.Product() and TransducerBase.ProjectSource() were rewritten without use of StateCollection, State
  and ReadOnlyArraySegment<> types. These types provided convinient APIs but JIT was not ablet to eliminate
  their overhead.

This PR speeds up methods mentioned in PR title by about 30%.