### PR TITLE
Remove duplicate references to FSharp.Core

### DIFF
--- a/src/FSharpWrapper/FSharpWrapper.fsproj
+++ b/src/FSharpWrapper/FSharpWrapper.fsproj
@@ -8,7 +8,6 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.ML.Probabilistic.FSharp.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.7.2" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/test/TestFSharp/TestFSharp.fsproj
+++ b/test/TestFSharp/TestFSharp.fsproj
@@ -52,7 +52,6 @@
     <ProjectReference Include="..\..\src\FSharpWrapper\FSharpWrapper.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">


### PR DESCRIPTION
Remove duplicate references to FSharp.Core. Without this change, builds with Visual Studio 17.3.1+ will result in "Error NU1504	Duplicate 'PackageReference' items found" errors.