### PR TITLE
Add .NET 7 check to runningOnNetCore assignment

### DIFF
--- a/src/Compiler/TransformFramework/CodeTransformer.cs
+++ b/src/Compiler/TransformFramework/CodeTransformer.cs
@@ -100,7 +100,8 @@ namespace Microsoft.ML.Probabilistic.Compiler
         protected string language = "C#";
         protected bool runningOnNetCore = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase)
             || System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 5", StringComparison.OrdinalIgnoreCase)
-            || System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 6", StringComparison.OrdinalIgnoreCase);
+            || System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 6", StringComparison.OrdinalIgnoreCase)
+            || System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 7", StringComparison.OrdinalIgnoreCase);
         protected bool runningOnMono = Type.GetType("Mono.Runtime") != null;
 
         /// <summary>


### PR DESCRIPTION
Fixes `CompilerChoice.Auto` choosing CodeDom on unsupported platforms when running .NET 7.