### PR TITLE
Add user guide documentation for copulas and vine copulas

### DIFF
--- a/userguide/Bivariate copula families.md
+++ b/userguide/Bivariate copula families.md
@@ -1,0 +1,90 @@
+---
+layout: default 
+--- 
+
+[Infer.NET user guide](index.md) : [Copulas and vines](Copulas and vines.md)
+
+## Bivariate copula families
+
+This page describes an experimental feature that is likely to change in future releases
+
+A bivariate copula is a joint distribution on the unit square whose marginals are uniform. It is the building block of everything on these pages: a [vine](Vine copulas.md) is a product of bivariate copulas, and the [copula EP factor](Gaussian Process vine copulas.md) attaches a single bivariate copula likelihood to a latent score.
+
+All families live in `Microsoft.ML.Probabilistic.Distributions.Copulas` and implement `IBivariateCopula`. They are plain numeric classes with no dependency on the inference compiler, so you can use them standalone.
+
+### The IBivariateCopula interface
+
+Every family is parameterised by **Kendall's tau**, not by its own native parameter. This is what lets one latent function and one EP message operator serve every family: `tau` is a common currency in [-1, 1], and each family converts it to its native `theta` internally.
+
+| Member | Signature | Purpose |
+|--------|-----------|---------|
+| `Name` | `string { get; }` | Human-readable family name, e.g. `"Gaussian"`. |
+| `TauRange` | `(double Min, double Max) { get; }` | The valid range of Kendall's tau for this family. |
+| `TauToTheta` | `double TauToTheta(double tau)` | Maps Kendall's tau to the family's native parameter. |
+| `ThetaToTau` | `double ThetaToTau(double theta)` | The inverse map. |
+| `LogDensity` | `double LogDensity(double u, double v, double tau)` | Log copula density <code>log c(u, v &#124; tau)</code> for one observation. |
+| `Cdf` | `double Cdf(double u, double v, double tau)` | The copula CDF `C(u, v) = P(U <= u, V <= v)`. |
+| `ConditionalCdf` | `double ConditionalCdf(double u, double v, double tau, int given)` | The conditional CDF, known in the vine literature as the **h-function**. With `given = 1` it returns <code>P(U &lt;= u &#124; V = v)</code>; with `given = 0` it returns <code>P(V &lt;= v &#124; U = u)</code>. |
+| `InverseConditionalCdf` | `double InverseConditionalCdf(double w, double x, double tau, int given)` | Inverts `ConditionalCdf` for the unknown variable, given the conditioning value `x` and the conditional-CDF level `w`. The building block of the inverse-Rosenblatt transform used to sample. |
+| `Sample` | `Vector Sample(double tau)` | Draws one pair `(u, v)`, returned as a length-2 `Vector`. |
+
+`u` and `v` are always pseudo-observations strictly inside (0, 1). The `given` argument selects _which_ variable is being conditioned on: `given = 1` conditions on `v` and returns a value for `u`; `given = 0` conditions on `u` and returns a value for `v`. The h-function is what generates the pseudo-observations that feed the deeper trees of a vine — see [Vine copulas](Vine copulas.md).
+
+### The implemented families
+
+| Family | Dependence captured | Tau range | theta from tau |
+|--------|--------------------|-----------|----------------|
+| `GaussianCopula` | Symmetric, no tail dependence | (-1, 1) | `theta = sin(pi/2 * tau)` |
+| `ClaytonCopula` | **Lower**-tail dependence (variables crash together) | (0, 1) | `theta = 2 * tau / (1 - tau)` |
+| `GumbelCopula` | **Upper**-tail dependence (variables boom together) | (0, 1) | `theta = 1 / (1 - tau)` |
+
+`GaussianCopula` is the default and the most generally useful: it is the only one of the three that handles **negative** dependence.
+
+**An important caveat for Clayton and Gumbel.** Both are Archimedean families that model positive dependence only, so their `TauRange` is (0, 1) and their `TauToTheta` clamps `tau` into that range. The GPVINE link `tau = 2 * Phi(f) - 1` spans (-1, 1), so any latent value implying negative dependence is mapped to (near-)independence rather than to negative dependence. If your data has negative or sign-changing dependence, use `GaussianCopula`. Rotated Archimedean copulas, which would cover negative dependence, are not implemented.
+
+### Using a family directly
+
+```csharp
+using Microsoft.ML.Probabilistic.Distributions.Copulas;
+using Microsoft.ML.Probabilistic.Math;
+
+IBivariateCopula c = new ClaytonCopula();
+
+double theta = c.TauToTheta(0.4);            // native parameter for tau = 0.4
+double logDensity = c.LogDensity(0.3, 0.8, 0.4);
+double joint = c.Cdf(0.3, 0.8, 0.4);         // P(U <= 0.3, V <= 0.8)
+double h = c.ConditionalCdf(0.3, 0.8, 0.4, given: 1);   // P(U <= 0.3 | V = 0.8)
+double back = c.InverseConditionalCdf(h, 0.8, 0.4, given: 1);   // recovers 0.3
+
+Vector uv = c.Sample(0.4);                   // one draw, uv[0] and uv[1] in (0, 1)
+```
+
+`Sample` uses the shared random number generator, so call `Rand.Restart(seed)` if you need reproducible draws.
+
+### Choosing a family
+
+Fit each candidate and compare the **held-out** copula log-likelihood; the winner tells you the shape of the dependence:
+
+```csharp
+foreach (IBivariateCopula family in new IBivariateCopula[]
+         { new GaussianCopula(), new ClaytonCopula(), new GumbelCopula() })
+{
+    double ll = new RegularVine(family).Fit(train).LogLikelihood(test);
+    Console.WriteLine($"{family.Name}: {ll:f1}");
+}
+```
+
+A Clayton win indicates lower-tail dependence, a Gumbel win upper-tail dependence, and a Gaussian win symmetric dependence with light tails. Because Clayton and Gumbel cannot represent negative dependence, a Gaussian win on data with mixed signs is expected and is not evidence about the tails.
+
+### Numerical notes
+
+You do not normally need to think about any of this, but it explains the behaviour you will see at extreme values.
+
+*   `GaussianCopula` clamps `theta` to `(-1 + 1e-6, 1 - 1e-6)` (`GaussianCopula.ThetaEpsilon`) so that `1 - theta^2` stays strictly positive and the density stays finite as `tau` approaches +/-1.
+*   `ClaytonCopula` clamps `tau` to `[1e-6, 1 - 1e-6]` (`ClaytonCopula.TauEpsilon`), and treats a sufficiently small `theta` as exact independence (density 1, CDF `u*v`).
+*   `GumbelCopula` clamps `tau` to `[0, 1 - 1e-6]` (`GumbelCopula.TauEpsilon`) and evaluates its density entirely in log space, because the intermediate `x^theta` would overflow or underflow for large `theta` (tau near 1).
+*   `GaussianCopula` and `ClaytonCopula` have closed-form inverse h-functions. `GumbelCopula` does not, so `InverseConditionalCdf` solves for the unknown by 60 steps of bisection on (0, 1) — correct, but noticeably slower if you call it in a tight loop.
+
+### Adding a family
+
+Implement `IBivariateCopula` and pass an instance wherever a copula is expected — `RegularVine(copula)`, `IConditionalCopulaFitter.Fit(u, v, z, copula)`, or the `CopulaFactor.BivariateCopula` factor. No changes to the vine layer or to the EP message operator are needed, because both are written against the interface and only ever speak in Kendall's tau. The one requirement is that `LogDensity`, `ConditionalCdf` and `InverseConditionalCdf` are mutually consistent, since the vine recursion relies on the h-function being the exact partial derivative of the CDF.

--- a/userguide/Copulas and vines.md
+++ b/userguide/Copulas and vines.md
@@ -1,0 +1,82 @@
+---
+layout: default 
+--- 
+
+[Infer.NET user guide](index.md)
+
+## Copulas and vines
+
+This page describes an experimental feature that is likely to change in future releases
+
+A **copula** describes the _dependence_ between several variables separately from their individual (marginal) distributions. A **vine** factorises a high-dimensional copula into a hierarchy of simple bivariate copulas, which makes it practical to model rich dependence in many dimensions. Infer.NET additionally implements **GPVINE**, in which the strength of each conditional copula is allowed to _vary with the variables it is conditioned on_, learned with a sparse Gaussian process and Expectation Propagation.
+
+The implementation follows Lopez-Paz, Hernández-Lobato and Ghahramani, _Gaussian Process Vine Copulas for Multivariate Dependence_, ICML 2013.
+
+### When to use this
+
+Use copulas and vines when you want to model the joint distribution of several continuous variables and a multivariate Gaussian is too rigid — for example when the dependence is asymmetric in the tails (variables that crash together but do not boom together), or when the strength of dependence between two variables changes with the value of a third. Typical tasks are:
+
+*   **Estimating a joint density** over continuous variables with flexible dependence.
+*   **Discovering dependence structure** — which variables are directly coupled, and how strongly.
+*   **Capturing context-dependent dependence** — "the correlation between X and Y changes with Z" — which a correlation matrix cannot express.
+*   **Generating** synthetic joint data, **imputing** missing dimensions, or doing posterior-predictive inference given a partial observation.
+*   **Comparing** dependence models by held-out likelihood.
+
+A vine recovers statistical dependence, not causation: the trees are a conditional-dependence factorisation, not a causal graph. For causal questions see [Causal inference with Infer.NET](Causal inference with Infer.NET.md).
+
+### Key concepts
+
+**Probability integral transform (PIT).** Copulas operate on _pseudo-observations_: each variable is mapped to a uniform value in (0, 1) by its empirical CDF, using `rank / (n + 1)`. This strips out the marginals and leaves only the dependence. Infer.NET applies the PIT for you, so you pass raw data in its natural units.
+
+**Kendall's tau.** A rank correlation in [-1, 1]. It plays two roles here: its absolute value is the weight used to _select_ the vine structure, and it is the parameter through which every copula family is expressed. Parameterising by tau rather than by each family's native parameter means a single latent function can drive any family.
+
+**Vine trees.** The first tree `T1` connects the raw variables; each deeper tree `Ti` has the previous tree's _edges_ as its nodes and represents _conditional_ copulas. A full vine over `d` variables has `d - 1` trees and `d(d - 1)/2` edges. Truncating to fewer trees treats the omitted dependence as independence, and is the usual accuracy/cost knob.
+
+**SVINE versus GPVINE.** A simplified vine (SVINE) fits each conditional copula with a single constant tau — the "simplifying assumption". GPVINE instead models tau as a function of the conditioning variables, `tau = 2 * Phi(f(z)) - 1`, where `f` is given a sparse Gaussian process prior and inferred by EP. When conditional dependence genuinely varies, GPVINE achieves a higher held-out likelihood; when it does not, the two agree.
+
+### Where the types live
+
+| Namespace | Types | Assembly |
+|-----------|-------|----------|
+| `Microsoft.ML.Probabilistic.Distributions.Copulas` | `IBivariateCopula`, `GaussianCopula`, `ClaytonCopula`, `GumbelCopula` | Runtime |
+| `Microsoft.ML.Probabilistic.Distributions.Copulas.Vine` | `RegularVine`, `VineStructure`, `VineTree`, `VineEdge`, `Pit`, `KendallTau`, `MaxSpanningTree`, `IConditionalCopulaFitter`, `IConditionalCopulaPosterior`, `SparseGPCopulaPosterior` | Runtime |
+| `Microsoft.ML.Probabilistic.Factors` | `CopulaFactor`, `BivariateCopulaOp` | Runtime |
+| `Microsoft.ML.Probabilistic.Models` | `GaussianProcessCopulaFitter` | Compiler |
+
+Everything except `GaussianProcessCopulaFitter` is pure numeric code with no dependency on the inference compiler. The GP fit needs the inference engine, and therefore lives in the modelling layer.
+
+### Quick start
+
+```csharp
+using Microsoft.ML.Probabilistic.Distributions.Copulas;
+using Microsoft.ML.Probabilistic.Distributions.Copulas.Vine;
+using Microsoft.ML.Probabilistic.Models;
+
+// Data: rows are observations, columns are variables, in raw units.
+double[][] train = ...;   // [n][d]
+double[][] test  = ...;   // [m][d]
+
+// (a) SVINE baseline - closed form, no inference engine needed.
+double llSvine = new RegularVine().Fit(train).LogLikelihood(test);
+
+// (b) GPVINE - deeper-tree copulas fitted with a sparse GP and EP.
+var fitter = new GaussianProcessCopulaFitter();
+double llGpvine = new RegularVine().Fit(train, nTrees: 0, fitter).LogLikelihood(test);
+
+// Higher held-out log-likelihood is better. On data whose conditional dependence
+// varies with the conditioning variables, llGpvine > llSvine.
+```
+
+`nTrees: 0` means "build all `d - 1` trees". Passing a `fitter` is what turns an SVINE into a GPVINE.
+
+### Read next
+
+*   [Bivariate copula families](Bivariate copula families.md) — the `IBivariateCopula` interface and the Gaussian, Clayton and Gumbel families.
+*   [Vine copulas](Vine copulas.md) — fitting, scoring, inspecting, sampling and conditional simulation with `RegularVine`.
+*   [Gaussian Process vine copulas](Gaussian Process vine copulas.md) — the GPVINE model, the `GaussianProcessCopulaFitter`, and the copula EP factor.
+
+### References
+
+*   D. Lopez-Paz, J. M. Hernández-Lobato and Z. Ghahramani, [Gaussian Process Vine Copulas for Multivariate Dependence](http://proceedings.mlr.press/v28/lopez-paz13.html), ICML 2013.
+*   K. Aas, C. Czado, A. Frigessi and H. Bakken, _Pair-copula constructions of multiple dependence_, Insurance: Mathematics and Economics, 2009. (The C-vine simulation algorithm used by `RegularVine.Sample`.)
+*   T. Bedford and R. M. Cooke, _Vines - a new graphical model for dependent random variables_, Annals of Statistics, 2002.

--- a/userguide/Gaussian Process vine copulas.md
+++ b/userguide/Gaussian Process vine copulas.md
@@ -1,0 +1,200 @@
+---
+layout: default 
+--- 
+
+[Infer.NET user guide](index.md) : [Copulas and vines](Copulas and vines.md)
+
+## Gaussian Process vine copulas
+
+This page describes an experimental feature that is likely to change in future releases
+
+An ordinary vine makes the **simplifying assumption**: each conditional copula has a single, constant parameter, regardless of the values it is conditioned on. **GPVINE** drops that assumption. It models Kendall's tau of each conditional copula as a smooth function of the conditioning variables,
+
+```
+tau = g(f(z)) = 2 * Phi(f(z)) - 1
+```
+
+where `f` is a latent function given a sparse Gaussian process prior and inferred by Expectation Propagation. The link `g` maps the unbounded latent score into the valid tau range (-1, 1), and, being folded inside the factor, means EP only ever sees a smooth non-conjugate likelihood on a single Gaussian variable.
+
+This implements Lopez-Paz, Hernández-Lobato and Ghahramani, _Gaussian Process Vine Copulas for Multivariate Dependence_, ICML 2013. You can run the bundled example from the [Examples Browser](The examples browser.md); the source is `src/Tutorials/GaussianProcessVine.cs`.
+
+### The per-edge model
+
+Each conditional edge of a vine is one small Infer.NET model, structurally identical to the [Gaussian Process classifier](Gaussian Process classifier.md): a sparse GP prior over `f`, a `score = f(z)` evaluation, and an observed likelihood on that score. The only new piece is the likelihood, which is the copula density of the observed pseudo-observation pair.
+
+```csharp
+Variable<bool> evidence = Variable.Bernoulli(0.5).Named("evidence");
+IfBlock block = Variable.If(evidence);
+
+Variable<SparseGP> prior = Variable.New<SparseGP>().Named("copulaPrior");
+Variable<IFunction> f = Variable<IFunction>.Random(prior).Named("f");
+
+VariableArray<Vector> z = Variable.Observed(inputs).Named("z");   // the conditioning vectors
+Range j = z.Range.Named("j");
+Variable<double> score = Variable.FunctionEvaluate(f, z[j]).Named("score");
+
+VariableArray<Vector> uv = Variable.Observed(pairs, j).Named("uv");   // the (u, v) pairs
+uv[j] = Variable<Vector>.Factor(CopulaFactor.BivariateCopula, score, Variable.Observed(copula));
+
+block.CloseBlock();
+
+double logEvidence = engine.Infer<Bernoulli>(evidence).LogOdds;
+SparseGP posterior = engine.Infer<SparseGP>(f);
+```
+
+The copula family is passed as **observed data** rather than baked into the factor, so a single factor and a single EP message operator serve every family. The `Variable.Bernoulli(0.5)` and `IfBlock` pattern gives you the [model evidence](Computing model evidence for model selection.md), which is what you use for hyperparameter and family comparison.
+
+You rarely need to write this out: `GaussianProcessCopulaFitter` builds exactly this model for you.
+
+### GaussianProcessCopulaFitter
+
+`Microsoft.ML.Probabilistic.Models.GaussianProcessCopulaFitter` implements the Runtime interface `IConditionalCopulaFitter`. Hand one to `RegularVine.Fit` and the deeper trees become conditional.
+
+| Member | Default | Purpose |
+|--------|---------|---------|
+| `GaussianProcessCopulaFitter(InferenceEngine engine = null)` | — | If no engine is supplied, a non-verbose Expectation Propagation engine is created. |
+| `NumInducing` | `20` | Number of inducing inputs (pseudo-inputs) for the sparse GP. |
+| `LogLengthScale` | `-1.5` | Log length-scale used to initialise every ARD kernel dimension. |
+| `LogSignalSd` | `0.0` | Log signal standard deviation of the ARD kernel. |
+| `LogNoiseSd` | `log(0.2)` | Log standard deviation of an added white-noise kernel component. |
+| `NumberOfIterations` | `15` | EP iterations per edge fit. |
+| `LastLogEvidence` | `NaN` | The EP log-evidence of the most recent `Fit`. |
+| `Fit(double[] u, double[] v, double[][] z, IBivariateCopula copula)` | — | Fits one conditional copula, returning an `IConditionalCopulaPosterior`. |
+
+```csharp
+using Microsoft.ML.Probabilistic.Models;
+
+var fitter = new GaussianProcessCopulaFitter
+{
+    NumInducing        = 20,
+    NumberOfIterations = 15,
+    LogLengthScale     = -1.5,
+};
+
+var gpvine = new RegularVine().Fit(train, nTrees: 0, fitter);
+double ll = gpvine.LogLikelihood(test);
+```
+
+Reusing one fitter across every edge of a vine is fine and is what you should do — a fitter holds no per-edge state beyond `LastLogEvidence`, and sharing it shares the inference engine rather than constructing a new one per edge. Each `Fit` call does build a fresh model, so the settings above take effect on every edge.
+
+Three points about the defaults are worth knowing.
+
+**The length-scale must match the scale of your conditioning inputs.** Inside a vine, the conditioning inputs are pseudo-observations in (0, 1), and the default `LogLengthScale = -1.5` (a length of about 0.22) is tuned for that range. If you call `fitter.Fit(u, v, z, copula)` directly with **raw** conditioning values — say `z` in [-3, 3] — raise it to around `0.0` (a length of about 1), as the [GP classifier](Gaussian Process classifier.md) does.
+
+**The white-noise term is doing real work.** It regularises the inducing-point covariance and acts as the GP nugget. Without it, the GP fit can fail with a positive-definiteness error on (0, 1) inputs. Leave `LogNoiseSd` alone unless you have a reason.
+
+**The GP mean is initialised from the data.** It is set to `Phi^-1((tau_MLE + 1) / 2)`, where `tau_MLE` is the unconditional Kendall's tau of the edge, clamped away from +/-1. This happens automatically.
+
+### The fitted posterior
+
+`Fit` returns an `IConditionalCopulaPosterior`:
+
+| Member | Signature | Purpose |
+|--------|-----------|---------|
+| `TauAt` | `double TauAt(double[] z)` | The posterior **mean** Kendall's tau at conditioning vector `z`. |
+| `SampleTau` | `double SampleTau(double[] z)` | A Kendall's tau **drawn** from the posterior at `z`, reflecting the latent function's uncertainty. |
+
+The concrete implementation is `SparseGPCopulaPosterior`, which wraps the fitted `SparseGP` and exposes it through its `Posterior` property if you want the raw GP. `RegularVine` uses `TauAt` when computing likelihoods and `SampleTau` when generating posterior-predictive samples — which is why GPVINE draws carry the GP's uncertainty rather than plugging in a point estimate.
+
+You can use the fitter on its own, without a vine, to learn how the dependence between two variables varies with a covariate:
+
+```csharp
+// u, v: paired pseudo-observations in (0, 1). z: one conditioning vector per observation.
+IConditionalCopulaPosterior post = fitter.Fit(u, v, z, new GaussianCopula());
+
+for (double zStar = -3; zStar <= 3; zStar += 0.25)
+    Console.WriteLine($"{zStar,5:f2}  tau = {post.TauAt(new[] { zStar }):f3}");
+
+Console.WriteLine($"log evidence = {fitter.LastLogEvidence:f2}");
+```
+
+That sweep is the curve GPVINE exists to produce.
+
+### The copula factor and its EP operator
+
+`CopulaFactor.BivariateCopula(double score, IBivariateCopula copula)` returns a `Vector` pair `(u, v)`. It is a thin hook for the inference compiler: it names the factor that `BivariateCopulaOp` attaches its EP messages to. Its body samples from the copula at `tau = 2 * Phi(score) - 1`, but EP never calls it — the messages moment-match the copula likelihood against the Gaussian latent directly.
+
+`BivariateCopulaOp` is the Expectation Propagation message operator, and carries the `Experimental` [quality band](Quality bands.md). For an observed pair `(u, v)` the factor contributes the copula likelihood as a non-conjugate term on the single Gaussian latent `score`. The message to `score` is obtained by moment matching: with cavity <code>N(s; m, v)</code> the tilted distribution is <code>N(s; m, v) c(u, v &#124; g(s))</code>, and its first two moments are computed by quadrature. The integrand is evaluated in log space and shifted by its value at the proposal mean before being exponentiated, which keeps it in range; the offset is folded back into the log normaliser analytically. The projected Gaussian divided by the cavity is the message, and the log normaliser of the tilted integral is the evidence contribution.
+
+| Method | Purpose |
+|--------|---------|
+| `Gaussian ScoreAverageConditional(Vector pair, Gaussian score, IBivariateCopula copula, Gaussian result)` | The EP message to `score`. |
+| `Gaussian ScoreAverageConditionalInit()` | Initialiser (returns a uniform Gaussian). |
+| `double LogAverageFactor(Vector pair, Gaussian score, IBivariateCopula copula, Gaussian to_score)` | <code>log int N(s; m, v) c(u, v &#124; g(s)) ds</code> — the evidence contribution. |
+| `double LogEvidenceRatio(Vector pair, Gaussian score, IBivariateCopula copula, Gaussian to_score)` | The evidence ratio. The pair is observed, so this equals `LogAverageFactor`. |
+
+Three static fields tune the operator. The defaults are robust and you should only change them if you hit numerical trouble.
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `BivariateCopulaOp.QuadratureNodeCount` | `64` | Initial node count for the adaptive quadrature. |
+| `BivariateCopulaOp.QuadratureRelTol` | `1e-10` | Relative tolerance for the adaptive quadrature. |
+| `BivariateCopulaOp.ForceProper` | `true` | Force the outgoing message to have non-negative precision. |
+
+Adaptive Clenshaw-Curtis is used rather than fixed Gauss-Hermite because the copula likelihood can blow up as the latent pushes tau towards +/-1, which makes the integrand heavy-tailed. Where the quadrature cannot produce a usable result — a collapsed variance, or a NaN — the operator returns a uniform message rather than an improper one, so a difficult edge degrades to uninformative rather than corrupting the fit.
+
+### A worked comparison: does the simplifying assumption cost you anything?
+
+This is the bundled example (`src/Tutorials/GaussianProcessVine.cs`), reduced to its essentials. The data is three variables where X and Y each depend on Z, and the copula of (X, Y) given Z has a Kendall's tau that _varies with Z_ — exactly the structure the simplifying assumption cannot represent.
+
+```csharp
+var engine = new InferenceEngine(new ExpectationPropagation()) { ShowProgress = false };
+var fitter = new GaussianProcessCopulaFitter(engine) { NumInducing = 15, NumberOfIterations = 15 };
+
+for (int nTrees = 1; nTrees <= 2; nTrees++)
+{
+    double svine  = new RegularVine(new GaussianCopula()).Fit(train, nTrees).LogLikelihood(test);
+    double gpvine = new RegularVine(new GaussianCopula()).Fit(train, nTrees, fitter).LogLikelihood(test);
+    Console.WriteLine($"  {nTrees}   |     {svine,10:f2}     |     {gpvine,10:f2}");
+}
+```
+
+The data is generated from a fixed seed, so the example prints the same numbers every run:
+
+```
+trees | SVINE test log-lik | GPVINE test log-lik
+------+--------------------+--------------------
+  1   |         257.65     |         257.65
+  2   |         257.57     |         304.26
+```
+
+The two agreeing exactly at one tree is a correctness check — the first tree is unconditional by construction, so there is nothing for the GP to do. At two trees SVINE gains nothing (it slips very slightly, to 257.57, because a constant-tau second-tree copula is the wrong model and costs a little on held-out data), while GPVINE gains about 47 nats by modelling how the (X, Y) dependence varies with Z. That gap is the value of dropping the simplifying assumption, and it is the entire claim of the method.
+
+When you run this you will also see two compiler warnings, one for `ScoreAverageConditional` and one for `LogEvidenceRatio`, noting that `BivariateCopulaOp` has quality band `Experimental`. That is expected — see [Quality bands](Quality bands.md).
+
+### Model comparison
+
+Everything here is comparable by **held-out** copula log-likelihood, and that should be your primary criterion:
+
+*   **GPVINE against SVINE** — fit both and compare `LogLikelihood(test)`. If they are close, your conditional dependence really is constant and the cheaper SVINE is the better model.
+*   **Family selection** — fit Gaussian, Clayton and Gumbel and compare. See [Bivariate copula families](Bivariate copula families.md).
+*   **Truncation** — sweep `nTrees` and stop where the held-out score plateaus.
+
+For a Bayesian criterion at the level of a single edge, `fitter.LastLogEvidence` holds the EP log-evidence of the most recent fit, which you can compare across kernel hyperparameters or families. Automated hyperparameter and inducing-point optimisation is **not** built in: Infer.NET does not optimise kernel hyperparameters for you, so you compare a handful of settings manually, as the [GP classifier](Gaussian Process classifier.md) does.
+
+### Cost
+
+Fitting scales roughly linearly in the number of observations `n`, and quadratically in the number of variables `d` and in the number of inducing points. Each GPVINE conditional edge is a full EP run, taking on the order of seconds; SVINE edges are near-instant by comparison. The knobs that reduce cost, in the order you should reach for them, are: truncate `nTrees`; reduce `NumInducing`; reduce `NumberOfIterations`; and use an SVINE wherever conditional dependence is weak. Sampling from a fitted vine is cheap — the GP posterior is queried but never refitted.
+
+### Troubleshooting
+
+| Symptom | Cause and fix |
+|---------|---------------|
+| A positive-definiteness error during a GP fit | The inducing covariance is ill-conditioned. Keep the white-noise nugget (`LogNoiseSd`), and make sure `LogLengthScale` matches the scale of the inputs: about `-1.5` for (0, 1) pseudo-observations, about `0.0` for raw inputs. |
+| `NotSupportedException` from `Sample` or `SampleConditional` | Refit with `structure: VineStructure.Canonical`, and with `rootOrder` if you intend to condition. |
+| `NotSupportedException: Conditioned set must be the leading roots...` | Refit with `rootOrder` set to the variable ids you want to condition on. The message names them for you. |
+| A Clayton or Gumbel fit looks like independence | Those families model positive dependence only. Negative or sign-changing dependence needs `GaussianCopula`. |
+| Held-out log-likelihood falls as you add trees | The deeper trees are fitting noise. Truncate `nTrees`. |
+| The fit is slow | Reduce `NumInducing` and `NumberOfIterations`, truncate `nTrees`, or drop to an SVINE. |
+| Recovered `tau(z)` is flat when it should vary | The length-scale is too long for the input range. Lower `LogLengthScale`, and check that `z` really is the variable the dependence varies with. |
+
+### Limitations
+
+Sampling and conditional simulation require a canonical (C-vine) fit; general R-vine sampling is not implemented. Conditioning is exact only for the leading roots of the vine, so conditioning on a different subset needs a refit with the appropriate `rootOrder`. The Frank family and rotated Clayton/Gumbel copulas (which would cover negative dependence in the Archimedean families) are not implemented. Kernel hyperparameters and inducing inputs are not optimised automatically.
+
+### See also
+
+*   [Copulas and vines](Copulas and vines.md) — the overview.
+*   [Vine copulas](Vine copulas.md) — `RegularVine`, fitting, sampling, conditional simulation.
+*   [Gaussian Process classifier](Gaussian Process classifier.md) — the sparse-GP modelling pattern this builds on.
+*   [Computing model evidence for model selection](Computing model evidence for model selection.md).

--- a/userguide/Infer.NET tutorials and examples.md
+++ b/userguide/Infer.NET tutorials and examples.md
@@ -33,6 +33,7 @@ Short examples of using Infer.NET to solve a variety of different problems. Can 
 *   **[Click model](Click model example.md)** \- an information retrieval example which builds a model to reconcile document click counts and human relevance judgements of documents.
 *   **[Difficulty versus ability](Difficulty versus ability.md)** \- a model of multiple-choice tests and crowdsourcing.
 *   **[Gaussian Process classifier](Gaussian Process classifier.md)** \- a Bayes point machine that uses kernel functions to do nonlinear discrimination.
+*   **[Gaussian Process vine copulas](Gaussian Process vine copulas.md)** \- models multivariate dependence with a vine of bivariate copulas, letting the strength of each conditional copula vary with the variables it is conditioned on.
 *   **[Recommender System](Recommender System.md)** \- a matrix factorization model for collaborative filtering.
 *   **[Student skills](Student skills.md)** \- cognitive assessment models for inferring the skills of a test-taker.
 *   **[Chess Analysis](Chess Analysis.md)** \- comparing the strength of chess players over time.

--- a/userguide/Vine copulas.md
+++ b/userguide/Vine copulas.md
@@ -1,0 +1,172 @@
+---
+layout: default 
+--- 
+
+[Infer.NET user guide](index.md) : [Copulas and vines](Copulas and vines.md)
+
+## Vine copulas
+
+This page describes an experimental feature that is likely to change in future releases
+
+A **regular vine** (R-vine) factorises a `d`-dimensional copula density into a product of bivariate copulas arranged in a nested sequence of trees. The first tree `T1` connects the raw variables; each deeper tree `Ti` has the edges of `T(i-1)` as its nodes, and joins two of them only if they share a node — the _proximity condition_. The pseudo-observations feeding a deeper edge are the h-functions (conditional CDFs) of the previous tree's fitted copulas, and the conditioning set grows by one variable per level.
+
+The `RegularVine` class in `Microsoft.ML.Probabilistic.Distributions.Copulas.Vine` implements all of this. It is a plain numeric class: fitting an ordinary vine needs no inference engine at all. Only [GPVINE](Gaussian Process vine copulas.md), where the copula parameter is a learned function of the conditioning variables, brings in Infer.NET inference.
+
+### The RegularVine API
+
+| Member | Signature | Purpose |
+|--------|-----------|---------|
+| Constructor | `RegularVine(IBivariateCopula copula = null)` | The copula family for every edge. Defaults to `GaussianCopula`. |
+| `Fit` | `RegularVine Fit(double[][] x, int nTrees = 0, IConditionalCopulaFitter fitter = null, VineStructure structure = VineStructure.Regular, int[] rootOrder = null)` | Fits the vine to raw data and returns `this`, so calls can be chained. |
+| `LogLikelihood` | `double LogLikelihood(double[][] x)` | Total copula log-likelihood of `x` under the fitted vine. |
+| `Sample` | `double[][] Sample(int n)` | `n` joint draws on the data scale. Requires a canonical fit. |
+| `SampleConditional` | `double[][] SampleConditional(IDictionary<int, double> known, int n)` | Draws with some variables held at observed values. Requires a canonical fit. |
+| `Trees` | `List<VineTree> { get; }` | The fitted trees, in order. |
+| `Marginals` | `InnerQuantiles[] { get; }` | The empirical marginals captured at fit time, one per variable. |
+| `Structure` | `VineStructure { get; }` | The tree-selection strategy used by the last `Fit`. |
+| `Copula` | `IBivariateCopula { get; }` | The copula family this vine uses. |
+
+### Input data
+
+Data is `double[][]` with `x[i][j]` = variable `j` of observation `i`. All variables are treated as continuous.
+
+**You do not transform the data yourself.** `Fit` applies the empirical PIT internally, so you pass raw values in their natural units. `LogLikelihood` re-applies the PIT to its own argument, so training and test data are transformed consistently and the result is a valid held-out score. The marginals are stored at fit time in `Marginals`, so generated samples come back on the original data scale.
+
+### Fitting
+
+```csharp
+using Microsoft.ML.Probabilistic.Distributions.Copulas;
+using Microsoft.ML.Probabilistic.Distributions.Copulas.Vine;
+
+var vine = new RegularVine(new GaussianCopula()).Fit(train, nTrees: 2);
+double ll = vine.LogLikelihood(test);
+```
+
+**`nTrees`** truncates the vine. A full vine has `d - 1` trees; passing `0` (or anything larger than `d - 1`) builds all of them. Deeper trees capture higher-order conditional dependence at increasing cost, and the omitted trees are treated as independence. This is the standard accuracy/cost knob: sweep `nTrees` and stop where held-out log-likelihood plateaus.
+
+**`fitter`** selects the model class. With no fitter, every deeper-tree copula is fitted with a single Kendall's-tau MLE — the simplifying assumption, giving an SVINE. With a [`GaussianProcessCopulaFitter`](Gaussian Process vine copulas.md), deeper-tree copulas become _conditional_: tau varies with the conditioning variables. The first tree is always fitted unconditionally, so SVINE and GPVINE agree exactly at `nTrees: 1`.
+
+**`structure`** selects the tree topology:
+
+*   `VineStructure.Regular` (the default) picks a maximum spanning tree on the `|tau|` weights at each level, giving a general R-vine. This is the best choice for fitting and scoring.
+*   `VineStructure.Canonical` builds a C-vine, in which every tree is a star centred on the variable with the strongest summed dependence. Fitting and scoring behave identically; the only difference is the topology. **Sampling and conditional simulation require a canonical fit** — see below.
+
+**`rootOrder`** applies to canonical fits only. It forces the listed variables, in order, to be the leading roots of the vine, which is what makes `SampleConditional` able to condition on them exactly.
+
+### Reading the fitted vine
+
+After `Fit`, the vine is a list of trees, each a list of edges.
+
+```csharp
+foreach (VineTree tree in vine.Trees)
+{
+    Console.WriteLine($"Tree {tree.Level}:");
+    foreach (VineEdge e in tree.Edges)
+    {
+        string strength = e.IsConditional
+            ? $"tau varies with z (e.g. {e.Posterior.TauAt(new[] { 0.5 }):f2} at z = 0.5)"
+            : $"tau = {e.Tau:f2}";
+        Console.WriteLine($"  {e.Label,-10} weight |tau| = {e.Weight:f3}   {strength}");
+    }
+}
+```
+
+`VineEdge.Label` reads as _conditioned_ `|` _conditioning_: `0,2|1,3` means "the copula of variables 0 and 2 given variables 1 and 3". Tree `T1` therefore shows you the strongest direct pairwise dependencies, and deeper trees show what dependence remains after conditioning. Edge counts per tree are `d-1, d-2, ..., 1`.
+
+The useful members of `VineEdge` are:
+
+| Member | Type | Meaning |
+|--------|------|---------|
+| `Left`, `Right` | `int` | The two conditioned variables, aligned with the `U` and `V` series. |
+| `Conditioning` | `int[]` | The conditioning set `D(e)`, sorted. Empty in `T1`. |
+| `Tau` | `double` | The fitted unconditional Kendall's tau. Meaningful when `Posterior` is null. |
+| `Posterior` | `IConditionalCopulaPosterior` | The fitted conditional posterior, or null for an unconditional edge. |
+| `IsConditional` | `bool` | Shorthand for `Posterior != null`. |
+| `Weight` | `double` | The <code>&#124;tau&#124;</code> used to select this edge during tree construction. |
+| `Label` | `string` | The <code>"0,2&#124;1,3"</code> display form. |
+| `U`, `V` | `double[]` | The pseudo-observation series feeding this edge. |
+| `Z` | `double[][]` | The conditioning matrix, one row per observation, one column per conditioning variable. Empty in `T1`. |
+| `HByVar` | `Dictionary<int, double[]>` | The h-function series computed at fit time, which seed the next tree. |
+| `N()` | `int[]` | The complete set `{Left, Right} ∪ Conditioning`, sorted. |
+
+For an unconditional edge, `Tau` is a single number: its magnitude is the strength of the dependence and its sign the direction. For a conditional (GPVINE) edge, tau is a _function_, and `Posterior.TauAt(z)` evaluates it. Sweeping `z` over a grid and plotting the result is the headline output of GPVINE: dependence as a learned curve rather than a single number.
+
+### The log-likelihood, and how to read it
+
+```csharp
+double ll = vine.LogLikelihood(test);
+```
+
+This is the **copula** log-likelihood: the summed log copula densities over every edge of every tree. Marginal densities are deliberately _not_ included, which is exactly what you want when comparing dependence models on the same data — the marginal terms would be identical and would cancel anyway.
+
+*   **Higher is better.** The value can be positive, because dependence concentrates probability mass relative to the independent case.
+*   **Independence gives approximately zero.** A vine fitted to independent variables contributes roughly nothing.
+*   **Always score on held-out data.** In-sample log-likelihood only ever increases as you add trees, so it cannot tell you when to stop.
+
+The vine structure is replayed on the PIT of the argument, so `LogLikelihood(test)` is a genuine held-out score and not an in-sample artefact.
+
+### Sampling
+
+A fitted vine is a generative model. Sampling uses the inverse-Rosenblatt transform and **requires a canonical (C-vine) fit**; calling `Sample` on a `Regular` vine throws `NotSupportedException` telling you to refit.
+
+```csharp
+var vine = new RegularVine()
+    .Fit(train, nTrees: 0, fitter, VineStructure.Canonical);
+
+double[][] synthetic = vine.Sample(1000);   // [1000][d], in the original data units
+```
+
+Output is on the data scale: the stored empirical marginals (`InnerQuantiles.GetQuantile`) invert the PIT. For a GPVINE, each draw samples the latent function from the GP posterior rather than using its mean, so the synthetic data reflects both the learned context-varying dependence _and_ the posterior uncertainty about it — a genuine posterior-predictive sample rather than a plug-in.
+
+A quick sanity check on a sample is that it should reproduce the training data's pairwise Kendall's tau:
+
+```csharp
+double tauData = KendallTau.Compute(Column(train, i), Column(train, j));
+double tauSamp = KendallTau.Compute(Column(synthetic, i), Column(synthetic, j));
+// these should agree to within sampling error
+```
+
+### Conditional simulation and imputation
+
+`SampleConditional` fixes a chosen set of variables to observed values and draws the rest from their conditional distribution. This gives you imputation of missing dimensions, scenario analysis ("given this Z, what happens?"), and posterior-predictive inference given a partial observation.
+
+The one rule is that **conditioning is exact when the conditioned set is the leading roots of the canonical vine**. So fit with `rootOrder` set to the variable ids you intend to condition on:
+
+```csharp
+using System.Collections.Generic;
+
+int zId = 2;
+var vine = new RegularVine()
+    .Fit(train, nTrees: 0, fitter, VineStructure.Canonical, rootOrder: new[] { zId });
+
+// "Given Z = 1.0, what are plausible (X, Y)?"
+double[][] drawn = vine.SampleConditional(
+    new Dictionary<int, double> { { zId, 1.0 } }, n: 1000);
+```
+
+Each returned row has `drawn[i][zId] == 1.0` exactly — conditioned variables are returned as given — and the remaining columns are drawn from their conditional distribution. Under a GPVINE those draws reflect the dependence _at that conditioning value_, so the sampled X-Y rank correlation matches the learned tau(z). If you condition on a set that is not the leading roots, or on a `Regular`-fit vine, you get a `NotSupportedException` that names the `rootOrder` you should refit with. Conditioning on an arbitrary subset without refitting is not supported.
+
+### Helper classes
+
+These are public and usable on their own.
+
+**`Pit`** — the empirical probability integral transform.
+
+```csharp
+double[] u  = Pit.Transform(column);      // one column of raw values -> (0, 1)
+double[][] U = Pit.Transform(x);          // [n][d] -> [n][d], column by column
+double safe = Pit.ClampUnit(value);       // clamp into [eps, 1 - eps], eps = 1e-6 by default
+```
+
+`Transform` uses average ranks divided by `n + 1`, which keeps values strictly inside (0, 1) and so avoids the infinities that `Phi^-1(0)` and `Phi^-1(1)` would produce. Ties receive the mean of the ranks they span.
+
+**`KendallTau`** — `double KendallTau.Compute(double[] a, double[] b)` returns Kendall's tau-b in [-1, 1], or 0 where it is undefined (constant input, or fewer than two points). The tau-b form corrects for ties; on tie-free continuous data it equals the ordinary (concordant - discordant) / (n(n-1)/2).
+
+**`MaxSpanningTree`** — `List<(int I, int J)> MaxSpanningTree.Prim(double[,] weights)` returns the edges of the maximum spanning tree of a symmetric weight matrix. Mark a disallowed pair with `double.NegativeInfinity`; if the allowed edges do not connect every node, you get a spanning forest with fewer than `m - 1` edges. This is how each vine tree is selected.
+
+**Marginals** are `InnerQuantiles`, so `vine.Marginals[j].GetProbLessThan(value)` maps a data value to (0, 1), and `vine.Marginals[j].GetQuantile(p)` maps back to the data scale.
+
+### Next
+
+*   [Gaussian Process vine copulas](Gaussian Process vine copulas.md) — modelling tau as a learned function of the conditioning variables.
+*   [Bivariate copula families](Bivariate copula families.md) — the copula families a vine can be built from.

--- a/userguide/index.md
+++ b/userguide/index.md
@@ -47,6 +47,11 @@ layout: default
         *   [Undirected factors](Undirected factors.md)
         *   [List of factors and constraints](list of factors and constraints.md)
 
+    *   [Copulas and vines](Copulas and vines.md)
+        *   [Bivariate copula families](Bivariate copula families.md)
+        *   [Vine copulas](Vine copulas.md)
+        *   [Gaussian Process vine copulas](Gaussian Process vine copulas.md)
+
     *   Advanced model building
         *   [Adding attributes to your model](Adding attributes to your model.md)
         *   [The Model Specification Language](The Model Specification Language.md)


### PR DESCRIPTION
Documents the copula feature added in #496, which currently has no coverage on the documentation site.

New pages under userguide/:
  - Copulas and vines - overview, concepts, namespace map, quick start
  - Bivariate copula families - IBivariateCopula, and the Gaussian, Clayton and Gumbel families
  - Vine copulas - RegularVine fitting, scoring, sampling and conditional simulation, plus the Pit/KendallTau/MaxSpanningTree helpers
  - Gaussian Process vine copulas - the GPVINE model, the GaussianProcessCopulaFitter, and the CopulaFactor/BivariateCopulaOp EP factor

Linked from userguide/index.md and the tutorials and examples index.

Every documented signature, default and constant was checked against the source. The worked-example figures are the real output of running src/Tutorials/GaussianProcessVine.cs. Rendering was verified with a local Jekyll build (github-pages 230 / jekyll 3.9.5 / kramdown 2.4); note that kramdown does not unescape a backslash-escaped pipe inside a code span, so table cells needing a literal pipe use <code> with &#124;.