### PR TITLE
Fix some causes of Arithmetic Overflow exceptions (when running with checked arithmetic)

### DIFF
--- a/src/Compiler/Graphs/MinCut.cs
+++ b/src/Compiler/Graphs/MinCut.cs
@@ -171,10 +171,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Graphs
                     {
                         NodeType target = graph.TargetOf(edge);
                         bool isSinkEdge = IsSinkEdge(edge);
-
-                        // Long to avoid overflow.
-                        long distTarget = isSinkEdge ? 0 : distanceToSink[target];
-                        if (distanceToSink[node] != distTarget + 1) continue;
+                        if (sourceGroup.Contains(target)) continue;
+                        if (distanceToSink[node] - 1 != distanceToSink[target]) continue;
                         // target cannot be in sourceGroup since their distances are huge
                         float cap = capacity(edge);
                         float residual;
@@ -200,14 +198,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Graphs
                     foreach (EdgeType edge in graph.EdgesInto(node))
                     {
                         NodeType target = graph.SourceOf(edge);
-
-                        // Long to avoid overflow
-                        long nodeDistanceToSink = distanceToSink[node];
-                        long targetDistanceToSink = distanceToSink[target];
-                        if (nodeDistanceToSink != targetDistanceToSink + 1) continue;
-                        // target cannot be in sourceGroup since their distances are huge,
-                        // unless it is both a source and sink.
-                        if (Sources.Contains(target)) continue;
+                        if (sourceGroup.Contains(target)) continue;
+                        if (distanceToSink[node] - 1 != distanceToSink[target]) continue;
                         float revCap = reverseCapacity(edge);
                         float residual;
                         if (-revCap == flow[edge]) residual = 0f;

--- a/src/Compiler/Graphs/MinCut.cs
+++ b/src/Compiler/Graphs/MinCut.cs
@@ -166,15 +166,14 @@ namespace Microsoft.ML.Probabilistic.Compiler.Graphs
                 {
                     // discharge this node
                     // find an admissible edge
-                    // an edge is admissible if neither endpoint is in the sourceGroup, distanceToSink(source)=distanceToSink(target)+1, and residual capacity>0
+                    // an edge is admissible if neither endpoint is in the sourceGroup (unless target is a sink), distanceToSink(source)=distanceToSink(target)+1, and residual capacity>0
                     foreach (EdgeType edge in graph.EdgesOutOf(node))
                     {
                         NodeType target = graph.TargetOf(edge);
                         bool isSinkEdge = IsSinkEdge(edge);
-                        if (sourceGroup.Contains(target)) continue;
                         int distTarget = isSinkEdge ? 0 : distanceToSink[target];
                         if (distanceToSink[node] - 1 != distTarget) continue;
-                        // target cannot be in sourceGroup since their distances are huge
+                        // target can be in sourceGroup if it is a sink
                         float cap = capacity(edge);
                         float residual;
                         if (cap == flow[edge]) residual = 0f; // avoid infinity-infinity
@@ -199,8 +198,9 @@ namespace Microsoft.ML.Probabilistic.Compiler.Graphs
                     foreach (EdgeType edge in graph.EdgesInto(node))
                     {
                         NodeType target = graph.SourceOf(edge);
-                        if (sourceGroup.Contains(target)) continue;
                         if (distanceToSink[node] - 1 != distanceToSink[target]) continue;
+                        // if target is both a source and sink, its distanceToSink will be zero, but we cannot push flow backward into it
+                        if (Sources.Contains(target)) continue;
                         float revCap = reverseCapacity(edge);
                         float residual;
                         if (-revCap == flow[edge]) residual = 0f;

--- a/src/Compiler/Graphs/MinCut.cs
+++ b/src/Compiler/Graphs/MinCut.cs
@@ -172,7 +172,8 @@ namespace Microsoft.ML.Probabilistic.Compiler.Graphs
                         NodeType target = graph.TargetOf(edge);
                         bool isSinkEdge = IsSinkEdge(edge);
                         if (sourceGroup.Contains(target)) continue;
-                        if (distanceToSink[node] - 1 != distanceToSink[target]) continue;
+                        int distTarget = isSinkEdge ? 0 : distanceToSink[target];
+                        if (distanceToSink[node] - 1 != distTarget) continue;
                         // target cannot be in sourceGroup since their distances are huge
                         float cap = capacity(edge);
                         float residual;

--- a/src/Compiler/Graphs/MinCut.cs
+++ b/src/Compiler/Graphs/MinCut.cs
@@ -171,7 +171,9 @@ namespace Microsoft.ML.Probabilistic.Compiler.Graphs
                     {
                         NodeType target = graph.TargetOf(edge);
                         bool isSinkEdge = IsSinkEdge(edge);
-                        int distTarget = isSinkEdge ? 0 : distanceToSink[target];
+
+                        // Long to avoid overflow.
+                        long distTarget = isSinkEdge ? 0 : distanceToSink[target];
                         if (distanceToSink[node] != distTarget + 1) continue;
                         // target cannot be in sourceGroup since their distances are huge
                         float cap = capacity(edge);
@@ -198,7 +200,11 @@ namespace Microsoft.ML.Probabilistic.Compiler.Graphs
                     foreach (EdgeType edge in graph.EdgesInto(node))
                     {
                         NodeType target = graph.SourceOf(edge);
-                        if (distanceToSink[node] != distanceToSink[target] + 1) continue;
+
+                        // Long to avoid overflow
+                        long nodeDistanceToSink = distanceToSink[node];
+                        long targetDistanceToSink = distanceToSink[target];
+                        if (nodeDistanceToSink != targetDistanceToSink + 1) continue;
                         // target cannot be in sourceGroup since their distances are huge,
                         // unless it is both a source and sink.
                         if (Sources.Contains(target)) continue;

--- a/src/Compiler/Infer/Transforms/DependencyGraph.cs
+++ b/src/Compiler/Infer/Transforms/DependencyGraph.cs
@@ -1581,13 +1581,13 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             if (findloops)
             {
                 dfs.BackEdge += delegate (Edge<NodeIndex> edge)
-                {
-                    FindLoop(node, FreshTargetsOf, nodeData, "needs a fresh");
-                    //Console.WriteLine("{0} triggers {1}", edge.Source, edge.Target);
-                    //Console.WriteLine(StringUtil.JoinColumns("[" + edge.Source + "] ", NodeToString(edge.Source)));
-                    //Console.WriteLine(StringUtil.JoinColumns("[" + edge.Target + "] ", NodeToString(edge.Target)));
-                    throw new Exception("The model has a loop of fresh edges");
-                };
+                    {
+                        FindLoop(node, FreshTargetsOf, nodeData, "needs a fresh");
+                        //Console.WriteLine("{0} triggers {1}", edge.Source, edge.Target);
+                        //Console.WriteLine(StringUtil.JoinColumns("[" + edge.Source + "] ", NodeToString(edge.Source)));
+                        //Console.WriteLine(StringUtil.JoinColumns("[" + edge.Target + "] ", NodeToString(edge.Target)));
+                        throw new Exception("The model has a loop of fresh edges");
+                    };
             }
             dfs.SearchFrom(node);
         }
@@ -1615,10 +1615,10 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             dfs.ClearActions();
             dfs.TreeEdge += delegate (Edge<NodeIndex> edge) { action(edge.Target); };
             dfs.BackEdge += delegate (Edge<NodeIndex> edge)
-            {
-                FindLoop(trigger, TriggeesOf, nodeData, "is triggered by");
-                throw new Exception("The model has a loop of deterministic edges, which is not allowed by Variational Message Passing.");
-            };
+                {
+                    FindLoop(trigger, TriggeesOf, nodeData, "is triggered by");
+                    throw new Exception("The model has a loop of deterministic edges, which is not allowed by Variational Message Passing.");
+                };
             dfs.SearchFrom(trigger);
         }
 
@@ -1678,22 +1678,22 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             DepthFirstSearch<NodeIndex> dfs = new DepthFirstSearch<NodeIndex>(successors, data);
             dfs.TreeEdge += delegate (Edge<NodeIndex> edge) { parent[edge.Target] = edge.Source; };
             dfs.BackEdge += delegate (Edge<NodeIndex> edge)
-            {
-                if (!found)
                 {
-                    found = true;
-                    NodeIndex target = edge.Target;
-                    Console.WriteLine("{0} {2} {1}", edge.Target, edge.Source, message);
-                    Console.WriteLine(StringUtil.JoinColumns("[" + edge.Target + "] ", NodeToString(edge.Target)));
-                    NodeIndex node = edge.Source;
-                    while (!node.Equals(target))
+                    if (!found)
                     {
-                        Console.WriteLine("{0} {2} {1}", node, parent[node], message);
-                        Console.WriteLine(StringUtil.JoinColumns("[" + node + "] ", NodeToString(node)));
-                        node = parent[node];
+                        found = true;
+                        NodeIndex target = edge.Target;
+                        Console.WriteLine("{0} {2} {1}", edge.Target, edge.Source, message);
+                        Console.WriteLine(StringUtil.JoinColumns("[" + edge.Target + "] ", NodeToString(edge.Target)));
+                        NodeIndex node = edge.Source;
+                        while (!node.Equals(target))
+                        {
+                            Console.WriteLine("{0} {2} {1}", node, parent[node], message);
+                            Console.WriteLine(StringUtil.JoinColumns("[" + node + "] ", NodeToString(node)));
+                            node = parent[node];
+                        }
                     }
-                }
-            };
+                };
             dfs.SearchFrom(start);
         }
 

--- a/src/Compiler/Infer/Transforms/DependencyGraph.cs
+++ b/src/Compiler/Infer/Transforms/DependencyGraph.cs
@@ -720,12 +720,10 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
                         {
                             if (anyCounter > 8)
                                 throw new NotSupportedException("Method has > 8 SkipIfAllUniform annotations");
-                            unchecked
-                            {
-                                byte bit = (byte)(1 << (anyCounter - 1));
-                                // when a required node is missing and not labelled uniform, assume that it is available.  thus this bit is no longer required.
-                                requiredBits[targetIndex] &= (byte)~bit;
-                            }
+                            byte bit = (byte)(1 << (anyCounter - 1));
+                            // when a required node is missing and not labelled uniform, assume that it is available.  thus this bit is no longer required.
+                            // unchecked is required because the "~" operator returns an int, which then overflows when casting to a byte.
+                            requiredBits[targetIndex] &= unchecked((byte)~bit);
                             // no need to consider rest of the AnyStatement
                             return true;
                         }

--- a/src/Runtime/Core/Utils/Hash.cs
+++ b/src/Runtime/Core/Utils/Hash.cs
@@ -67,10 +67,13 @@ namespace Microsoft.ML.Probabilistic.Utilities
         /// <returns>Incorporates the second hash key into the first hash key and returns the new, combined hash key</returns>
         public static Int32 Combine(Int32 hash, Int32 key)
         {
-            hash = Combine(hash, (byte) key);
-            hash = Combine(hash, (byte) (key >> 8));
-            hash = Combine(hash, (byte) (key >> 16));
-            hash = Combine(hash, (byte) (key >> 24));
+            unchecked
+            {
+                hash = Combine(hash, (byte)key);
+                hash = Combine(hash, (byte)(key >> 8));
+                hash = Combine(hash, (byte)(key >> 16));
+                hash = Combine(hash, (byte)(key >> 24));
+            }
             return hash;
         }
 

--- a/src/Runtime/Distributions/QuantileEstimator.cs
+++ b/src/Runtime/Distributions/QuantileEstimator.cs
@@ -674,33 +674,36 @@ namespace Microsoft.ML.Probabilistic.Distributions
             {
                 var rand = new SerializableRandom();
 
-                int ii;
-                int mj, mk;
+                unchecked
+                {
+                    int ii;
+                    int mj, mk;
 
-                int subtraction = (seed == Int32.MinValue) ? Int32.MaxValue : Math.Abs(seed);
-                mj = MSEED - subtraction;
-                rand.seedArray[55] = mj;
-                mk = 1;
-                for (int i = 1; i < 55; i++)
-                {
-                    ii = (21 * i) % 55;
-                    rand.seedArray[ii] = mk;
-                    mk = mj - mk;
-                    if (mk < 0) mk += MBIG;
-                    mj = rand.seedArray[ii];
-                }
-                for (int k = 1; k < 5; k++)
-                {
-                    for (int i = 1; i < 56; i++)
+                    int subtraction = (seed == Int32.MinValue) ? Int32.MaxValue : Math.Abs(seed);
+                    mj = MSEED - subtraction;
+                    rand.seedArray[55] = mj;
+                    mk = 1;
+                    for (int i = 1; i < 55; i++)
                     {
-                        rand.seedArray[i] -= rand.seedArray[1 + (i + 30) % 55];
-                        if (rand.seedArray[i] < 0) rand.seedArray[i] += MBIG;
+                        ii = (21 * i) % 55;
+                        rand.seedArray[ii] = mk;
+                        mk = mj - mk;
+                        if (mk < 0) mk += MBIG;
+                        mj = rand.seedArray[ii];
                     }
-                }
-                rand.inext = 0;
-                rand.inextp = 21;
+                    for (int k = 1; k < 5; k++)
+                    {
+                        for (int i = 1; i < 56; i++)
+                        {
+                            rand.seedArray[i] -= rand.seedArray[1 + (i + 30) % 55];
+                            if (rand.seedArray[i] < 0) rand.seedArray[i] += MBIG;
+                        }
+                    }
+                    rand.inext = 0;
+                    rand.inextp = 21;
 
-                return rand;
+                    return rand;
+                }
             }
 
             double Sample()


### PR DESCRIPTION
Two of these (MinCut) are fixing unintended overflow.

Three of them (the rest) are just marking intended overflow with "unchecked".