### PR TITLE
Update release pipeline

### DIFF
--- a/build/copyassemblies.sh
+++ b/build/copyassemblies.sh
@@ -46,3 +46,11 @@ src="bin/${configuration}/net472"
 cp ../src/Visualizers/Windows/${src}/Microsoft.ML.Probabilistic.Compiler.Visualizers.Windows.dll ${dst}
 cp ../src/Visualizers/Windows/${src}/Microsoft.ML.Probabilistic.Compiler.Visualizers.Windows.pdb ${dst}
 cp ../src/Visualizers/Windows/${src}/Microsoft.ML.Probabilistic.Compiler.Visualizers.Windows.xml ${dst}
+
+mkdir "${out}/net6.0-windows"
+dst="${out}/net6.0-windows"
+src="bin/${configuration}/net6.0-windows"
+
+cp ../src/Visualizers/Windows/${src}/Microsoft.ML.Probabilistic.Compiler.Visualizers.Windows.dll ${dst}
+cp ../src/Visualizers/Windows/${src}/Microsoft.ML.Probabilistic.Compiler.Visualizers.Windows.pdb ${dst}
+cp ../src/Visualizers/Windows/${src}/Microsoft.ML.Probabilistic.Compiler.Visualizers.Windows.xml ${dst}

--- a/build/release.yml
+++ b/build/release.yml
@@ -133,9 +133,9 @@ jobs:
       sourceFolder: $(Build.SourcesDirectory)/bin/obj/packages/VersionedAssemblies
       targetFolder: $(Build.SourcesDirectory)/bin/obj/packages  
 
-  # Install MicroBuild.Core
+  # Install Microsoft.VisualStudioEng.MicroBuild.Core
   - task: NuGetCommand@2
-    displayName: Install MicroBuild.Core
+    displayName: Install Microsoft.VisualStudioEng.MicroBuild.Core
     inputs:
       command: custom 
       arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core'

--- a/build/release.yml
+++ b/build/release.yml
@@ -138,7 +138,7 @@ jobs:
     displayName: Install MicroBuild.Core
     inputs:
       command: custom 
-      arguments: 'install MicroBuild.Core'
+      arguments: 'install Microsoft.VisualStudioEng.MicroBuild.Core'
 
   - task: MSBuild@1
     displayName: Sign Windows Binaries

--- a/build/release.yml
+++ b/build/release.yml
@@ -152,7 +152,7 @@ jobs:
     displayName: Get dotnet 6.x
     inputs:
       packageType: 'sdk'
-      version: '6.x'
+      version: '8.x'
 
   - task: DotNetCoreCLI@2
     displayName: Restore Infer.sln to enable packaging.

--- a/build/release.yml
+++ b/build/release.yml
@@ -107,6 +107,10 @@ jobs:
     name: VSEngSS-MicroBuild2022-1ES # For real signing
 
   steps:
+  - task: NuGetToolInstaller@1
+    inputs:
+      versionSpec: '>=6.9'
+
   # Install MicroBuild plugin
   - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
     displayName: Install MicroBuild Signing Plugin

--- a/build/release.yml
+++ b/build/release.yml
@@ -59,7 +59,7 @@ jobs:
 
   - task: NuGetToolInstaller@1
     inputs:
-      versionSpec: '>=5.5.1'
+      versionSpec: '>=6.9'
 
   - task: NuGetCommand@2
     displayName: 'Restoring NuGet packages'

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -4,7 +4,7 @@
     <PackageAssetsPath>$(RepoRoot)bin/obj/packages/</PackageAssetsPath>
     <PackageOutputPath>$(RepoRoot)bin/packages/</PackageOutputPath>
     <IntermediateOutputRootPath>$(RepoRoot)bin/obj/Release/</IntermediateOutputRootPath>
-    <MicroBuildToolsPath>$(RepoRoot)MicroBuild.Core.0.3.1\build\</MicroBuildToolsPath>
+    <MicroBuildToolsPath>$(RepoRoot)Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\</MicroBuildToolsPath>
   </PropertyGroup>
 
   <!-- This will be overridden if we're building with MicroBuild. -->

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -12,8 +12,8 @@
     <Message Text="Attempting to sign %(FilesToSign.Identity) with authenticode='%(FilesToSign.Authenticode)'" />
   </Target>
 
-  <Import Project="$(MicroBuildToolsPath)MicroBuild.Core.props" />
-  <Import Project="$(MicroBuildToolsPath)MicroBuild.Core.targets" />
+  <Import Project="$(MicroBuildToolsPath)Microsoft.VisualStudioEng.MicroBuild.Core.props" />
+  <Import Project="$(MicroBuildToolsPath)Microsoft.VisualStudioEng.MicroBuild.Core.targets" />
 
   <Target Name="SetSigningProperties">
     <PropertyGroup>

--- a/src/Visualizers/Windows/Visualizers.Windows.csproj
+++ b/src/Visualizers/Windows/Visualizers.Windows.csproj
@@ -73,7 +73,9 @@
     resolves property values during packing; or to map these platforms to the target-framework paths used
     by the NuGet package format; so we list them explicitly here.
     -->
-    <None Include="bin\Any CPU\$(Configuration)\net6.0-windows\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net6.0-windows7.0\" />
-    <None Include="bin\Any CPU\$(Configuration)\net472\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net472\" />
+    <!--<None Include="bin\Any CPU\$(Configuration)\net6.0-windows\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net6.0-windows7.0\" />
+    <None Include="bin\Any CPU\$(Configuration)\net472\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net472\" />-->
+    <None Include="$(OutDir)..\net6.0-windows\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net6.0-windows7.0\" />
+    <None Include="$(OutDir)..\net472\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net472\" />
   </ItemGroup>
 </Project>

--- a/src/Visualizers/Windows/Visualizers.Windows.csproj
+++ b/src/Visualizers/Windows/Visualizers.Windows.csproj
@@ -73,8 +73,6 @@
     resolves property values during packing; or to map these platforms to the target-framework paths used
     by the NuGet package format; so we list them explicitly here.
     -->
-    <!--<None Include="bin\Any CPU\$(Configuration)\net6.0-windows\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net6.0-windows7.0\" />
-    <None Include="bin\Any CPU\$(Configuration)\net472\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net472\" />-->
     <None Include="$(BaseOutputPath)\net6.0-windows\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net6.0-windows7.0\" />
     <None Include="$(BaseOutputPath)\net472\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net472\" />
   </ItemGroup>

--- a/src/Visualizers/Windows/Visualizers.Windows.csproj
+++ b/src/Visualizers/Windows/Visualizers.Windows.csproj
@@ -75,7 +75,7 @@
     -->
     <!--<None Include="bin\Any CPU\$(Configuration)\net6.0-windows\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net6.0-windows7.0\" />
     <None Include="bin\Any CPU\$(Configuration)\net472\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net472\" />-->
-    <None Include="$(OutDir)..\net6.0-windows\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net6.0-windows7.0\" />
-    <None Include="$(OutDir)..\net472\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net472\" />
+    <None Include="$(BaseOutputPath)\net6.0-windows\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net6.0-windows7.0\" />
+    <None Include="$(BaseOutputPath)\net472\$(AssemblyName).pdb" Pack="true" PackagePath="\lib\net472\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Changes to the release framework and the addition of the net6.0-windows target require updates to the release pipeline.