### PR TITLE
Add .NET 9 to compiler check

### DIFF
--- a/src/Compiler/TransformFramework/CodeTransformer.cs
+++ b/src/Compiler/TransformFramework/CodeTransformer.cs
@@ -102,7 +102,8 @@ namespace Microsoft.ML.Probabilistic.Compiler
             || System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 5", StringComparison.OrdinalIgnoreCase)
             || System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 6", StringComparison.OrdinalIgnoreCase)
             || System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 7", StringComparison.OrdinalIgnoreCase)
-            || System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 8", StringComparison.OrdinalIgnoreCase);
+            || System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 8", StringComparison.OrdinalIgnoreCase)
+            || System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 9", StringComparison.OrdinalIgnoreCase);
         protected bool runningOnMono = Type.GetType("Mono.Runtime") != null;
 
         /// <summary>


### PR DESCRIPTION
Adds .NET 9 to the list of frameworks that will use the Roslyn compiler