### PR TITLE
Add .net6.0-windows as a target

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -76,7 +76,7 @@ There are three test assemblies in the solution:
 - **TestPublic.dll** in the folder `test/TestPublic`.
 - **Microsoft.ML.Probabilistic.Learners.Tests.dll** in the folder `test/Learners/LearnersTests`. 
 
-Depending on the build configuration and targeted framework, the assemblies will be located in the `bin/Debug<Core|Full>/<net6.0|net462>` or `bin/Release<Core|Full>/<net6.0|net462>` subdirectories
+Depending on the build configuration and targeted framework, the assemblies will be located in the `bin/Debug<Core|Full>/<net6.0|net472>` or `bin/Release<Core|Full>/<net6.0|net472>` subdirectories
 of the test project.
 
 Runner executes tests in parallel by default. However, some test category must be run

--- a/build/all-compiler-options.yml
+++ b/build/all-compiler-options.yml
@@ -47,7 +47,7 @@ jobs:
       configuration: '$(Configuration)'
   
   - script: |
-      test\TestAllCompilerOptions\bin\$(Configuration)\net462\TestAllCompilerOptions.exe
+      test\TestAllCompilerOptions\bin\$(Configuration)\net472\TestAllCompilerOptions.exe
     displayName: 'Run test'
 
   # Clean up the process if the script timeout out.

--- a/build/copyassemblies.sh
+++ b/build/copyassemblies.sh
@@ -39,9 +39,9 @@ cp ../src/Learners/Recommender/${src}/Microsoft.ML.Probabilistic.Learners.Recomm
 cp ../src/Learners/Recommender/${src}/Microsoft.ML.Probabilistic.Learners.Recommender.pdb ${dst}
 cp ../src/Learners/Recommender/${src}/Microsoft.ML.Probabilistic.Learners.Recommender.xml ${dst}
 
-mkdir "${out}/net462"
-dst="${out}/net462"
-src="bin/${configuration}/net462"
+mkdir "${out}/net472"
+dst="${out}/net472"
+src="bin/${configuration}/net472"
 
 cp ../src/Visualizers/Windows/${src}/Microsoft.ML.Probabilistic.Compiler.Visualizers.Windows.dll ${dst}
 cp ../src/Visualizers/Windows/${src}/Microsoft.ML.Probabilistic.Compiler.Visualizers.Windows.pdb ${dst}

--- a/build/evaluator-netframework.yml
+++ b/build/evaluator-netframework.yml
@@ -14,6 +14,6 @@ steps:
   inputs:
     targetType: 'inline'
     script: ./Evaluator.exe InferNetRunsOnly.xml
-    workingDirectory: ${{ format('src/Learners/Runners/Evaluator/bin/{0}/net462', parameters.Configuration) }}
+    workingDirectory: ${{ format('src/Learners/Runners/Evaluator/bin/{0}/net472', parameters.Configuration) }}
     displayName: Running Evaluator
     continueOnError: true

--- a/build/vstest-fast.yml
+++ b/build/vstest-fast.yml
@@ -14,7 +14,7 @@ steps:
       displayName: Unit tests x64 (sequential)
       inputs:
         testSelector: 'testAssemblies'
-        testAssemblyVer2: test/Tests/bin/*/net462/Microsoft.ML.Probabilistic.Tests.dll
+        testAssemblyVer2: test/Tests/bin/*/net472/Microsoft.ML.Probabilistic.Tests.dll
         testFiltercriteria: '(Platform!=x86)&(((Category=CsoftModel)|(Category=ModifiesGlobals)|(Category=DistributedTests)|(Category=Performance))&(Category!=OpenBug)&(Category!=BadTest)&(Category!=CompilerOptionsTest))' 
         runInParallel: false
         runSettingsFile: test.runsettings
@@ -23,9 +23,9 @@ steps:
       inputs:
         testSelector: 'testAssemblies'
         testAssemblyVer2: |
-          test/Tests/bin/*/net462/Microsoft.ML.Probabilistic.Tests.dll
-          test/Learners/LearnersTests/bin/*/net462/Microsoft.ML.Probabilistic.Learners.Tests.dll
-          test/TestPublic/bin/*/net462/TestPublic.dll
+          test/Tests/bin/*/net472/Microsoft.ML.Probabilistic.Tests.dll
+          test/Learners/LearnersTests/bin/*/net472/Microsoft.ML.Probabilistic.Learners.Tests.dll
+          test/TestPublic/bin/*/net472/TestPublic.dll
         testFiltercriteria: '(Platform!=x86)&(Category!=OpenBug)&(Category!=BadTest)&(Category!=CompilerOptionsTest)&(Category!=CsoftModel)&(Category!=ModifiesGlobals)&(Category!=DistributedTest)&(Category!=Performance)' 
         runInParallel: true
         runSettingsFile: test.runsettings
@@ -35,7 +35,7 @@ steps:
       displayName: Unit tests x86 (sequential)
       inputs:
         testSelector: 'testAssemblies'
-        testAssemblyVer2: test/Tests/bin/*/net462/Microsoft.ML.Probabilistic.Tests.dll
+        testAssemblyVer2: test/Tests/bin/*/net472/Microsoft.ML.Probabilistic.Tests.dll
         testFiltercriteria: '(Platform!=x64)&(((Category=CsoftModel)|(Category=ModifiesGlobals)|(Category=DistributedTests)|(Category=Performance))&(Category!=OpenBug)&(Category!=BadTest)&(Category!=CompilerOptionsTest))' 
         runInParallel: false
         runSettingsFile: x86.runsettings
@@ -44,9 +44,9 @@ steps:
       inputs:
         testSelector: 'testAssemblies'
         testAssemblyVer2: |
-          test/Tests/bin/*/net462/Microsoft.ML.Probabilistic.Tests.dll
-          test/Learners/LearnersTests/bin/*/net462/Microsoft.ML.Probabilistic.Learners.Tests.dll
-          test/TestPublic/bin/*/net462/TestPublic.dll
+          test/Tests/bin/*/net472/Microsoft.ML.Probabilistic.Tests.dll
+          test/Learners/LearnersTests/bin/*/net472/Microsoft.ML.Probabilistic.Learners.Tests.dll
+          test/TestPublic/bin/*/net472/TestPublic.dll
         testFiltercriteria: '(Platform!=x64)&(Category!=OpenBug)&(Category!=BadTest)&(Category!=CompilerOptionsTest)&(Category!=CsoftModel)&(Category!=ModifiesGlobals)&(Category!=DistributedTest)&(Category!=Performance)' 
         runInParallel: true
         runSettingsFile: x86.runsettings

--- a/src/Examples/ClickThroughModel/ClickThroughModel.csproj
+++ b/src/Examples/ClickThroughModel/ClickThroughModel.csproj
@@ -12,7 +12,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -22,7 +22,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0-windows;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Examples/ClinicalTrial/ClinicalTrial.csproj
+++ b/src/Examples/ClinicalTrial/ClinicalTrial.csproj
@@ -13,7 +13,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -23,7 +23,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0-windows;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Examples/Crowdsourcing/Crowdsourcing.csproj
+++ b/src/Examples/Crowdsourcing/Crowdsourcing.csproj
@@ -12,7 +12,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -22,7 +22,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Examples/CrowdsourcingWithWords/CrowdsourcingWithWords.csproj
+++ b/src/Examples/CrowdsourcingWithWords/CrowdsourcingWithWords.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\build\common.props" />
 
   <PropertyGroup>
@@ -11,7 +11,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -21,7 +21,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Examples/ImageClassifier/Image_Classifier.csproj
+++ b/src/Examples/ImageClassifier/Image_Classifier.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <Configurations>Debug;DebugFull;DebugCore;Release;ReleaseFull;ReleaseCore</Configurations>
     <Prefer32Bit>false</Prefer32Bit>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Examples/InferNET101/InferNET101.csproj
+++ b/src/Examples/InferNET101/InferNET101.csproj
@@ -11,7 +11,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -21,7 +21,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Examples/LDA/LDA.csproj
+++ b/src/Examples/LDA/LDA.csproj
@@ -13,7 +13,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -23,7 +23,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Examples/MontyHall/MontyHall.csproj
+++ b/src/Examples/MontyHall/MontyHall.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <Configurations>Debug;DebugFull;DebugCore;Release;ReleaseFull;ReleaseCore</Configurations>
     <Prefer32Bit>false</Prefer32Bit>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Examples/MotifFinder/MotifFinder.csproj
+++ b/src/Examples/MotifFinder/MotifFinder.csproj
@@ -13,7 +13,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -23,7 +23,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Examples/ReviewerCalibration/ReviewerCalibration.csproj
+++ b/src/Examples/ReviewerCalibration/ReviewerCalibration.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\build\common.props" />
 
   <PropertyGroup>
@@ -12,7 +12,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -22,7 +22,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Examples/RobustGaussianProcess/RobustGaussianProcess.csproj
+++ b/src/Examples/RobustGaussianProcess/RobustGaussianProcess.csproj
@@ -15,7 +15,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -28,10 +28,10 @@
     </When>
     <Otherwise>
     	<PropertyGroup Condition="'$(IsWindows)'=='true'">
-        <TargetFrameworks>net6.0-windows;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
       </PropertyGroup>
 		  <PropertyGroup Condition="'$(IsWindows)'!='true'">
-			  <TargetFramework>net6.0;net462</TargetFramework>
+			  <TargetFramework>net6.0;net472</TargetFramework>
 		  </PropertyGroup>
 	  </Otherwise>
   </Choose>

--- a/src/Learners/ClassifierModels/ClassifierModels.csproj
+++ b/src/Learners/ClassifierModels/ClassifierModels.csproj
@@ -14,7 +14,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net6.0-windows</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -24,7 +24,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net6.0-windows;net472</TargetFrameworks>
         <!-- No need to generate code twice -->
         <IgnorePostBuildNetCore>true</IgnorePostBuildNetCore>
       </PropertyGroup>
@@ -35,7 +35,10 @@
     <RunPostBuildNetCore Condition="$(IgnorePostBuildNetCore) != 'true'">true</RunPostBuildNetCore>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0-windows'">
+    <RunPostBuildNetFull>true</RunPostBuildNetFull>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472'">
     <RunPostBuildNetFull>true</RunPostBuildNetFull>
   </PropertyGroup>
 
@@ -68,7 +71,7 @@
     <ProjectReference Include="..\..\Runtime\Runtime.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(DefineConstants.Contains('NETFRAMEWORK'))">
+  <ItemGroup Condition="$(DefineConstants.Contains('NETFRAMEWORK')) OR $(TargetFramework.Contains('windows'))">
     <ProjectReference Include="..\..\Visualizers\Windows\Visualizers.Windows.csproj" />
   </ItemGroup>
 

--- a/src/Learners/ClassifierModels/ClassifierModels.csproj
+++ b/src/Learners/ClassifierModels/ClassifierModels.csproj
@@ -14,7 +14,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net6.0-windows</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -35,10 +35,7 @@
     <RunPostBuildNetCore Condition="$(IgnorePostBuildNetCore) != 'true'">true</RunPostBuildNetCore>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0-windows'">
-    <RunPostBuildNetFull>true</RunPostBuildNetFull>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0-windows' OR '$(TargetFramework)' == 'net472'">
     <RunPostBuildNetFull>true</RunPostBuildNetFull>
   </PropertyGroup>
 

--- a/src/Learners/ClassifierModels/ClassifierModels.csproj
+++ b/src/Learners/ClassifierModels/ClassifierModels.csproj
@@ -81,10 +81,10 @@
   </ItemGroup>
 
   <Target Name="PostBuildNetFull" AfterTargets="PostBuildEvent" Condition="'$(RunPostBuildNetFull)' == 'true'">
-    <Exec Command="&quot;$(TargetPath)&quot; &quot;$([System.IO.Path]::Combine($(SolutionDir),'src', 'Learners', 'Classifier', 'BayesPointMachineClassifierInternal', 'GeneratedAlgorithms'))&quot;" />
+    <Exec Command="&quot;$(TargetPath.Replace('.dll', '.exe'))&quot; &quot;$([System.IO.Path]::Combine($(SolutionDir),'src', 'Learners', 'Classifier', 'BayesPointMachineClassifierInternal', 'GeneratedAlgorithms'))&quot;" />
   </Target>
 
   <Target Name="PostBuildNetCore" AfterTargets="PostBuildEvent" Condition="'$(RunPostBuildNetCore)' == 'true'">
-    <Exec Command="dotnet &quot;$(TargetPath)&quot; &quot;$([System.IO.Path]::Combine($(SolutionDir),'src', 'Learners', 'Classifier', 'BayesPointMachineClassifierInternal', 'GeneratedAlgorithms'))&quot;" />
+    <Exec Command="dotnet &quot;$(TargetPath.Replace('.dll', '.exe'))&quot; &quot;$([System.IO.Path]::Combine($(SolutionDir),'src', 'Learners', 'Classifier', 'BayesPointMachineClassifierInternal', 'GeneratedAlgorithms'))&quot;" />
   </Target>
 </Project>

--- a/src/Learners/ClassifierModels/ClassifierModels.csproj
+++ b/src/Learners/ClassifierModels/ClassifierModels.csproj
@@ -82,6 +82,6 @@
   </Target>
 
   <Target Name="PostBuildNetCore" AfterTargets="PostBuildEvent" Condition="'$(RunPostBuildNetCore)' == 'true'">
-    <Exec Command="dotnet &quot;$(TargetPath.Replace('.dll', '.exe'))&quot; &quot;$([System.IO.Path]::Combine($(SolutionDir),'src', 'Learners', 'Classifier', 'BayesPointMachineClassifierInternal', 'GeneratedAlgorithms'))&quot;" />
+    <Exec Command="dotnet &quot;$(TargetPath)&quot; &quot;$([System.IO.Path]::Combine($(SolutionDir),'src', 'Learners', 'Classifier', 'BayesPointMachineClassifierInternal', 'GeneratedAlgorithms'))&quot;" />
   </Target>
 </Project>

--- a/src/Learners/ClassifierModels/Program.cs
+++ b/src/Learners/ClassifierModels/Program.cs
@@ -34,7 +34,7 @@ namespace Microsoft.ML.Probabilistic.Learners.BayesPointMachineClassifierInterna
                 Trace.Listeners.Add(new TextWriterTraceListener(logWriter));
                 Debug.AutoFlush = true;
                 Trace.AutoFlush = true;
-#if NETFRAMEWORK
+#if NETFRAMEWORK || WINDOWS
                 Models.InferenceEngine.Visualizer = new WindowsVisualizer();
 #endif
                 Models.InferenceEngine.DefaultEngine.Compiler.BrowserMode = Compiler.BrowserMode.Always;

--- a/src/Learners/ClassifierModels/Properties/launchSettings.json
+++ b/src/Learners/ClassifierModels/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ClassifierModels": {
       "commandName": "Project",
-      "commandLineArgs": "."
+      "commandLineArgs": "\"C:\\Users\\jonat\\source\\repos\\TrueSkill2\\Infer.NET\\src\\Learners\\Classifier\\BayesPointMachineClassifierInternal\\GeneratedAlgorithms\""
     }
   }
 }

--- a/src/Learners/ClassifierModels/Properties/launchSettings.json
+++ b/src/Learners/ClassifierModels/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ClassifierModels": {
       "commandName": "Project",
-      "commandLineArgs": "\"C:\\Users\\jonat\\source\\repos\\TrueSkill2\\Infer.NET\\src\\Learners\\Classifier\\BayesPointMachineClassifierInternal\\GeneratedAlgorithms\""
+      "commandLineArgs": "."
     }
   }
 }

--- a/src/Learners/RecommenderModels/RecommenderModels.csproj
+++ b/src/Learners/RecommenderModels/RecommenderModels.csproj
@@ -14,7 +14,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -24,7 +24,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
         <!-- No need to generate code twice -->
         <IgnorePostBuildNetCore>true</IgnorePostBuildNetCore>
       </PropertyGroup>
@@ -35,7 +35,7 @@
     <RunPostBuildNetCore Condition="$(IgnorePostBuildNetCore) != 'true'">true</RunPostBuildNetCore>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472'">
     <RunPostBuildNetFull>true</RunPostBuildNetFull>
   </PropertyGroup>
 

--- a/src/Learners/Runners/CommandLine/CommandLine.csproj
+++ b/src/Learners/Runners/CommandLine/CommandLine.csproj
@@ -13,7 +13,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -23,7 +23,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Learners/Runners/Evaluator/Evaluator.csproj
+++ b/src/Learners/Runners/Evaluator/Evaluator.csproj
@@ -15,7 +15,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -25,7 +25,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/src/Tutorials/ExamplesBrowser.cs
+++ b/src/Tutorials/ExamplesBrowser.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ML.Probabilistic.Tutorials
         /// </summary>
         public static void RunBrowser() // Must not be called "Run"
         {
-#if NETFRAMEWORK
+#if NETFRAMEWORK || WINDOWS
             InferenceEngine.Visualizer = new Compiler.Visualizers.WindowsVisualizer();
             // Show all tutorials, in a browser
             IAlgorithm[] algs = InferenceEngine.GetBuiltInAlgorithms();

--- a/src/Tutorials/ExamplesBrowser.cs
+++ b/src/Tutorials/ExamplesBrowser.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ML.Probabilistic.Tutorials
     public class ExamplesBrowser
     {
         /// <summary>
-        /// Pop up a window for running examples, when compiled with .NET 4.6.2 or higher, then exit the application.  Otherwise do nothing.
+        /// Pop up a window for running examples, when targeting Windows, then exit the application.  Otherwise do nothing.
         /// </summary>
         public static void RunBrowser() // Must not be called "Run"
         {

--- a/src/Tutorials/ExamplesViewer.cs
+++ b/src/Tutorials/ExamplesViewer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NETFRAMEWORK || WINDOWS
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -906,3 +907,4 @@ namespace Microsoft.ML.Probabilistic.Tutorials
         }
     }
 }
+#endif

--- a/src/Tutorials/ExamplesViewer.cs
+++ b/src/Tutorials/ExamplesViewer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETFRAMEWORK || WINDOWS
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -907,4 +906,3 @@ namespace Microsoft.ML.Probabilistic.Tutorials
         }
     }
 }
-#endif

--- a/src/Tutorials/Tutorials.csproj
+++ b/src/Tutorials/Tutorials.csproj
@@ -15,7 +15,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net6.0-windows</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -25,7 +25,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net6.0-windows;net472</TargetFrameworks>
         <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
       </PropertyGroup>
     </Otherwise>
@@ -51,14 +51,15 @@
   <ItemGroup Condition="$(DefineConstants.Contains('NETFRAMEWORK'))">
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+  <ItemGroup Condition="$(DefineConstants.Contains('NETFRAMEWORK')) OR $(TargetFramework.Contains('windows'))">
     <ProjectReference Include="..\Visualizers\Windows\Visualizers.Windows.csproj" />
     <Compile Update="ExamplesViewer.cs">
       <SubType>UserControl</SubType>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="$(DefineConstants.Contains('NETCOREAPP'))">
-    <Compile Remove="ExamplesViewer.cs">
-    </Compile>
+  <ItemGroup Condition="$(TargetFramework.Contains('windows'))">
+    <ProjectReference Include="..\Visualizers\Windows\Visualizers.Windows.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="BayesianPCA.cs">

--- a/src/Tutorials/Tutorials.csproj
+++ b/src/Tutorials/Tutorials.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildThisFileDirectory)..\..\build\common.props" />
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>Tutorials</AssemblyName>
@@ -52,15 +51,25 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
-  <ItemGroup Condition="$(DefineConstants.Contains('NETFRAMEWORK')) OR $(TargetFramework.Contains('windows'))">
-    <ProjectReference Include="..\Visualizers\Windows\Visualizers.Windows.csproj" />
-    <Compile Update="ExamplesViewer.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.Contains('windows'))">
-    <ProjectReference Include="..\Visualizers\Windows\Visualizers.Windows.csproj" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="$(TargetFramework) == 'net472' OR $(TargetFramework) == 'net6.0-windows'">
+      <ItemGroup>
+        <ProjectReference Include="..\Visualizers\Windows\Visualizers.Windows.csproj" />
+        <Compile Update="ExamplesViewer.cs">
+          <SubType>UserControl</SubType>
+        </Compile>
+        <EmbeddedResource Update="ExamplesViewer.resx">
+          <DependentUpon>ExamplesViewer.cs</DependentUpon>
+        </EmbeddedResource>
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Compile Remove="ExamplesViewer.cs" />
+        <EmbeddedResource Remove="ExamplesViewer.resx" />
+      </ItemGroup>  
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <Compile Update="BayesianPCA.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -135,8 +144,5 @@
     <Content Include="Infer.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <EmbeddedResource Update="ExamplesViewer.resx">
-      <DependentUpon>ExamplesViewer.cs</DependentUpon>
-    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/src/Tutorials/Tutorials.csproj
+++ b/src/Tutorials/Tutorials.csproj
@@ -15,7 +15,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net6.0-windows</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">

--- a/src/Visualizers/Windows/Visualizers.Windows.csproj
+++ b/src/Visualizers/Windows/Visualizers.Windows.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Description>Infer.NET is a framework for running Bayesian inference in graphical models. It can also be used for probabilistic programming. This package contains visualization tools for exploring and analyzing models on Windows platform.</Description>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
     <AssemblyName>Microsoft.ML.Probabilistic.Compiler.Visualizers.Windows</AssemblyName>
     <PackageId>Microsoft.ML.Probabilistic.Visualizers.Windows$(NuGetPackageIdSuffix)</PackageId>
     <DefineConstants>TRACE;SUPPRESS_XMLDOC_WARNINGS, SUPPRESS_UNREACHABLE_CODE_WARNINGS, SUPPRESS_AMBIGUOUS_REFERENCE_WARNINGS</DefineConstants>
@@ -27,9 +27,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Msagl" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Msagl.Drawing" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Msagl.GraphViewerGdi" Version="1.1.1" />
+    <PackageReference Include="AutomaticGraphLayout" Version="1.1.12" />
+    <PackageReference Include="AutomaticGraphLayout.Drawing" Version="1.1.12" />
+    <PackageReference Include="AutomaticGraphLayout.GraphViewerGDI" Version="1.1.12" />
   </ItemGroup>
 
   <PropertyGroup Condition=" $(DefineConstants.Contains('INCLUDE_TRANSFORM_BROWSER'))">

--- a/test/Learners/LearnersTests/LearnersTests.csproj
+++ b/test/Learners/LearnersTests/LearnersTests.csproj
@@ -10,7 +10,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -20,7 +20,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/test/Learners/LearnersTests/Test.bat
+++ b/test/Learners/LearnersTests/Test.bat
@@ -4,7 +4,7 @@
 @echo on
 
 set CONFIGURATION=Debug
-set TARGET_PLATFORM=net462
+set TARGET_PLATFORM=net472
 set RUN_DIR=bin\%CONFIGURATION%\%TARGET_PLATFORM%
 set RUNNER=%RUN_DIR%\Learner.exe Recommender
 set DATA=..\Runners\Evaluator\Data\Recommendation\MovieLens.dat

--- a/test/Learners/TestApp/TestApp.csproj
+++ b/test/Learners/TestApp/TestApp.csproj
@@ -13,7 +13,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -23,7 +23,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/test/TestAllCompilerOptions/TestAllCompilerOptions.csproj
+++ b/test/TestAllCompilerOptions/TestAllCompilerOptions.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configurations>Debug;Release;DebugFull;ReleaseFull</Configurations>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -48,9 +48,7 @@ namespace TestApp
             Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
             var logWriter = new StreamWriter("debug.txt");
             Trace.Listeners.Add(new TextWriterTraceListener(logWriter));
-#if NETFRAMEWORK
-            InferenceEngine.Visualizer = new WindowsVisualizer();
-#elif WINDOWS
+#if NETFRAMEWORK || WINDOWS
             InferenceEngine.Visualizer = new WindowsVisualizer();
 #endif
             Debug.AutoFlush = true;

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -50,6 +50,8 @@ namespace TestApp
             Trace.Listeners.Add(new TextWriterTraceListener(logWriter));
 #if NETFRAMEWORK
             InferenceEngine.Visualizer = new WindowsVisualizer();
+#elif WINDOWS
+            InferenceEngine.Visualizer = new WindowsVisualizer();
 #endif
             Debug.AutoFlush = true;
             Trace.AutoFlush = true;

--- a/test/TestApp/TestApp.csproj
+++ b/test/TestApp/TestApp.csproj
@@ -15,7 +15,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net6.0-windows</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">

--- a/test/TestApp/TestApp.csproj
+++ b/test/TestApp/TestApp.csproj
@@ -15,7 +15,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net6.0-windows</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -25,7 +25,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net6.0-windows;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -58,7 +58,7 @@
     <ProjectReference Include="..\TestPublic\TestPublic.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(DefineConstants.Contains('NETFRAMEWORK'))">
+  <ItemGroup Condition="$(DefineConstants.Contains('NETFRAMEWORK')) OR $(TargetFramework.Contains('windows'))">
     <ProjectReference Include="..\..\src\Visualizers\Windows\Visualizers.Windows.csproj" />
   </ItemGroup>
 

--- a/test/TestFSharp/TestFSharp.fsproj
+++ b/test/TestFSharp/TestFSharp.fsproj
@@ -24,7 +24,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net50;net472</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/test/TestPublic/TestPublic.csproj
+++ b/test/TestPublic/TestPublic.csproj
@@ -12,7 +12,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net6.0-windows</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -22,7 +22,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net6.0-windows;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/test/TestPublic/TestPublic.csproj
+++ b/test/TestPublic/TestPublic.csproj
@@ -12,7 +12,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net6.0-windows</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">

--- a/test/Tests/Tests.csproj
+++ b/test/Tests/Tests.csproj
@@ -13,7 +13,7 @@
   <Choose>
     <When Condition="'$(Configuration)'=='DebugFull' OR '$(Configuration)'=='ReleaseFull'">
       <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
       </PropertyGroup>
     </When>
     <When Condition="'$(Configuration)'=='DebugCore' OR '$(Configuration)'=='ReleaseCore'">
@@ -23,7 +23,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks>net6.0;net462</TargetFrameworks>
+        <TargetFrameworks>net6.0;net472</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
Add .net6.0-windows as a target so that Visualizer features are available on .NET 6.0 when targeting Windows (while preserving the cross-platform net6.0 target).

I have changed our minimum .NET 4xx dependency from net462 to net472 because this is the minimum version supported by the version of the automatic graph layout package that supports net6.0-windows.

It is possible to still use net462 and in this case to use the previous version of automatic graph layout; but the increased complexity doesn't seem worth it.