### PR TITLE
Added ModelCompiler.AssemblyLoader

### DIFF
--- a/src/Compiler/Infer/ModelCompiler.cs
+++ b/src/Compiler/Infer/ModelCompiler.cs
@@ -156,6 +156,11 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// </remarks>
         public CompilerChoice CompilerChoice { get; set; } = CompilerChoice.Auto;
 
+        /// <summary>
+        /// A custom assembly loader.  If null, use Assembly.Load.
+        /// </summary>
+        public LoadAssemblyFromStreamDelegate AssemblyLoader { get; set; }
+
         private bool useParallelForLoops = false;
 
         /// <summary>
@@ -822,7 +827,8 @@ namespace Microsoft.ML.Probabilistic.Compiler
                 includeDebugInformation = IncludeDebugInformation,
                 optimizeCode = !IncludeDebugInformation, // tie these together for now
                 showProgress = ShowProgress,
-                compilerChoice = CompilerChoice
+                compilerChoice = CompilerChoice,
+                AssemblyLoader = AssemblyLoader,
             };
             CompilerResults cr = cc.WriteAndCompile(itds);
             // Examine the compilation results and stop if errors
@@ -1002,6 +1008,7 @@ namespace Microsoft.ML.Probabilistic.Compiler
         /// <param name="compiler">The compiler to copy settings from</param>
         public void SetTo(ModelCompiler compiler)
         {
+            AssemblyLoader = compiler.AssemblyLoader;
             CompilerChoice = compiler.CompilerChoice;
             ShowSchedule = compiler.ShowSchedule;
             BrowserMode = compiler.BrowserMode;

--- a/test/Tests/CodeCompilerTests/AssemblyLoadingTests.cs
+++ b/test/Tests/CodeCompilerTests/AssemblyLoadingTests.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.ML.Probabilistic.Models;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.ML.Probabilistic.Compiler;
+using Xunit;
+
+namespace Microsoft.ML.Probabilistic.Tests.CodeCompilerTests
+{
+    public class AssemblyLoadingTests
+    {
+        [Fact]
+        [Trait("Category", "ModifiesGlobals")]
+        public void AssemblyUnloadingTest()
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => a.GetName().GetPublicKeyToken().Length == 0)
+                .Select(a => a.FullName)
+                .ToHashSet();
+
+            RunWithCustomAssemblyLoader();
+            for (int i = 0; i < 10; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+
+            var assemblies2 = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => a.GetName().GetPublicKeyToken().Length == 0)
+                .Select(a => a.FullName)
+                .ToHashSet();
+            var extraAssemblyCount = assemblies2.Except(assemblies).Count();
+            Assert.True(extraAssemblyCount == 0, $"There are {extraAssemblyCount} extra assemblies loaded in the current AppDomain. This is likely due to a failure to unload an assembly. Please check the code for any static references to types or methods that may prevent unloading.");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void RunWithCustomAssemblyLoader()
+        {
+            var savedAssemblyLoader = InferenceEngine.DefaultEngine.Compiler.AssemblyLoader;
+            try
+            {
+                InferenceEngine.DefaultEngine.Compiler.AssemblyLoader = LoadAssemblyIntoLocalContext;
+
+                new ModelTests().BetaConstructionTest();
+            }
+            finally
+            {
+                InferenceEngine.DefaultEngine.Compiler.AssemblyLoader = savedAssemblyLoader;
+            }
+        }
+
+        /// <summary>
+        /// When used as the AssemblyLoader, this method loads the generated assembly into a new AssemblyLoadContext.  Once the InferenceEngine goes out of scope, all generated assemblies will be unloaded.
+        /// </summary>
+        Assembly LoadAssemblyIntoLocalContext(Stream assemblyStream, Stream pdbStream)
+        {
+            AssemblyLoadContext assemblyLoadContext = new SimpleAssemblyLoadContext();
+            return assemblyLoadContext.LoadFromStream(assemblyStream, pdbStream);
+        }
+
+        /// <summary>
+        /// An AssemblyLoadContext that loads all dependent assemblies into the default context.
+        /// Taken from https://learn.microsoft.com/en-us/dotnet/standard/assembly/unloadability
+        /// </summary>
+        class SimpleAssemblyLoadContext : AssemblyLoadContext
+        {
+            public SimpleAssemblyLoadContext() : base(isCollectible: true)
+            {
+            }
+
+            protected override Assembly Load(AssemblyName name)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/test/Tests/CodeCompilerTests/AssemblyLoadingTests.cs
+++ b/test/Tests/CodeCompilerTests/AssemblyLoadingTests.cs
@@ -1,15 +1,11 @@
-﻿using Microsoft.ML.Probabilistic.Models;
-
+﻿#if NET
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.ML.Probabilistic.Compiler;
+using Microsoft.ML.Probabilistic.Models;
 using Xunit;
 
 namespace Microsoft.ML.Probabilistic.Tests.CodeCompilerTests
@@ -82,3 +78,4 @@ namespace Microsoft.ML.Probabilistic.Tests.CodeCompilerTests
         }
     }
 }
+#endif

--- a/test/Tests/Strings/StringAutomatonTests.cs
+++ b/test/Tests/Strings/StringAutomatonTests.cs
@@ -268,7 +268,7 @@ namespace Microsoft.ML.Probabilistic.Tests
             /// <returns>The computed hash code.</returns>
             public int GetHashCode(T obj)
             {
-                throw new InvalidOperationException("This method should not be called.");
+                return 0;
             }
         }
 


### PR DESCRIPTION
Problem:
If an application creates many models, the generated assemblies will accumulate in memory.  

Solution:
This change allows generated assemblies to be loaded into local contexts, which allows them to be later unloaded.  The class `AssemblyLoadingTests` illustrates how this works.