### PR TITLE
FastSumOp.ArrayAverageConditional handles nearly improper sums

### DIFF
--- a/src/Compiler/Infer/InferenceException.cs
+++ b/src/Compiler/Infer/InferenceException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.ML.Probabilistic.Compiler
+{
+    public class InferenceException : Exception
+    {
+        public string loopVariable;
+        public int loopIndex;
+        public int iteration;
+
+        public InferenceException(string loopVariable, int loopIndex, int iteration, Exception exception)
+            : base($"Inference failed at iteration {iteration}, {loopVariable}={loopIndex}", exception)
+        {
+            this.loopVariable = loopVariable;
+            this.loopIndex = loopIndex;
+            this.iteration = iteration;
+        }
+    }
+}

--- a/src/Compiler/Infer/ModelCompiler.cs
+++ b/src/Compiler/Infer/ModelCompiler.cs
@@ -979,7 +979,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
             tc.AddTransform(new LocalTransform(this));
             if (OptimiseInferenceCode)
                 tc.AddTransform(new DeadCode2Transform(this));
-            tc.AddTransform(new ParallelScheduleTransform());
+            tc.AddTransform(new ParallelScheduleTransform(this.UseLocals));
             // All messages after each iteration will be logged to csv files in a folder named with the model name.
             // Use MatlabWriter.WriteFromCsvFolder to convert these to a mat file.
             if (TraceAllMessages && UseTracingTransform)

--- a/src/Compiler/Infer/Transforms/ShallowCopyTransform.cs
+++ b/src/Compiler/Infer/Transforms/ShallowCopyTransform.cs
@@ -535,7 +535,33 @@ namespace Microsoft.ML.Probabilistic.Compiler.Transforms
             {
                 return ConvertThrow(ites);
             }
+            else if (ist is ITryCatchFinallyStatement itcfs)
+            {
+                return ConvertTry(itcfs);
+            }
             else throw new Exception("Unhandled statement: " + ist.GetType());
+        }
+
+        protected virtual IStatement ConvertTry(ITryCatchFinallyStatement itcfs)
+        {
+            ITryCatchFinallyStatement tcfs = Builder.TryCatchFinallyStmt();
+            context.SetPrimaryOutput(tcfs);
+            tcfs.Try = ConvertBlock(itcfs.Try);
+            tcfs.Fault = ConvertBlock(itcfs.Fault);
+            tcfs.Finally = ConvertBlock(itcfs.Finally);
+            foreach (ICatchClause icc in itcfs.CatchClauses)
+            {
+                ICatchClause cc = ConvertCatchClause(icc);
+                tcfs.CatchClauses.Add(cc);
+            }
+            return tcfs;
+        }
+
+        protected virtual ICatchClause ConvertCatchClause(ICatchClause icc)
+        {
+            ICatchClause cc = Builder.CatchClause(ConvertVariableDecl(icc.Variable));
+            cc.Body = ConvertBlock(icc.Body);
+            return cc;
         }
 
         protected virtual IStatement ConvertThrow(IThrowExceptionStatement its)

--- a/src/Compiler/TransformFramework/CodeBuilderFactory.cs
+++ b/src/Compiler/TransformFramework/CodeBuilderFactory.cs
@@ -562,6 +562,30 @@ namespace Microsoft.ML.Probabilistic.Compiler
         }
 
         /// <summary>
+        /// Default constructor for try-catch-finally statement
+        /// </summary>
+        /// <returns></returns>
+        public virtual ITryCatchFinallyStatement TryCatchFinallyStmt()
+        {
+            return new XTryCatchFinallyStatement()
+            {
+                Try = BlockStmt(),
+                Fault = BlockStmt(),
+                Finally = BlockStmt()
+            };
+        }
+
+        public virtual ICatchClause CatchClause(IVariableDeclaration ivd)
+        {
+            return new XCatchClause()
+            {
+                Body = BlockStmt(),
+                Condition = VarDeclExpr(ivd),
+                Variable = ivd
+            };
+        }
+
+        /// <summary>
         /// Default constructor for statement collection
         /// </summary>
         /// <returns>A new statement collection</returns>


### PR DESCRIPTION
ParallelScheduleTransform inserts try/catch blocks that throw InferenceException when UseLocals=true