### PR TITLE
Fix Visualizer NuGet

### DIFF
--- a/src/Visualizers/Windows/Visualizers.Windows.csproj
+++ b/src/Visualizers/Windows/Visualizers.Windows.csproj
@@ -73,7 +73,7 @@
     resolves property values during packing; or to map these platforms to the target-framework paths used
     by the NuGet package format; so we list them explicitly here.
     -->
-    <None Include="bin\$(Configuration)\net6.0-windows\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net6.0-windows7.0\" />
-    <None Include="bin\$(Configuration)\net472\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net472\" />
+    <None Include="bin\Any CPU\$(Configuration)\net6.0-windows\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net6.0-windows7.0\" />
+    <None Include="bin\Any CPU\$(Configuration)\net472\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net472\" />
   </ItemGroup>
 </Project>

--- a/src/Visualizers/Windows/Visualizers.Windows.csproj
+++ b/src/Visualizers/Windows/Visualizers.Windows.csproj
@@ -54,7 +54,26 @@
     <ProjectReference Include="..\..\Compiler\Compiler.csproj" />
   </ItemGroup>
 
-    <PropertyGroup>
+  <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyNamePrefix)Microsoft.ML.Probabilistic.Compiler.Visualizers.Windows.xml</DocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+    NuGet's IncludeSymbols setting creates a separate symbols NuGet package, but we would like the
+    symbols included in the same package - hence this workaround.
+    -->
+    <!--
+    First we remove the entry that is added by nuget-properties.props that does not work here because
+    of the multiple target platforms.
+    -->
+    <None Remove="$(OutDir)$(AssemblyName).pdb" />
+    <!--
+    There isn't a convenient way right now to use the $(TargetPlatform) because of the manner NuGet
+    resolves property values during packing; or to map these platforms to the target-framework paths used
+    by the NuGet package format; so we list them explicitly here.
+    -->
+    <None Include="bin\$(Configuration)\net6.0-windows\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net6.0-windows7.0\" />
+    <None Include="bin\$(Configuration)\net472\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net472\" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
# problem
The way the ".pdb" is specified currently doesn't work for projects with multiple target platforms (OutDir is not populated).

# solution
Override the way we do it for other projects, and add entries for each target platform we have.