### PR TITLE
Support null values in PropertiesToString

### DIFF
--- a/src/Runtime/Core/Utils/StringUtil.cs
+++ b/src/Runtime/Core/Utils/StringUtil.cs
@@ -618,7 +618,7 @@ namespace Microsoft.ML.Probabilistic.Utilities
                     try
                     {
                         //string rhs = ToString(prop.GetValue(o, null));
-                        string rhs = prop.GetValue(o, null).ToString();
+                        string rhs = prop.GetValue(o, null)?.ToString() ?? "null";
                         if (i > 0) s.Append(delimiter);
                         s.Append(JoinColumns(prop.Name, " = ", rhs));
                         i++;


### PR DESCRIPTION
Produce "null" string output for property values that are null in `PropertiesToString` instead of failing with an exception.